### PR TITLE
Remove token efficiency details from README

### DIFF
--- a/examples/analyzer/token_efficient_agent/README.md
+++ b/examples/analyzer/token_efficient_agent/README.md
@@ -65,14 +65,6 @@ The CLI automatically:
 2. Creates sidecar proxy container when needed
 3. Connects sandbox to datasets via MCP
 
-### Token Efficiency
-
-**Traditional**: Send 100KB CSV in every prompt = 150K tokens across 3 turns
-
-**This approach**: Generate code that loads CSV once = 8K tokens across 3 turns
-
-**Savings: 94%**
-
 ### Example Interaction
 
 ```


### PR DESCRIPTION
Removed token efficiency comparison section from README.