### PR TITLE
feat: add cross-framework tool conversion with RayToolWrapper

### DIFF
--- a/docs/frameworks/langchain.mdx
+++ b/docs/frameworks/langchain.mdx
@@ -51,6 +51,38 @@ lc_tools = wrapper.wrap_tools([search_web])
 agent = create_react_agent(llm, lc_tools)
 ```
 
+## Cross-framework tools
+
+Use tools from **any framework** with your LangChain agents. `RayToolWrapper` auto-detects the source framework and converts tools to LangChain-compatible `BaseTool` instances:
+
+```python
+from pydantic_ai import Tool as PydanticTool
+from ray_agents.adapters import RayToolWrapper, AgentFramework
+
+# Pydantic AI tool
+def multiply(x: int, y: int) -> int:
+    """Multiply two numbers."""
+    return x * y
+
+pydantic_tool = PydanticTool(multiply, name="multiply")
+
+# Plain Python function
+def greet(name: str) -> str:
+    """Greet someone by name."""
+    return f"Hello, {name}!"
+
+# Convert ANY tools to LangChain format
+wrapper = RayToolWrapper(framework=AgentFramework.LANGCHAIN)
+lc_tools = wrapper.wrap_tools([pydantic_tool, greet], num_cpus=1)
+
+# Use with LangChain agent - all tools execute on Ray
+agent = create_react_agent(llm, lc_tools)
+```
+
+<Info>
+The wrapper auto-detects: Ray `@tool` functions, LangChain `BaseTool`, Pydantic AI `Tool`, and plain Python callables.
+</Info>
+
 ## Next steps
 
 <CardGroup cols={2}>

--- a/docs/frameworks/pure-python.mdx
+++ b/docs/frameworks/pure-python.mdx
@@ -58,6 +58,35 @@ results = execute_tools([
 ], parallel=True)
 ```
 
+## Use with agent frameworks
+
+Plain Python functions can be used directly with any agent framework. `RayToolWrapper` converts them to framework-compatible tools that execute on Ray:
+
+```python
+from ray_agents.adapters import RayToolWrapper, AgentFramework
+
+# Plain Python functions - no decorators needed
+def search(query: str) -> str:
+    """Search the web for information."""
+    return f"Results for: {query}"
+
+def calculate(expression: str) -> float:
+    """Evaluate a math expression."""
+    return eval(expression)
+
+# Convert to LangChain tools
+wrapper = RayToolWrapper(framework=AgentFramework.LANGCHAIN)
+lc_tools = wrapper.wrap_tools([search, calculate], num_cpus=1)
+
+# Or convert to Pydantic AI tools
+wrapper = RayToolWrapper(framework=AgentFramework.PYDANTIC)
+pydantic_tools = wrapper.wrap_tools([search, calculate], num_cpus=1)
+```
+
+<Tip>
+Type annotations and docstrings are preserved for LLM schema generation. Always include them for best results.
+</Tip>
+
 ## Next steps
 
 <CardGroup cols={2}>

--- a/docs/frameworks/pure-python.mdx
+++ b/docs/frameworks/pure-python.mdx
@@ -70,17 +70,17 @@ def search(query: str) -> str:
     """Search the web for information."""
     return f"Results for: {query}"
 
-def calculate(expression: str) -> float:
-    """Evaluate a math expression."""
-    return eval(expression)
+def add(a: int, b: int) -> int:
+    """Add two numbers together."""
+    return a + b
 
 # Convert to LangChain tools
 wrapper = RayToolWrapper(framework=AgentFramework.LANGCHAIN)
-lc_tools = wrapper.wrap_tools([search, calculate], num_cpus=1)
+lc_tools = wrapper.wrap_tools([search, add], num_cpus=1)
 
 # Or convert to Pydantic AI tools
 wrapper = RayToolWrapper(framework=AgentFramework.PYDANTIC)
-pydantic_tools = wrapper.wrap_tools([search, calculate], num_cpus=1)
+pydantic_tools = wrapper.wrap_tools([search, add], num_cpus=1)
 ```
 
 <Tip>

--- a/docs/frameworks/pydantic.mdx
+++ b/docs/frameworks/pydantic.mdx
@@ -55,6 +55,35 @@ pydantic_tools = wrapper.wrap_tools([search_web])
 agent = Agent("openai:gpt-4o-mini", tools=pydantic_tools)
 ```
 
+## Cross-framework tools
+
+Use tools from **any framework** with your Pydantic AI agents. `RayToolWrapper` auto-detects the source framework and converts tools to Pydantic AI-compatible callables:
+
+```python
+from langchain_community.tools import DuckDuckGoSearchRun
+from pydantic_ai import Agent
+from ray_agents.adapters import RayToolWrapper, AgentFramework
+
+# LangChain tool
+langchain_search = DuckDuckGoSearchRun()
+
+# Plain Python function
+def calculate(a: int, b: int) -> int:
+    """Add two numbers together."""
+    return a + b
+
+# Convert ANY tools to Pydantic AI format
+wrapper = RayToolWrapper(framework=AgentFramework.PYDANTIC)
+tools = wrapper.wrap_tools([langchain_search, calculate], num_cpus=1)
+
+# Use with Pydantic AI agent - all tools execute on Ray
+agent = Agent("openai:gpt-4o-mini", tools=tools)
+```
+
+<Info>
+The wrapper auto-detects: Ray `@tool` functions, LangChain `BaseTool`, Pydantic AI `Tool`, and plain Python callables. Type annotations and docstrings are preserved for schema generation.
+</Info>
+
 ## Next steps
 
 <CardGroup cols={2}>

--- a/src/ray_agents/adapters/__init__.py
+++ b/src/ray_agents/adapters/__init__.py
@@ -1,8 +1,12 @@
 """Adapters for different agent frameworks to integrate with Ray distributed tool execution."""
 
-from ray_agents.adapters.abc import AgentFramework, ToolAdapter
+from ray_agents.adapters.abc import AgentFramework, RayToolWrapper
+from ray_agents.adapters.langchain import from_langchain_tool
+from ray_agents.adapters.pydantic import from_pydantic_tool
 
 __all__ = [
     "AgentFramework",
-    "ToolAdapter",
+    "RayToolWrapper",
+    "from_langchain_tool",
+    "from_pydantic_tool",
 ]

--- a/src/ray_agents/adapters/core.py
+++ b/src/ray_agents/adapters/core.py
@@ -1,0 +1,461 @@
+"""Internal core module for cross-framework tool conversion.
+
+This module provides the canonical RayTool intermediate representation
+and converters for N+M extensibility when adding new frameworks.
+"""
+
+import functools
+import inspect
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import Enum
+from inspect import Signature
+from typing import TYPE_CHECKING, Any
+
+import ray
+
+if TYPE_CHECKING:
+    from ray_agents.adapters.abc import AgentFramework
+
+
+class SourceFramework(Enum):
+    """Detected source framework of an input tool."""
+
+    RAY_TOOL = "ray_tool"
+    LANGCHAIN = "langchain"
+    PYDANTIC = "pydantic"
+    CALLABLE = "callable"
+
+
+@dataclass
+class RayTool:
+    """Canonical intermediate representation for cross-framework tool conversion.
+
+    This dataclass captures all metadata needed to reconstruct a tool in any
+    target framework while executing on Ray workers.
+    """
+
+    name: str
+    description: str
+    ray_remote: Any  # Ray remote function
+    func: Callable  # Original underlying function
+    args_schema: type | None = None
+    signature: Signature | None = None
+    annotations: dict[str, Any] = field(default_factory=dict)
+    return_annotation: Any = None
+    source_framework: str = "unknown"
+    # Input style: "kwargs" for **kwargs, "single_input" for single positional arg
+    input_style: str = "kwargs"
+
+
+def _normalize_memory(memory: int | float) -> int:
+    """Convert memory spec to bytes."""
+    if isinstance(memory, float) and memory < 1024:
+        return int(memory * (1024**3))  # Treat as GB
+    return int(memory)
+
+
+def detect_framework(tool: Any) -> SourceFramework:
+    """Auto-detect the source framework of an input tool.
+
+    Detection order (most specific first):
+    1. Ray @tool decorated - has _remote_func attribute
+    2. LangChain BaseTool - isinstance check
+    3. Pydantic AI Tool - isinstance check
+    4. Plain callable - callable() check
+
+    Args:
+        tool: The tool to detect
+
+    Returns:
+        SourceFramework enum value
+
+    Raises:
+        ValueError: If tool is not a recognized type
+    """
+    # Check for Ray @tool decorated functions first
+    if hasattr(tool, "_remote_func") or hasattr(tool, "remote"):
+        return SourceFramework.RAY_TOOL
+
+    # Try LangChain (lazy import to avoid hard dependency)
+    try:
+        from langchain_core.tools import BaseTool
+
+        if isinstance(tool, BaseTool):
+            return SourceFramework.LANGCHAIN
+    except ImportError:
+        pass
+
+    # Try Pydantic AI (lazy import to avoid hard dependency)
+    try:
+        from pydantic_ai import Tool as PydanticTool
+
+        if isinstance(tool, PydanticTool):
+            return SourceFramework.PYDANTIC
+    except ImportError:
+        pass
+
+    # Check for plain callable
+    if callable(tool):
+        return SourceFramework.CALLABLE
+
+    raise ValueError(
+        f"Cannot detect framework for tool of type {type(tool).__name__}. "
+        "Expected Ray @tool, LangChain BaseTool, Pydantic AI Tool, or callable."
+    )
+
+
+# =============================================================================
+# Source Converters (to RayTool)
+# =============================================================================
+
+
+def to_raytool_from_ray_tool(tool: Any) -> RayTool:
+    """Convert Ray @tool decorated function to canonical RayTool.
+
+    Already a Ray tool, just extract metadata.
+    """
+    if hasattr(tool, "_remote_func"):
+        remote_func = tool._remote_func
+        original_func = getattr(tool, "_original_func", tool)
+    else:
+        remote_func = tool
+        original_func = getattr(tool, "_function", tool)
+
+    # Extract metadata from tool decorator
+    metadata = getattr(tool, "_tool_metadata", {})
+    name = original_func.__name__
+    description = metadata.get("desc", original_func.__doc__ or f"Calls {name}")
+
+    # Get signature and annotations
+    try:
+        sig = inspect.signature(original_func)
+    except (ValueError, TypeError):
+        sig = None
+
+    annotations = getattr(original_func, "__annotations__", {}).copy()
+    return_annotation = annotations.pop("return", None)
+
+    return RayTool(
+        name=name,
+        description=description,
+        ray_remote=remote_func,
+        func=original_func,
+        args_schema=getattr(tool, "args_schema", None),
+        signature=sig,
+        annotations=annotations,
+        return_annotation=return_annotation,
+        source_framework="ray_tool",
+    )
+
+
+def to_raytool_from_langchain(
+    tool: Any,
+    num_cpus: int,
+    memory_bytes: int,
+    num_gpus: int,
+) -> RayTool:
+    """Convert LangChain BaseTool to canonical RayTool."""
+    from langchain_core.tools import BaseTool
+
+    if not isinstance(tool, BaseTool):
+        raise ValueError(f"Expected LangChain BaseTool, got {type(tool).__name__}")
+
+    # Create Ray remote function
+    @ray.remote(num_cpus=num_cpus, memory=memory_bytes, num_gpus=num_gpus)
+    def _execute(tool_input: Any) -> Any:
+        return tool.invoke(tool_input)
+
+    # Extract metadata
+    args_schema = getattr(tool, "args_schema", None)
+
+    # Try to get annotations from args_schema
+    annotations: dict[str, Any] = {}
+    if args_schema and hasattr(args_schema, "model_fields"):
+        # Pydantic v2 model - reconstruct annotations
+        annotations = {
+            name: field_info.annotation
+            for name, field_info in args_schema.model_fields.items()
+            if field_info.annotation is not None
+        }
+
+    # Get the underlying function for signature
+    func = tool._run if hasattr(tool, "_run") else tool.invoke
+
+    try:
+        sig = inspect.signature(func)
+    except (ValueError, TypeError):
+        sig = None
+
+    return RayTool(
+        name=tool.name,
+        description=tool.description,
+        ray_remote=_execute,
+        func=func,
+        args_schema=args_schema,
+        signature=sig,
+        annotations=annotations,
+        return_annotation=str,  # LangChain tools typically return str
+        source_framework="langchain",
+        input_style="single_input",  # LangChain tools expect single input
+    )
+
+
+def to_raytool_from_pydantic(
+    tool: Any,
+    num_cpus: int,
+    memory_bytes: int,
+    num_gpus: int,
+) -> RayTool:
+    """Convert Pydantic AI Tool to canonical RayTool."""
+    try:
+        from pydantic_ai import Tool as PydanticTool
+    except ImportError:
+        raise ImportError(
+            "Pydantic AI tool conversion requires 'pydantic-ai'. "
+            "Install with: pip install pydantic-ai"
+        ) from None
+
+    if not isinstance(tool, PydanticTool):
+        raise ValueError(f"Expected Pydantic AI Tool, got {type(tool).__name__}")
+
+    func = tool.function
+    tool_name = tool.name or func.__name__
+    tool_description = tool.description or func.__doc__ or ""
+
+    # Create Ray remote function
+    @ray.remote(num_cpus=num_cpus, memory=memory_bytes, num_gpus=num_gpus)
+    def _execute(**kwargs: Any) -> Any:
+        return func(**kwargs)
+
+    # Extract signature and annotations
+    try:
+        sig = inspect.signature(func)
+    except (ValueError, TypeError):
+        sig = None
+
+    annotations = getattr(func, "__annotations__", {}).copy()
+    return_annotation = annotations.pop("return", None)
+
+    return RayTool(
+        name=tool_name,
+        description=tool_description,
+        ray_remote=_execute,
+        func=func,
+        args_schema=None,  # Pydantic AI uses annotations, not schema
+        signature=sig,
+        annotations=annotations,
+        return_annotation=return_annotation,
+        source_framework="pydantic",
+    )
+
+
+def to_raytool_from_callable(
+    func: Callable,
+    num_cpus: int,
+    memory_bytes: int,
+    num_gpus: int,
+) -> RayTool:
+    """Convert plain callable to canonical RayTool."""
+    tool_name = func.__name__
+    tool_description = func.__doc__ or f"Calls {tool_name}"
+
+    # Create Ray remote function
+    @ray.remote(num_cpus=num_cpus, memory=memory_bytes, num_gpus=num_gpus)
+    def _execute(*args: Any, **kwargs: Any) -> Any:
+        return func(*args, **kwargs)
+
+    # Extract signature and annotations
+    try:
+        sig = inspect.signature(func)
+    except (ValueError, TypeError):
+        sig = None
+
+    annotations = getattr(func, "__annotations__", {}).copy()
+    return_annotation = annotations.pop("return", None)
+
+    return RayTool(
+        name=tool_name,
+        description=tool_description,
+        ray_remote=_execute,
+        func=func,
+        args_schema=None,
+        signature=sig,
+        annotations=annotations,
+        return_annotation=return_annotation,
+        source_framework="callable",
+    )
+
+
+def to_raytool(
+    tool: Any,
+    num_cpus: int = 1,
+    memory: int | float = 256 * 1024**2,
+    num_gpus: int = 0,
+) -> RayTool:
+    """Convert any supported tool to canonical RayTool.
+
+    Args:
+        tool: Tool from any supported framework
+        num_cpus: Number of CPUs to allocate
+        memory: Memory in bytes (int) or GB (float < 1024)
+        num_gpus: Number of GPUs to allocate
+
+    Returns:
+        Canonical RayTool representation
+    """
+    memory_bytes = _normalize_memory(memory)
+    source = detect_framework(tool)
+
+    if source == SourceFramework.RAY_TOOL:
+        return to_raytool_from_ray_tool(tool)
+    elif source == SourceFramework.LANGCHAIN:
+        return to_raytool_from_langchain(tool, num_cpus, memory_bytes, num_gpus)
+    elif source == SourceFramework.PYDANTIC:
+        return to_raytool_from_pydantic(tool, num_cpus, memory_bytes, num_gpus)
+    elif source == SourceFramework.CALLABLE:
+        return to_raytool_from_callable(tool, num_cpus, memory_bytes, num_gpus)
+    else:
+        raise ValueError(f"Unsupported source framework: {source}")
+
+
+# =============================================================================
+# Target Emitters (from RayTool)
+# =============================================================================
+
+
+def _handle_result(result: Any) -> Any:
+    """Handle result from Ray task, extracting from status dict if needed."""
+    if isinstance(result, dict) and "status" in result:
+        if result["status"] == "error":
+            error_msg = result.get("error", "Unknown error")
+            raise RuntimeError(f"Tool error: {error_msg}")
+        if "result" in result:
+            return result["result"]
+    return result
+
+
+def from_raytool_to_langchain(ray_tool: RayTool) -> Any:
+    """Convert canonical RayTool to LangChain BaseTool."""
+    try:
+        from langchain_core.tools import BaseTool
+    except ImportError:
+        raise ImportError(
+            "LangChain target requires 'langchain-core'. "
+            "Install with: pip install langchain-core"
+        ) from None
+
+    ray_remote = ray_tool.ray_remote
+    tool_input_style = ray_tool.input_style
+
+    def _normalize_input(*args: Any, **kwargs: Any) -> Any:
+        """Normalize input for LangChain tools."""
+        if args and not kwargs:
+            return args[0] if len(args) == 1 else args
+        elif kwargs and not args:
+            return next(iter(kwargs.values())) if len(kwargs) == 1 else kwargs
+        else:
+            return kwargs or ""
+
+    # Generate args_schema from annotations if not present
+    tool_args_schema = ray_tool.args_schema
+    if tool_args_schema is None and ray_tool.annotations:
+        try:
+            from pydantic import create_model
+
+            fields = {
+                name: (annotation, ...)
+                for name, annotation in ray_tool.annotations.items()
+            }
+            if fields:
+                tool_args_schema = create_model(f"{ray_tool.name}Input", **fields)
+        except ImportError:
+            pass
+
+    # Capture values for class definition
+    _name = ray_tool.name
+    _description = ray_tool.description
+    _args_schema = tool_args_schema
+
+    class ConvertedLangChainTool(BaseTool):
+        name: str = _name
+        description: str = _description
+        args_schema: type | None = _args_schema
+
+        def _run(self, *args: Any, **kwargs: Any) -> Any:
+            if tool_input_style == "single_input":
+                tool_input = _normalize_input(*args, **kwargs)
+                result = ray.get(ray_remote.remote(tool_input))
+            else:
+                # Pass args/kwargs directly for Ray tools and callables
+                result = ray.get(ray_remote.remote(*args, **kwargs))
+            return _handle_result(result)
+
+        async def _arun(self, *args: Any, **kwargs: Any) -> Any:
+            if tool_input_style == "single_input":
+                tool_input = _normalize_input(*args, **kwargs)
+                result = await ray_remote.remote(tool_input)
+            else:
+                result = await ray_remote.remote(*args, **kwargs)
+            return _handle_result(result)
+
+    return ConvertedLangChainTool()
+
+
+def from_raytool_to_pydantic(ray_tool: RayTool) -> Callable:
+    """Convert canonical RayTool to Pydantic AI-compatible callable."""
+    ray_remote = ray_tool.ray_remote
+    tool_input_style = ray_tool.input_style
+
+    @functools.wraps(ray_tool.func)
+    def wrapper(**kwargs: Any) -> Any:
+        """Execute tool on Ray worker."""
+        if tool_input_style == "single_input":
+            # LangChain source tools expect single input
+            # Convert kwargs to single value
+            if len(kwargs) == 1:
+                tool_input = next(iter(kwargs.values()))
+            else:
+                tool_input = kwargs
+            result = ray.get(ray_remote.remote(tool_input))
+        else:
+            result = ray.get(ray_remote.remote(**kwargs))
+        return _handle_result(result)
+
+    # Preserve metadata for Pydantic AI
+    wrapper.__name__ = ray_tool.name
+    wrapper.__qualname__ = ray_tool.name
+    wrapper.__doc__ = ray_tool.description
+
+    # Restore annotations for schema generation
+    if ray_tool.annotations:
+        wrapper.__annotations__ = ray_tool.annotations.copy()
+        if ray_tool.return_annotation:
+            wrapper.__annotations__["return"] = ray_tool.return_annotation
+
+    # Restore signature
+    if ray_tool.signature:
+        wrapper.__signature__ = ray_tool.signature  # type: ignore[attr-defined]
+
+    return wrapper
+
+
+def from_raytool(ray_tool: RayTool, target: "AgentFramework") -> Any:
+    """Convert canonical RayTool to target framework.
+
+    Args:
+        ray_tool: Canonical RayTool representation
+        target: Target framework from AgentFramework enum
+
+    Returns:
+        Tool compatible with target framework
+    """
+    # Import here to avoid circular import
+    from ray_agents.adapters.abc import AgentFramework
+
+    if target == AgentFramework.LANGCHAIN:
+        return from_raytool_to_langchain(ray_tool)
+    elif target == AgentFramework.PYDANTIC:
+        return from_raytool_to_pydantic(ray_tool)
+    else:
+        raise ValueError(f"Unsupported target framework: {target}")

--- a/src/ray_agents/adapters/langchain/tools.py
+++ b/src/ray_agents/adapters/langchain/tools.py
@@ -1,6 +1,5 @@
-"""Converter for LangChain tools to Ray-compatible tools."""
+"""Converter for LangChain tools to Ray-executed LangChain tools."""
 
-from collections.abc import Callable
 from typing import Any
 
 import ray
@@ -11,8 +10,11 @@ def from_langchain_tool(
     num_cpus: int = 1,
     memory: int | float = 256 * 1024**2,
     num_gpus: int = 0,
-) -> Callable:
-    """Convert a LangChain tool to a Ray-compatible remote function.
+) -> Any:
+    """Wrap a LangChain tool to execute on Ray workers.
+
+    Returns a LangChain BaseTool that can be used directly with LangChain agents.
+    The tool's execution is distributed to Ray workers with the specified resources.
 
     Args:
         langchain_tool: LangChain tool (BaseTool instance)
@@ -21,11 +23,23 @@ def from_langchain_tool(
         num_gpus: Number of GPUs to allocate (default: 0)
 
     Returns:
-        Ray remote function compatible with RayAgent.register_tools()
+        LangChain BaseTool that executes on Ray workers
 
     Raises:
         ImportError: If langchain-core is not installed
         ValueError: If tool is not a LangChain BaseTool
+
+    Example:
+        ```python
+        from langchain_community.tools import DuckDuckGoSearchRun
+        from ray_agents.adapters import from_langchain_tool
+
+        # Wrap for Ray execution
+        search = from_langchain_tool(DuckDuckGoSearchRun(), num_cpus=1)
+
+        # Use directly with LangChain agent
+        agent = create_react_agent(llm, [search])
+        ```
     """
     try:
         from langchain_core.tools import BaseTool
@@ -40,230 +54,38 @@ def from_langchain_tool(
             f"Expected LangChain BaseTool, got {type(langchain_tool).__name__}"
         )
 
-    tool_name = langchain_tool.name
-    tool_description = langchain_tool.description
-
     if isinstance(memory, float) and memory < 1024:
         memory_bytes = int(memory * (1024**3))
     else:
         memory_bytes = int(memory)
 
-    def _normalize_input(kwargs: dict[str, Any]) -> str | dict[str, Any]:
-        """Normalize kwargs to format expected by LangChain tools."""
-        if len(kwargs) == 1:
-            return next(iter(kwargs.values()))  # type: ignore[no-any-return]
-        elif len(kwargs) == 0:
-            return ""
+    # Create Ray remote function for tool execution
+    @ray.remote(num_cpus=num_cpus, memory=memory_bytes, num_gpus=num_gpus)
+    def _execute_tool(tool_input: Any) -> Any:
+        return langchain_tool.invoke(tool_input)
+
+    def _normalize_input(*args: Any, **kwargs: Any) -> Any:
+        """Normalize input for LangChain tools."""
+        if args and not kwargs:
+            return args[0] if len(args) == 1 else args
+        elif kwargs and not args:
+            return next(iter(kwargs.values())) if len(kwargs) == 1 else kwargs
         else:
-            return kwargs
+            return kwargs or ""
 
-    def _create_dynamic_wrapper(
-        lc_tool: Any, name: str, args_schema: Any = None
-    ) -> Callable:
-        """
-        Create a wrapper function with proper signature based on args_schema.
+    # Create a new tool class that wraps execution in Ray
+    class RayLangChainTool(BaseTool):
+        name: str = langchain_tool.name
+        description: str = langchain_tool.description
+        args_schema: type | None = getattr(langchain_tool, "args_schema", None)
 
-        This ensures LLMs can see the required
-        parameters and their types, rather than just **kwargs.
+        def _run(self, *args: Any, **kwargs: Any) -> Any:
+            tool_input = _normalize_input(*args, **kwargs)
+            return ray.get(_execute_tool.remote(tool_input))
 
-        Uses exec() to dynamically create a real function with proper parameters
-        so that typing.get_type_hints() works correctly.
-        """
-        if args_schema is None:
-            return _create_simple_wrapper(lc_tool, name)
+        async def _arun(self, *args: Any, **kwargs: Any) -> Any:
+            tool_input = _normalize_input(*args, **kwargs)
+            # Ray ObjectRefs are awaitable
+            return await _execute_tool.remote(tool_input)
 
-        try:
-            if hasattr(args_schema, "model_fields"):
-                fields = args_schema.model_fields
-            elif hasattr(args_schema, "__fields__"):
-                fields = args_schema.__fields__
-            else:
-                return _create_simple_wrapper(lc_tool, name)
-        except Exception:
-            return _create_simple_wrapper(lc_tool, name)
-
-        if not fields:
-            return _create_simple_wrapper(lc_tool, name)
-
-        param_strings = []
-        param_docs = []
-        annotations = {}
-
-        for field_name, field_info in fields.items():
-            if hasattr(field_info, "annotation"):
-                field_type = field_info.annotation
-            else:
-                field_type = Any
-
-            annotations[field_name] = field_type
-
-            if hasattr(field_info, "description") and field_info.description:
-                param_docs.append(f"        {field_name}: {field_info.description}")
-
-            is_required = getattr(field_info, "is_required", lambda: True)()
-            if callable(is_required):
-                is_required = is_required()
-
-            if is_required:
-                param_strings.append(f"{field_name}")
-            else:
-                default_val = getattr(field_info, "default", None)
-                if default_val is None:
-                    param_strings.append(f"{field_name}=None")
-                else:
-                    param_strings.append(f"{field_name}={repr(default_val)}")
-
-        base_doc = lc_tool.description or f"Calls {name}"
-        if param_docs:
-            full_doc = f"{base_doc}\n\n    Args:\n" + "\n".join(param_docs)
-        else:
-            full_doc = base_doc
-
-        params_str = ", ".join(param_strings)
-        func_code = f"""
-def {name}({params_str}):
-    \"\"\"Dynamically generated wrapper\"\"\"
-    kwargs = {{{', '.join(f"'{k}': {k}" for k in fields.keys())}}}
-    return _tool_executor(kwargs)
-
-async def {name}_async({params_str}):
-    \"\"\"Async version\"\"\"
-    kwargs = {{{', '.join(f"'{k}': {k}" for k in fields.keys())}}}
-    return await _async_tool_executor(kwargs)
-"""
-
-        def _tool_executor(kwargs: dict[str, Any]) -> dict[str, Any]:
-            try:
-                tool_input = _normalize_input(kwargs)
-                result = lc_tool.invoke(tool_input)
-                return {
-                    "result": result,
-                    "status": "success",
-                    "tool": name,
-                }
-            except Exception as e:
-                return {
-                    "error": str(e),
-                    "status": "error",
-                    "tool": name,
-                }
-
-        async def _async_tool_executor(kwargs: dict[str, Any]) -> dict[str, Any]:
-            try:
-                tool_input = _normalize_input(kwargs)
-                result = await lc_tool.ainvoke(tool_input)
-                return {
-                    "result": result,
-                    "status": "success",
-                    "tool": name,
-                }
-            except Exception as e:
-                return {
-                    "error": str(e),
-                    "status": "error",
-                    "tool": name,
-                }
-
-        local_vars: dict[str, Any] = {
-            "_tool_executor": _tool_executor,
-            "_async_tool_executor": _async_tool_executor,
-        }
-        exec(func_code, local_vars)
-
-        wrapper = local_vars[name]
-        async_wrapper = local_vars[f"{name}_async"]
-
-        wrapper.__annotations__ = {**annotations, "return": dict[str, Any]}
-        async_wrapper.__annotations__ = {**annotations, "return": dict[str, Any]}
-
-        wrapper.__doc__ = full_doc
-        async_wrapper.__doc__ = full_doc
-
-        wrapper._async = async_wrapper
-
-        return wrapper  # type: ignore[no-any-return]
-
-    def _create_simple_wrapper(lc_tool: Any, name: str) -> Callable:
-        """Fallback wrapper when no args_schema is available."""
-
-        def wrapper(**kwargs: Any) -> dict[str, Any]:
-            try:
-                tool_input = _normalize_input(kwargs)
-                result = lc_tool.invoke(tool_input)
-                return {
-                    "result": result,
-                    "status": "success",
-                    "tool": name,
-                }
-            except Exception as e:
-                return {
-                    "error": str(e),
-                    "status": "error",
-                    "tool": name,
-                }
-
-        async def async_wrapper(**kwargs: Any) -> dict[str, Any]:
-            """Async version for LangGraph compatibility."""
-            try:
-                tool_input = _normalize_input(kwargs)
-                result = await lc_tool.ainvoke(tool_input)
-                return {
-                    "result": result,
-                    "status": "success",
-                    "tool": name,
-                }
-            except Exception as e:
-                return {
-                    "error": str(e),
-                    "status": "error",
-                    "tool": name,
-                }
-
-        wrapper.__name__ = name
-        wrapper.__qualname__ = name
-        wrapper.__doc__ = lc_tool.description
-        wrapper._async = async_wrapper  # type: ignore[attr-defined]
-        return wrapper
-
-    args_schema = (
-        langchain_tool.args_schema if hasattr(langchain_tool, "args_schema") else None
-    )
-
-    tool_wrapper = _create_dynamic_wrapper(langchain_tool, tool_name, args_schema)
-
-    ray_remote_func = ray.remote(
-        num_cpus=num_cpus,
-        memory=memory_bytes,
-        num_gpus=num_gpus,
-    )(tool_wrapper)
-
-    def sync_wrapper(**kwargs: Any) -> dict[str, Any]:
-        """Synchronous wrapper that executes the Ray remote function."""
-        return ray.get(ray_remote_func.remote(**kwargs))  # type: ignore[no-any-return]
-
-    async def async_wrapper(**kwargs: Any) -> dict[str, Any]:
-        """Async wrapper that enables parallel execution."""
-        object_ref = ray_remote_func.remote(**kwargs)
-        return await object_ref  # type: ignore[no-any-return]
-
-    sync_wrapper.__name__ = tool_name
-    sync_wrapper.__doc__ = tool_description
-    sync_wrapper._remote_func = ray_remote_func  # type: ignore[attr-defined]
-    sync_wrapper._async = async_wrapper  # type: ignore[attr-defined]
-
-    if hasattr(tool_wrapper, "__signature__"):
-        sync_wrapper.__signature__ = tool_wrapper.__signature__  # type: ignore[attr-defined]
-        async_wrapper.__signature__ = tool_wrapper.__signature__  # type: ignore[attr-defined]
-
-    if hasattr(tool_wrapper, "__annotations__"):
-        sync_wrapper.__annotations__ = tool_wrapper.__annotations__
-        async_wrapper.__annotations__ = tool_wrapper.__annotations__
-
-    if (
-        hasattr(langchain_tool, "args_schema")
-        and langchain_tool.args_schema is not None
-    ):
-        sync_wrapper.args_schema = langchain_tool.args_schema  # type: ignore[attr-defined]
-        async_wrapper.args_schema = langchain_tool.args_schema  # type: ignore[attr-defined]
-
-    return sync_wrapper
+    return RayLangChainTool()

--- a/src/ray_agents/adapters/pydantic/__init__.py
+++ b/src/ray_agents/adapters/pydantic/__init__.py
@@ -1,6 +1,5 @@
 """Pydantic AI tools for Ray distributed execution."""
 
-# ToolAdapter from ray_agents.adapters handles Pydantic tool wrapping
-# No Pydantic-specific exports needed
+from ray_agents.adapters.pydantic.tools import from_pydantic_tool
 
-__all__: list[str] = []
+__all__ = ["from_pydantic_tool"]

--- a/src/ray_agents/adapters/pydantic/tools.py
+++ b/src/ray_agents/adapters/pydantic/tools.py
@@ -1,0 +1,99 @@
+"""Converter for Pydantic AI tools to Ray-executed tools."""
+
+import inspect
+from collections.abc import Callable
+from typing import Any
+
+import ray
+
+
+def from_pydantic_tool(
+    pydantic_tool: Any,
+    num_cpus: int = 1,
+    memory: int | float = 256 * 1024**2,
+    num_gpus: int = 0,
+) -> Callable:
+    """Wrap a Pydantic AI Tool to execute on Ray workers.
+
+    Returns a function that can be used directly with Pydantic AI agents.
+    The tool's execution is distributed to Ray workers with the specified resources.
+
+    Args:
+        pydantic_tool: Pydantic AI Tool instance (from pydantic_ai.Tool)
+        num_cpus: Number of CPUs to allocate (default: 1)
+        memory: Memory to allocate in bytes (int) or GB (float < 1024)
+        num_gpus: Number of GPUs to allocate (default: 0)
+
+    Returns:
+        Function that executes on Ray workers, usable with Pydantic AI agents
+
+    Raises:
+        ImportError: If pydantic-ai is not installed
+        ValueError: If tool is not a Pydantic AI Tool instance
+
+    Example:
+        ```python
+        from pydantic_ai import Agent, Tool
+        from ray_agents.adapters import from_pydantic_tool
+
+        def get_weather(city: str) -> str:
+            '''Get the current weather for a city.'''
+            return f"Weather in {city}: Sunny, 72°F"
+
+        weather_tool = Tool(get_weather, name="weather", description="Get weather")
+
+        # Wrap for Ray execution
+        ray_weather = from_pydantic_tool(weather_tool, num_cpus=1)
+
+        # Use directly with Pydantic AI agent
+        agent = Agent("openai:gpt-4o-mini", tools=[ray_weather])
+        ```
+    """
+    try:
+        from pydantic_ai import Tool
+    except ImportError:
+        raise ImportError(
+            "Pydantic AI tool conversion requires 'pydantic-ai'. "
+            "Install with: pip install pydantic-ai"
+        ) from None
+
+    if not isinstance(pydantic_tool, Tool):
+        raise ValueError(
+            f"Expected Pydantic AI Tool instance, got {type(pydantic_tool).__name__}. "
+            "For plain functions, use the @tool decorator from ray_agents instead."
+        )
+
+    func = pydantic_tool.function
+    tool_name = pydantic_tool.name or func.__name__
+    tool_description = pydantic_tool.description or func.__doc__ or ""
+
+    if isinstance(memory, float) and memory < 1024:
+        memory_bytes = int(memory * (1024**3))
+    else:
+        memory_bytes = int(memory)
+
+    # Create Ray remote function
+    @ray.remote(num_cpus=num_cpus, memory=memory_bytes, num_gpus=num_gpus)
+    def _execute_tool(**kwargs: Any) -> Any:
+        return func(**kwargs)
+
+    # Create wrapper function that Pydantic AI can use directly
+    def ray_wrapper(**kwargs: Any) -> Any:
+        """Execute tool on Ray worker."""
+        return ray.get(_execute_tool.remote(**kwargs))
+
+    # Preserve metadata for Pydantic AI tool registration
+    ray_wrapper.__name__ = tool_name
+    ray_wrapper.__qualname__ = tool_name
+    ray_wrapper.__doc__ = tool_description
+
+    # Preserve type annotations and signature for Pydantic AI schema generation
+    if hasattr(func, "__annotations__"):
+        ray_wrapper.__annotations__ = func.__annotations__
+
+    try:
+        ray_wrapper.__signature__ = inspect.signature(func)  # type: ignore[attr-defined]
+    except (ValueError, TypeError):
+        pass
+
+    return ray_wrapper

--- a/src/ray_agents/cli/commands/create_agent.py
+++ b/src/ray_agents/cli/commands/create_agent.py
@@ -143,7 +143,7 @@ from langchain_openai import ChatOpenAI
 from langgraph.prebuilt import create_react_agent
 
 from ray_agents import agent, tool
-from ray_agents.adapters import AgentFramework, ToolAdapter
+from ray_agents.adapters import AgentFramework, RayToolWrapper
 
 
 # Define tools with resource requirements
@@ -165,8 +165,8 @@ class {agent_name.title().replace("_", "")}:
         self.llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
 
         # Wrap Ray tools for LangChain compatibility
-        adapter = ToolAdapter(framework=AgentFramework.LANGCHAIN)
-        lc_tools = adapter.wrap_tools(self.tools)
+        wrapper = RayToolWrapper(framework=AgentFramework.LANGCHAIN)
+        lc_tools = wrapper.wrap_tools(self.tools)
 
         # Create LangChain ReAct agent
         self.lc_agent = create_react_agent(self.llm, lc_tools)
@@ -225,7 +225,7 @@ from pydantic_ai import Agent
 from pydantic_ai.messages import ModelMessage, ModelRequest, ModelResponse, TextPart, UserPromptPart
 
 from ray_agents import agent, tool
-from ray_agents.adapters import AgentFramework, ToolAdapter
+from ray_agents.adapters import AgentFramework, RayToolWrapper
 
 
 # Define tools with resource requirements
@@ -244,8 +244,8 @@ class {agent_name.title().replace("_", "")}:
         self.tools = [example_tool]
 
         # Wrap Ray tools for Pydantic AI compatibility
-        adapter = ToolAdapter(framework=AgentFramework.PYDANTIC)
-        pydantic_tools = adapter.wrap_tools(self.tools)
+        wrapper = RayToolWrapper(framework=AgentFramework.PYDANTIC)
+        pydantic_tools = wrapper.wrap_tools(self.tools)
 
         # Create Pydantic AI agent (requires OPENAI_API_KEY env var)
         self.pydantic_agent = Agent(

--- a/src/ray_agents/decorators.py
+++ b/src/ray_agents/decorators.py
@@ -1,5 +1,6 @@
 """Decorators for Ray agents."""
 
+import inspect
 from collections.abc import Callable
 from typing import Any
 
@@ -56,6 +57,11 @@ def tool(
 
         sync_wrapper.__name__ = func.__name__
         sync_wrapper.__doc__ = func.__doc__
+        sync_wrapper.__annotations__ = func.__annotations__
+        try:
+            sync_wrapper.__signature__ = inspect.signature(func)  # type: ignore[attr-defined]
+        except (ValueError, TypeError):
+            pass
 
         return sync_wrapper
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,11 +1,11 @@
-"""Integration tests for ToolAdapter with agent frameworks."""
+"""Integration tests for RayToolWrapper with agent frameworks."""
 
 from unittest.mock import patch
 
 import pytest
 import ray
 
-from ray_agents.adapters import AgentFramework, ToolAdapter
+from ray_agents.adapters import AgentFramework, RayToolWrapper
 
 
 class TestLangChainIntegration:
@@ -32,37 +32,32 @@ class TestLangChainIntegration:
 
     def test_langchain_agent_with_ray_tools(self, ray_start, ray_calculator_tool):
         """Test full flow: LangChain agent calls Ray tool and returns response."""
-        adapter = ToolAdapter(framework=AgentFramework.LANGCHAIN)
-        wrapped_tools = adapter.wrap_tools([ray_calculator_tool])
+        wrapper = RayToolWrapper(framework=AgentFramework.LANGCHAIN)
+        wrapped_tools = wrapper.wrap_tools([ray_calculator_tool])
 
         assert len(wrapped_tools) == 1
 
-        # Verify the tool works when called directly (simulating agent tool call)
+        # Verify the tool works when invoked (simulating agent tool call)
         tool = wrapped_tools[0]
-        result = tool(operation="add", a=5, b=3)
+        result = tool.invoke({"operation": "add", "a": 5, "b": 3})
 
         assert result == 8
 
-    def test_langchain_structured_tool_creation(self, ray_start, ray_calculator_tool):
-        """Test that wrapped tools can be converted to LangChain StructuredTool."""
+    def test_langchain_tool_is_basetool(self, ray_start, ray_calculator_tool):
+        """Test that wrapped tools are LangChain BaseTool instances."""
         pytest.importorskip("langchain_core")
-        from langchain_core.tools import StructuredTool
+        from langchain_core.tools import BaseTool
 
-        adapter = ToolAdapter(framework=AgentFramework.LANGCHAIN)
-        wrapped_tools = adapter.wrap_tools([ray_calculator_tool])
+        wrapper = RayToolWrapper(framework=AgentFramework.LANGCHAIN)
+        wrapped_tools = wrapper.wrap_tools([ray_calculator_tool])
 
-        # This is what users would do to use with LangChain
-        tool_func = wrapped_tools[0]
-        structured_tool = StructuredTool.from_function(
-            func=tool_func,
-            name="calculate",
-            description="Perform a calculation",
-        )
+        # Wrapped tools should be BaseTool instances
+        tool = wrapped_tools[0]
+        assert isinstance(tool, BaseTool)
+        assert tool.name is not None
 
-        assert structured_tool.name == "calculate"
-
-        # Invoke through StructuredTool
-        result = structured_tool.invoke({"operation": "multiply", "a": 4, "b": 5})
+        # Invoke through the tool
+        result = tool.invoke({"operation": "multiply", "a": 4, "b": 5})
         assert result == 20
 
 
@@ -88,8 +83,8 @@ class TestPydanticIntegration:
 
     def test_pydantic_agent_with_ray_tools(self, ray_start, ray_search_tool):
         """Test full flow: Pydantic AI agent calls Ray tool and returns response."""
-        adapter = ToolAdapter(framework=AgentFramework.PYDANTIC)
-        wrapped_tools = adapter.wrap_tools([ray_search_tool])
+        wrapper = RayToolWrapper(framework=AgentFramework.PYDANTIC)
+        wrapped_tools = wrapper.wrap_tools([ray_search_tool])
 
         assert len(wrapped_tools) == 1
 
@@ -104,8 +99,8 @@ class TestPydanticIntegration:
         pytest.importorskip("pydantic_ai")
         from pydantic_ai import FunctionToolset
 
-        adapter = ToolAdapter(framework=AgentFramework.PYDANTIC)
-        wrapped_tools = adapter.wrap_tools([ray_search_tool])
+        wrapper = RayToolWrapper(framework=AgentFramework.PYDANTIC)
+        wrapped_tools = wrapper.wrap_tools([ray_search_tool])
 
         # This is what users would do to use with Pydantic AI
         toolset = FunctionToolset()
@@ -117,34 +112,55 @@ class TestPydanticIntegration:
         assert toolset is not None
 
 
-class TestCrossFrameworkTools:
-    """Test using tools from one framework with another."""
+class TestFromLangChainTool:
+    """Test from_langchain_tool returns a usable LangChain tool."""
 
-    def test_langchain_tool_with_pydantic_adapter(self, ray_start):
-        """Test converting LangChain tool to Ray, then wrapping for Pydantic."""
+    def test_from_langchain_tool_returns_langchain_tool(self, ray_start):
+        """Test that from_langchain_tool returns a LangChain BaseTool."""
         pytest.importorskip("langchain_core")
+        from langchain_core.tools import BaseTool
         from langchain_core.tools import tool as langchain_tool
 
         from ray_agents.adapters.langchain import from_langchain_tool
 
-        # Create a LangChain tool
         @langchain_tool
         def greet(name: str) -> str:
             """Greet someone by name."""
             return f"Hello, {name}!"
 
-        # Convert to Ray tool
+        # Convert to Ray-executed LangChain tool
         ray_greet = from_langchain_tool(greet)
 
-        # Wrap for Pydantic
-        adapter = ToolAdapter(framework=AgentFramework.PYDANTIC)
-        wrapped = adapter.wrap_tools([ray_greet])
+        # Should be a LangChain BaseTool
+        assert isinstance(ray_greet, BaseTool)
+        assert ray_greet.name == "greet"
+        assert "Greet someone" in ray_greet.description
 
-        assert len(wrapped) == 1
-
-        # Should work with Pydantic agent
-        result = wrapped[0](name="World")
+        # Should work when invoked
+        result = ray_greet.invoke("World")
         assert result == "Hello, World!"
+
+    def test_from_langchain_tool_async(self, ray_start):
+        """Test that from_langchain_tool works with async invocation."""
+        pytest.importorskip("langchain_core")
+        import asyncio
+
+        from langchain_core.tools import tool as langchain_tool
+
+        from ray_agents.adapters.langchain import from_langchain_tool
+
+        @langchain_tool
+        def add(a: int, b: int) -> int:
+            """Add two numbers."""
+            return a + b
+
+        ray_add = from_langchain_tool(add)
+
+        # Should work with async invocation
+        result = asyncio.get_event_loop().run_until_complete(
+            ray_add.ainvoke({"a": 2, "b": 3})
+        )
+        assert result == 5
 
 
 class TestToolExecutionDistributed:
@@ -152,20 +168,20 @@ class TestToolExecutionDistributed:
 
     def test_tool_executes_via_ray_get(self, ray_start):
         """Verify tool execution goes through ray.get."""
-        adapter = ToolAdapter(framework=AgentFramework.LANGCHAIN)
+        wrapper = RayToolWrapper(framework=AgentFramework.LANGCHAIN)
 
         @ray.remote
         def tracked_tool(x: int) -> int:
             return x * 2
 
-        wrapped = adapter.wrap_tools([tracked_tool])
+        wrapped = wrapper.wrap_tools([tracked_tool])
 
-        # Patch ray.get to verify it's called
-        with patch("ray_agents.adapters.abc.ray.get") as mock_get:
+        # Patch ray.get in core module to verify it's called
+        with patch("ray_agents.adapters.core.ray.get") as mock_get:
             # Set up mock to return actual result
             mock_get.return_value = 10
 
-            result = wrapped[0](x=5)
+            result = wrapped[0].invoke({"x": 5})
 
             # Verify ray.get was called
             mock_get.assert_called_once()
@@ -173,7 +189,7 @@ class TestToolExecutionDistributed:
 
     def test_multiple_tools_execute_independently(self, ray_start):
         """Test that multiple tools can be wrapped and called independently."""
-        adapter = ToolAdapter(framework=AgentFramework.LANGCHAIN)
+        wrapper = RayToolWrapper(framework=AgentFramework.LANGCHAIN)
 
         @ray.remote
         def tool_a(x: int) -> dict:
@@ -183,12 +199,13 @@ class TestToolExecutionDistributed:
         def tool_b(x: int) -> dict:
             return {"status": "success", "result": x * 2}
 
-        wrapped = adapter.wrap_tools([tool_a, tool_b])
+        wrapped = wrapper.wrap_tools([tool_a, tool_b])
 
         assert len(wrapped) == 2
 
-        result_a = wrapped[0](x=5)
-        result_b = wrapped[1](x=5)
+        # Use .invoke() for LangChain tools
+        result_a = wrapped[0].invoke({"x": 5})
+        result_b = wrapped[1].invoke({"x": 5})
 
         assert result_a == 6  # 5 + 1
         assert result_b == 10  # 5 * 2

--- a/tests/test_tool_adapters.py
+++ b/tests/test_tool_adapters.py
@@ -1,31 +1,262 @@
-"""Unit tests for ToolAdapter."""
+"""Unit tests for RayToolWrapper and cross-framework conversion."""
 
 import pytest
 import ray
 
-from ray_agents.adapters import AgentFramework, ToolAdapter
+from ray_agents.adapters import AgentFramework, RayToolWrapper
+from ray_agents.adapters.core import (
+    RayTool,
+    SourceFramework,
+    detect_framework,
+)
 
 
-class TestToolAdapter:
-    """Tests for ToolAdapter class."""
+class TestFrameworkDetection:
+    """Tests for auto-detecting source framework."""
 
-    def test_adapter_accepts_framework_param(self):
-        """Test that adapter accepts framework parameter."""
-        adapter = ToolAdapter(framework=AgentFramework.LANGCHAIN)
-        assert adapter.framework == AgentFramework.LANGCHAIN
+    def test_detect_ray_remote_function(self, ray_start):
+        """Test detection of Ray remote functions."""
 
-        adapter = ToolAdapter(framework=AgentFramework.PYDANTIC)
-        assert adapter.framework == AgentFramework.PYDANTIC
+        @ray.remote
+        def my_tool(x: str) -> str:
+            return x
+
+        assert detect_framework(my_tool) == SourceFramework.RAY_TOOL
+
+    def test_detect_tool_with_remote_func_attribute(self, ray_start):
+        """Test detection of tools with _remote_func attribute."""
+
+        @ray.remote
+        def actual_remote(x: int) -> int:
+            return x
+
+        def tool_wrapper(x: int) -> int:
+            return ray.get(actual_remote.remote(x))
+
+        tool_wrapper._remote_func = actual_remote
+
+        assert detect_framework(tool_wrapper) == SourceFramework.RAY_TOOL
+
+    def test_detect_langchain_tool(self, ray_start):
+        """Test detection of LangChain BaseTool."""
+        pytest.importorskip("langchain_core")
+        from langchain_core.tools import tool as langchain_tool
+
+        @langchain_tool
+        def greet(name: str) -> str:
+            """Greet someone."""
+            return f"Hello, {name}!"
+
+        assert detect_framework(greet) == SourceFramework.LANGCHAIN
+
+    def test_detect_pydantic_tool(self, ray_start):
+        """Test detection of Pydantic AI Tool."""
+        pytest.importorskip("pydantic_ai")
+        from pydantic_ai import Tool
+
+        def my_func(x: int) -> int:
+            return x * 2
+
+        tool = Tool(my_func, name="double")
+        assert detect_framework(tool) == SourceFramework.PYDANTIC
+
+    def test_detect_plain_callable(self, ray_start):
+        """Test detection of plain callable."""
+
+        def my_func(x: int) -> int:
+            """Double a number."""
+            return x * 2
+
+        assert detect_framework(my_func) == SourceFramework.CALLABLE
+
+    def test_detect_raises_for_unknown(self, ray_start):
+        """Test that detection raises ValueError for unknown types."""
+        with pytest.raises(ValueError, match="Cannot detect framework"):
+            detect_framework("not a tool")
+
+
+class TestRayToolDataclass:
+    """Tests for the RayTool canonical representation."""
+
+    def test_raytool_has_expected_fields(self):
+        """Test RayTool dataclass has expected fields."""
+        # Should be importable and have expected attributes
+        assert hasattr(RayTool, "__dataclass_fields__")
+        fields = RayTool.__dataclass_fields__
+        assert "name" in fields
+        assert "description" in fields
+        assert "ray_remote" in fields
+        assert "func" in fields
+        assert "args_schema" in fields
+        assert "signature" in fields
+        assert "annotations" in fields
+
+
+class TestCrossFrameworkConversion:
+    """Tests for cross-framework tool conversion."""
+
+    def test_langchain_to_pydantic(self, ray_start):
+        """Test LangChain tool to Pydantic conversion."""
+        pytest.importorskip("langchain_core")
+        from langchain_core.tools import tool as langchain_tool
+
+        @langchain_tool
+        def search(query: str) -> str:
+            """Search the web for information."""
+            return f"Results for: {query}"
+
+        wrapper = RayToolWrapper(framework=AgentFramework.PYDANTIC)
+        pydantic_tools = wrapper.wrap_tools([search])
+
+        assert len(pydantic_tools) == 1
+        pydantic_tool = pydantic_tools[0]
+
+        # Should be a callable with metadata
+        assert callable(pydantic_tool)
+        assert pydantic_tool.__name__ == "search"
+        assert pydantic_tool.__doc__ and "Search" in pydantic_tool.__doc__
+
+        # Should execute correctly
+        result = pydantic_tool(query="python")
+        assert "python" in result
+
+    def test_pydantic_to_langchain(self, ray_start):
+        """Test Pydantic tool to LangChain conversion."""
+        pytest.importorskip("pydantic_ai")
+        pytest.importorskip("langchain_core")
+        from langchain_core.tools import BaseTool
+        from pydantic_ai import Tool
+
+        def multiply(x: int, y: int) -> int:
+            """Multiply two numbers together."""
+            return x * y
+
+        pydantic_tool = Tool(multiply, name="multiply", description="Multiply numbers")
+
+        wrapper = RayToolWrapper(framework=AgentFramework.LANGCHAIN)
+        lc_tools = wrapper.wrap_tools([pydantic_tool])
+
+        assert len(lc_tools) == 1
+        lc_tool = lc_tools[0]
+
+        # Should be a LangChain BaseTool
+        assert isinstance(lc_tool, BaseTool)
+        assert lc_tool.name == "multiply"
+        assert "Multiply" in lc_tool.description
+
+        # Should execute correctly
+        result = lc_tool.invoke({"x": 3, "y": 4})
+        assert result == 12
+
+    def test_callable_to_pydantic(self, ray_start):
+        """Test plain callable to Pydantic conversion."""
+
+        def calculate(a: int, b: int) -> int:
+            """Add two numbers."""
+            return a + b
+
+        wrapper = RayToolWrapper(framework=AgentFramework.PYDANTIC)
+        pydantic_tools = wrapper.wrap_tools([calculate])
+
+        assert len(pydantic_tools) == 1
+        pydantic_tool = pydantic_tools[0]
+
+        assert callable(pydantic_tool)
+        assert pydantic_tool.__name__ == "calculate"
+        assert pydantic_tool.__doc__ and "Add two numbers" in pydantic_tool.__doc__
+
+        # Check annotations are preserved
+        assert "a" in pydantic_tool.__annotations__
+        assert "b" in pydantic_tool.__annotations__
+
+    def test_callable_to_langchain(self, ray_start):
+        """Test plain callable to LangChain conversion."""
+        pytest.importorskip("langchain_core")
+        from langchain_core.tools import BaseTool
+
+        def greet(name: str) -> str:
+            """Greet a person by name."""
+            return f"Hello, {name}!"
+
+        wrapper = RayToolWrapper(framework=AgentFramework.LANGCHAIN)
+        lc_tools = wrapper.wrap_tools([greet])
+
+        assert len(lc_tools) == 1
+        lc_tool = lc_tools[0]
+
+        assert isinstance(lc_tool, BaseTool)
+        assert lc_tool.name == "greet"
+
+    def test_mixed_tools_conversion(self, ray_start):
+        """Test converting mixed tools from different frameworks."""
+        pytest.importorskip("langchain_core")
+        from langchain_core.tools import tool as langchain_tool
+
+        @langchain_tool
+        def lc_search(query: str) -> str:
+            """LangChain search tool."""
+            return f"LC: {query}"
+
+        def plain_func(x: int) -> int:
+            """Plain function."""
+            return x * 2
+
+        wrapper = RayToolWrapper(framework=AgentFramework.PYDANTIC)
+        pydantic_tools = wrapper.wrap_tools([lc_search, plain_func])
+
+        assert len(pydantic_tools) == 2
+
+        # Both should work
+        assert "LC:" in pydantic_tools[0](query="test")
+        assert pydantic_tools[1](x=5) == 10
+
+
+class TestResourceConfiguration:
+    """Tests for Ray resource configuration."""
+
+    def test_custom_cpu_allocation(self, ray_start):
+        """Test custom CPU allocation."""
+
+        def my_func(x: int) -> int:
+            return x
+
+        wrapper = RayToolWrapper(framework=AgentFramework.PYDANTIC)
+        # Should not error with custom resources
+        result = wrapper.wrap_tools([my_func], num_cpus=2)
+        assert len(result) == 1
+
+    def test_memory_in_gb(self, ray_start):
+        """Test memory specification in GB."""
+
+        def my_func(x: int) -> int:
+            return x
+
+        wrapper = RayToolWrapper(framework=AgentFramework.PYDANTIC)
+        # 1.0 should be interpreted as 1GB
+        result = wrapper.wrap_tools([my_func], memory=1.0)
+        assert len(result) == 1
+
+
+class TestRayToolWrapper:
+    """Tests for RayToolWrapper class."""
+
+    def test_wrapper_accepts_framework_param(self):
+        """Test that wrapper accepts framework parameter."""
+        wrapper = RayToolWrapper(framework=AgentFramework.LANGCHAIN)
+        assert wrapper.framework == AgentFramework.LANGCHAIN
+
+        wrapper = RayToolWrapper(framework=AgentFramework.PYDANTIC)
+        assert wrapper.framework == AgentFramework.PYDANTIC
 
     def test_wrap_tools_returns_list(self, ray_start):
         """Test that wrap_tools returns a list of callables."""
-        adapter = ToolAdapter(framework=AgentFramework.LANGCHAIN)
+        wrapper = RayToolWrapper(framework=AgentFramework.LANGCHAIN)
 
         @ray.remote
         def dummy_tool(x: str) -> str:
             return f"result: {x}"
 
-        wrapped = adapter.wrap_tools([dummy_tool])
+        wrapped = wrapper.wrap_tools([dummy_tool])
 
         assert isinstance(wrapped, list)
         assert len(wrapped) == 1
@@ -33,69 +264,75 @@ class TestToolAdapter:
 
     def test_wrapped_tool_executes_on_ray(self, ray_start):
         """Test that wrapped tool dispatches to Ray cluster."""
-        adapter = ToolAdapter(framework=AgentFramework.LANGCHAIN)
+        wrapper = RayToolWrapper(framework=AgentFramework.LANGCHAIN)
 
         @ray.remote
         def add_numbers(a: int, b: int) -> int:
             return a + b
 
-        wrapped = adapter.wrap_tools([add_numbers])
-        result = wrapped[0](a=2, b=3)
+        wrapped = wrapper.wrap_tools([add_numbers])
+        # LangChain tools should be invoked with .invoke()
+        result = wrapped[0].invoke({"a": 2, "b": 3})
 
         assert result == 5
 
     def test_wrapped_tool_handles_error_status(self, ray_start):
         """Test that wrapped tool raises RuntimeError on error status."""
-        adapter = ToolAdapter(framework=AgentFramework.LANGCHAIN)
+        wrapper = RayToolWrapper(framework=AgentFramework.LANGCHAIN)
 
         @ray.remote
         def failing_tool() -> dict:
             return {"status": "error", "error": "Something went wrong"}
 
-        wrapped = adapter.wrap_tools([failing_tool])
+        wrapped = wrapper.wrap_tools([failing_tool])
 
         with pytest.raises(RuntimeError, match="Tool error: Something went wrong"):
-            wrapped[0]()
+            wrapped[0].invoke({})
 
     def test_wrapped_tool_extracts_result(self, ray_start):
         """Test that wrapped tool extracts result from status dict."""
-        adapter = ToolAdapter(framework=AgentFramework.PYDANTIC)
+        wrapper = RayToolWrapper(framework=AgentFramework.PYDANTIC)
 
         @ray.remote
         def tool_with_status() -> dict:
             return {"status": "success", "result": "extracted value"}
 
-        wrapped = adapter.wrap_tools([tool_with_status])
+        wrapped = wrapper.wrap_tools([tool_with_status])
         result = wrapped[0]()
 
         assert result == "extracted value"
 
     def test_wrapped_tool_preserves_plain_result(self, ray_start):
         """Test that wrapped tool returns plain results as-is."""
-        adapter = ToolAdapter(framework=AgentFramework.LANGCHAIN)
+        wrapper = RayToolWrapper(framework=AgentFramework.LANGCHAIN)
 
         @ray.remote
         def plain_tool() -> str:
             return "plain result"
 
-        wrapped = adapter.wrap_tools([plain_tool])
-        result = wrapped[0]()
+        wrapped = wrapper.wrap_tools([plain_tool])
+        result = wrapped[0].invoke({})
 
         assert result == "plain result"
 
-    def test_wrap_tools_skips_non_ray_functions(self, ray_start):
-        """Test that wrap_tools skips non-Ray functions with warning."""
-        adapter = ToolAdapter(framework=AgentFramework.LANGCHAIN)
+    def test_wrap_tools_converts_plain_callables(self, ray_start):
+        """Test that wrap_tools converts plain callables to Ray-executed tools."""
+        wrapper = RayToolWrapper(framework=AgentFramework.PYDANTIC)
 
-        def not_a_ray_tool(x: str) -> str:
-            return x
+        def plain_func(x: str) -> str:
+            """A plain function."""
+            return f"result: {x}"
 
-        wrapped = adapter.wrap_tools([not_a_ray_tool])
-        assert wrapped == []
+        wrapped = wrapper.wrap_tools([plain_func])
+        assert len(wrapped) == 1
+        assert callable(wrapped[0])
+        # Should execute on Ray
+        result = wrapped[0](x="test")
+        assert result == "result: test"
 
     def test_wrapped_tool_preserves_args_schema(self, ray_start):
         """Test that wrapped tool preserves args_schema attribute."""
-        adapter = ToolAdapter(framework=AgentFramework.LANGCHAIN)
+        wrapper = RayToolWrapper(framework=AgentFramework.LANGCHAIN)
 
         @ray.remote
         def tool_func(query: str) -> str:
@@ -107,7 +344,7 @@ class TestToolAdapter:
             "properties": {"query": {"type": "string"}},
         }
 
-        wrapped = adapter.wrap_tools([tool_func])
+        wrapped = wrapper.wrap_tools([tool_func])
 
         assert hasattr(wrapped[0], "args_schema")
         assert wrapped[0].args_schema == {
@@ -117,22 +354,23 @@ class TestToolAdapter:
 
     def test_wrap_tools_handles_remote_func_attribute(self, ray_start):
         """Test that wrap_tools handles tools with _remote_func attribute."""
-        adapter = ToolAdapter(framework=AgentFramework.LANGCHAIN)
+        wrapper = RayToolWrapper(framework=AgentFramework.LANGCHAIN)
 
         @ray.remote
         def actual_remote(x: int) -> int:
             return x * 2
 
-        # Create a wrapper that has _remote_func (like from @tool decorator)
-        def wrapper(x: int) -> int:
+        # Create a tool_wrapper that has _remote_func (like from @tool decorator)
+        def tool_wrapper(x: int) -> int:
             return ray.get(actual_remote.remote(x))
 
-        wrapper._remote_func = actual_remote
+        tool_wrapper._remote_func = actual_remote
 
-        wrapped = adapter.wrap_tools([wrapper])
+        wrapped = wrapper.wrap_tools([tool_wrapper])
 
         assert len(wrapped) == 1
-        result = wrapped[0](x=5)
+        # LangChain tools should be invoked with .invoke()
+        result = wrapped[0].invoke({"x": 5})
         assert result == 10
 
     def test_both_frameworks_produce_working_wrappers(self, ray_start):
@@ -142,14 +380,14 @@ class TestToolAdapter:
         def shared_tool(message: str) -> dict:
             return {"status": "success", "result": f"processed: {message}"}
 
-        langchain_adapter = ToolAdapter(framework=AgentFramework.LANGCHAIN)
-        pydantic_adapter = ToolAdapter(framework=AgentFramework.PYDANTIC)
+        langchain_wrapper = RayToolWrapper(framework=AgentFramework.LANGCHAIN)
+        pydantic_wrapper = RayToolWrapper(framework=AgentFramework.PYDANTIC)
 
-        lc_wrapped = langchain_adapter.wrap_tools([shared_tool])
-        pd_wrapped = pydantic_adapter.wrap_tools([shared_tool])
+        lc_wrapped = langchain_wrapper.wrap_tools([shared_tool])
+        pd_wrapped = pydantic_wrapper.wrap_tools([shared_tool])
 
-        # Both should work identically
-        lc_result = lc_wrapped[0](message="hello")
+        # LangChain uses .invoke() with dict, Pydantic uses direct call with kwargs
+        lc_result = lc_wrapped[0].invoke({"message": "hello"})
         pd_result = pd_wrapped[0](message="hello")
 
         assert lc_result == "processed: hello"


### PR DESCRIPTION
## Related Issues
<!-- Link any related issues: Fixes #123, Relates to #456 -->

## Description
Cleaner API for cross-framework tool conversion with RayToolWrapper.

```
from ray_agents.adapters import RayToolWrapper, AgentFramework

# LangChain tool → Pydantic agent
wrapper = RayToolWrapper(framework=AgentFramework.PYDANTIC)
pydantic_tools = wrapper.wrap_tools([langchain_search_tool], num_cpus=2)

# Pydantic tool → LangChain agent
wrapper = RayToolWrapper(framework=AgentFramework.LANGCHAIN)
lc_tools = wrapper.wrap_tools([pydantic_tool])

# Mix tools from different frameworks
wrapper = RayToolWrapper(framework=AgentFramework.PYDANTIC)
tools = wrapper.wrap_tools([langchain_tool, pydantic_tool, plain_callable])
```

## Additional Context
<!-- Anything you want reviewers to know or give specific feedback on? -->

## Testing
<!-- Describe how you tested these changes -->

- [ ] Tested locally
- [x] Added/updated tests
- [x] All tests passing
- [x] Updated Docs 

## Screenshots/Demo
<!-- If applicable, add screenshots or a demo link -->
