### PR TITLE
Templates: rename alias → name across SDKs and console

### DIFF
--- a/apps/console/src/app/(dashboard)/sandboxes/[sandbox_id]/terminal/page.tsx
+++ b/apps/console/src/app/(dashboard)/sandboxes/[sandbox_id]/terminal/page.tsx
@@ -112,9 +112,7 @@ export default function TerminalPage() {
           icon={TerminalIcon}
           title="Sandbox is paused"
           description="Start the sandbox to open a terminal session. Resume takes a second or two."
-          actionLabel={
-            resumeMutation.isPending ? "Starting…" : "Start sandbox"
-          }
+          actionLabel={resumeMutation.isPending ? "Starting…" : "Start sandbox"}
           onAction={() => resumeMutation.mutate(sandbox.id)}
         />
       ) : sandbox.status === "resuming" ? (

--- a/apps/console/src/app/(dashboard)/sandboxes/page.tsx
+++ b/apps/console/src/app/(dashboard)/sandboxes/page.tsx
@@ -78,12 +78,12 @@ function SandboxesPageContent() {
   const [templateRef, setTemplateRef] = useState<string | null>(null)
 
   // When the user clicks "Launch sandbox" from the templates section, we
-  // navigate here with ?from_template=<alias>. Open the dialog with the
+  // navigate here with ?from_template=<name>. Open the dialog with the
   // template prefilled, then strip the param so refreshing doesn't re-open.
   useEffect(() => {
-    const alias = searchParams.get("from_template")
-    if (!alias) return
-    setTemplateRef(alias)
+    const name = searchParams.get("from_template")
+    if (!name) return
+    setTemplateRef(name)
     setCreateOpen(true)
     const params = new URLSearchParams(searchParams.toString())
     params.delete("from_template")

--- a/apps/console/src/app/(dashboard)/templates/[template_id]/page.tsx
+++ b/apps/console/src/app/(dashboard)/templates/[template_id]/page.tsx
@@ -69,7 +69,7 @@ export default function TemplateDetailPage() {
           </Link>
           <span className="text-muted">/</span>
           <h1 className="font-mono text-sm font-medium text-foreground">
-            {data.alias}
+            {data.name}
           </h1>
           <TemplateStatusBadge status={data.status} />
           {system && (
@@ -85,7 +85,7 @@ export default function TemplateDetailPage() {
             disabled={data.status !== "ready"}
             onClick={() =>
               router.push(
-                `/sandboxes?from_template=${encodeURIComponent(data.alias)}`,
+                `/sandboxes?from_template=${encodeURIComponent(data.name)}`,
               )
             }
           >

--- a/apps/console/src/app/(dashboard)/templates/page.tsx
+++ b/apps/console/src/app/(dashboard)/templates/page.tsx
@@ -54,7 +54,7 @@ function TemplatesPageContent() {
 
     const q = search.trim().toLowerCase()
     if (!q) return byTab
-    return byTab.filter((t) => t.alias.toLowerCase().includes(q))
+    return byTab.filter((t) => t.name.toLowerCase().includes(q))
   }, [templates, tab, search])
 
   const newButton = (
@@ -107,7 +107,7 @@ function TemplatesPageContent() {
             ]}
             activeTab={tab}
             onTabChange={(v) => setTab(v as Tab)}
-            searchPlaceholder="Search aliases…"
+            searchPlaceholder="Search names…"
             searchValue={search}
             onSearchChange={setSearch}
           />
@@ -125,7 +125,7 @@ function TemplatesPageContent() {
                 }
                 description={
                   search
-                    ? "Try a different alias prefix."
+                    ? "Try a different name prefix."
                     : tab === "team"
                       ? "Create one to get started."
                       : "System templates are curated by Superserve."

--- a/apps/console/src/components/sandboxes/create-sandbox-dialog.tsx
+++ b/apps/console/src/components/sandboxes/create-sandbox-dialog.tsx
@@ -35,7 +35,7 @@ const DEFAULT_TEMPLATE = "superserve/base"
 
 interface TemplatePickerItem {
   id: string
-  alias: string
+  name: string
   system: boolean
 }
 
@@ -46,14 +46,14 @@ function TemplatePicker({
 }: {
   value: string
   items: TemplatePickerItem[]
-  onChange: (alias: string) => void
+  onChange: (name: string) => void
 }) {
   const [open, setOpen] = useState(false)
   const [mounted, setMounted] = useState(false)
   const [rect, setRect] = useState<DOMRect | null>(null)
   const triggerRef = useRef<HTMLButtonElement | null>(null)
   const panelRef = useRef<HTMLDivElement | null>(null)
-  const current = items.find((i) => i.alias === value)
+  const current = items.find((i) => i.name === value)
 
   useEffect(() => setMounted(true), [])
 
@@ -114,13 +114,13 @@ function TemplatePicker({
               </div>
             ) : (
               items.map((item) => {
-                const selected = item.alias === value
+                const selected = item.name === value
                 return (
                   <button
                     key={item.id}
                     type="button"
                     onClick={() => {
-                      onChange(item.alias)
+                      onChange(item.name)
                       setOpen(false)
                     }}
                     className={cn(
@@ -130,7 +130,7 @@ function TemplatePicker({
                         : "text-foreground/80 hover:bg-surface-hover",
                     )}
                   >
-                    <span className="font-mono">{item.alias}</span>
+                    <span className="font-mono">{item.name}</span>
                     {item.system && (
                       <span className="font-mono text-[10px] uppercase text-muted">
                         System
@@ -304,8 +304,8 @@ interface CreateSandboxDialogProps {
   hideTrigger?: boolean
   onCreated?: (sandboxId: string) => void
   /**
-   * Template reference to launch the sandbox from — either a UUID or an
-   * alias. When set, the dialog shows a "From template" banner and the
+   * Template reference to launch the sandbox from — either a UUID or a
+   * name. When set, the dialog shows a "From template" banner and the
    * create payload includes `template_id`.
    */
   initialTemplateRef?: string | null
@@ -351,30 +351,30 @@ export function CreateSandboxDialog({
   const templateOptions = useMemo(() => {
     const list = templates ?? []
     const ready = list.filter((t) => t.status === "ready")
-    // Sort: system templates first (ss/* curated), then team by alias.
+    // Sort: system templates first (ss/* curated), then team by name.
     return [...ready].sort((a, b) => {
       const aSys = isSystemTemplate(a)
       const bSys = isSystemTemplate(b)
       if (aSys !== bSys) return aSys ? -1 : 1
-      return a.alias.localeCompare(b.alias)
+      return a.name.localeCompare(b.name)
     })
   }, [templates])
 
   const selectItems = useMemo(() => {
     const mapped = templateOptions.map((t) => ({
       id: t.id,
-      alias: t.alias,
+      name: t.name,
       system: isSystemTemplate(t),
     }))
     // Ensure the current value is always in the items list, even if the
     // templates query hasn't resolved yet.
-    const aliases = new Set(mapped.map((t) => t.alias))
-    if (templateRef && !aliases.has(templateRef)) {
+    const names = new Set(mapped.map((t) => t.name))
+    if (templateRef && !names.has(templateRef)) {
       return [
         {
           id: templateRef,
-          alias: templateRef,
-          system: isSystemTemplate({ alias: templateRef }),
+          name: templateRef,
+          system: isSystemTemplate({ name: templateRef }),
         },
         ...mapped,
       ]

--- a/apps/console/src/components/sandboxes/files-section.test.tsx
+++ b/apps/console/src/components/sandboxes/files-section.test.tsx
@@ -39,6 +39,7 @@ vi.mock("posthog-js/react", () => ({
 vi.mock("@phosphor-icons/react", () => ({
   DownloadSimpleIcon: () => <span>↓</span>,
   FileArrowUpIcon: () => <span>f</span>,
+  FilesIcon: () => <span>📁</span>,
   UploadSimpleIcon: () => <span>↑</span>,
 }))
 
@@ -80,18 +81,17 @@ function successResponse(
 }
 
 describe("FilesSection — disabled gating", () => {
-  it("disables panels when sandbox is resuming, with reason in header", () => {
+  it("renders the empty state when sandbox is resuming, with reason text", () => {
     render(<FilesSection sandbox={{ ...activeSandbox, status: "resuming" }} />)
-    // Reason text appears both in the section header and in tooltip popups.
-    expect(screen.getAllByText(/resuming/i).length).toBeGreaterThan(0)
-    expect(screen.getByRole("button", { name: /Upload/ })).toBeDisabled()
-    expect(screen.getByRole("button", { name: /Download/ })).toBeDisabled()
+    expect(screen.getByText(/Sandbox is resuming/i)).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /Upload/ })).toBeNull()
+    expect(screen.queryByRole("button", { name: /Download/ })).toBeNull()
   })
 
-  it("disables panels when sandbox is paused, with hint to start", () => {
+  it("renders the empty state when sandbox is paused, with hint to start", () => {
     render(<FilesSection sandbox={{ ...activeSandbox, status: "paused" }} />)
-    expect(screen.getAllByText(/Start the sandbox/i).length).toBeGreaterThan(0)
-    expect(screen.getByRole("button", { name: /Upload/ })).toBeDisabled()
+    expect(screen.getByText(/Start the sandbox/i)).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /Upload/ })).toBeNull()
   })
 
   it("enables download input but keeps Upload button disabled with no file", () => {

--- a/apps/console/src/components/sandboxes/sandbox-status-hero.tsx
+++ b/apps/console/src/components/sandboxes/sandbox-status-hero.tsx
@@ -72,17 +72,12 @@ export function SandboxStatusHero({
   const created = formatTime(new Date(sandbox.created_at))
 
   return (
-    <section
-      className={cn("border-b border-border px-4 py-6", cfg.bg)}
-    >
+    <section className={cn("border-b border-border px-4 py-6", cfg.bg)}>
       <div className="flex items-start justify-between gap-6">
         {/* Identity + status */}
         <div className="flex min-w-0 items-start gap-3">
           <span
-            className={cn(
-              "relative mt-2 inline-flex size-2 shrink-0",
-              cfg.dot,
-            )}
+            className={cn("relative mt-2 inline-flex size-2 shrink-0", cfg.dot)}
           >
             {cfg.pulse && (
               <span
@@ -102,9 +97,7 @@ export function SandboxStatusHero({
               <span>·</span>
               <span title={sandbox.id}>{sandbox.id.slice(0, 8)}</span>
               <span>·</span>
-              <span title={created.absolute}>
-                Created {created.relative}
-              </span>
+              <span title={created.absolute}>Created {created.relative}</span>
             </div>
           </div>
         </div>

--- a/apps/console/src/components/templates/create-template-dialog.tsx
+++ b/apps/console/src/components/templates/create-template-dialog.tsx
@@ -30,12 +30,12 @@ const MEMORY_OPTIONS = [256, 512, 1024, 2048, 4096] as const
 const DISK_OPTIONS = [1024, 2048, 4096, 8192] as const
 const VCPU_OPTIONS = [1, 2, 4] as const
 
-const ALIAS_RE = /^[a-z0-9][a-z0-9-]*$/
+const NAME_RE = /^[a-z0-9][a-z0-9-]*$/
 
-function validateAlias(alias: string): string | null {
-  if (!alias) return "Name is required"
-  if (alias.length > 128) return "Name must be 128 characters or fewer"
-  if (!ALIAS_RE.test(alias))
+function validateName(name: string): string | null {
+  if (!name) return "Name is required"
+  if (name.length > 128) return "Name must be 128 characters or fewer"
+  if (!NAME_RE.test(name))
     return "Use lowercase letters, numbers, and hyphens; start with a letter or number"
   return null
 }
@@ -72,7 +72,7 @@ export function CreateTemplateDialog({
   const open = controlledOpen ?? internalOpen
   const setOpen = onOpenChange ?? setInternalOpen
 
-  const [alias, setAlias] = useState("")
+  const [name, setName] = useState("")
   const [imageMode, setImageMode] = useState<"curated" | "custom">("curated")
   const [curatedImage, setCuratedImage] = useState<string>(CURATED_IMAGES[1])
   const [customImage, setCustomImage] = useState("")
@@ -80,13 +80,13 @@ export function CreateTemplateDialog({
   const [memory, setMemory] = useState<number>(1024)
   const [disk, setDisk] = useState<number>(4096)
   const [errors, setErrors] = useState<{
-    alias?: string
+    name?: string
     image?: string
     form?: string
   }>({})
 
   const reset = () => {
-    setAlias("")
+    setName("")
     setImageMode("curated")
     setCuratedImage(CURATED_IMAGES[1])
     setCustomImage("")
@@ -97,25 +97,25 @@ export function CreateTemplateDialog({
   }
 
   // Live-computed errors so the user sees feedback as they type.
-  // Only surfaced after the field has been touched (alias) or always when
-  // the user has entered a custom image (image).
+  // Only surfaced after the name field has been touched, or always when
+  // the user has entered a custom image.
   const trimmedImage =
     imageMode === "curated" ? curatedImage : customImage.trim()
-  const liveAliasError = useMemo(() => validateAlias(alias.trim()), [alias])
+  const liveNameError = useMemo(() => validateName(name.trim()), [name])
   const liveImageError = useMemo(
     () => (trimmedImage ? validateImage(trimmedImage) : null),
     [trimmedImage],
   )
 
-  const isValid = !liveAliasError && !liveImageError && trimmedImage.length > 0
+  const isValid = !liveNameError && !liveImageError && trimmedImage.length > 0
 
   const handleCreate = async () => {
     const image = trimmedImage
-    const aliasError = validateAlias(alias.trim())
+    const nameError = validateName(name.trim())
     const imageError = validateImage(image)
-    if (aliasError || imageError) {
+    if (nameError || imageError) {
       setErrors({
-        alias: aliasError ?? undefined,
+        name: nameError ?? undefined,
         image: imageError ?? undefined,
       })
       return
@@ -124,7 +124,7 @@ export function CreateTemplateDialog({
 
     try {
       const created = await create.mutateAsync({
-        alias: alias.trim(),
+        name: name.trim(),
         vcpu,
         memory_mib: memory,
         disk_mib: disk,
@@ -136,7 +136,7 @@ export function CreateTemplateDialog({
     } catch (err) {
       if (err instanceof ApiError) {
         if (err.status === 409) {
-          setErrors({ alias: "A template with this name already exists." })
+          setErrors({ name: "A template with this name already exists." })
           return
         }
         if (err.status === 429) {
@@ -172,12 +172,11 @@ export function CreateTemplateDialog({
           <Field label="Name" required>
             <Input
               autoFocus
-              value={alias}
-              onChange={(e) => setAlias(e.target.value)}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
               placeholder="e.g. python-ml"
               error={
-                errors.alias ??
-                (alias ? (liveAliasError ?? undefined) : undefined)
+                errors.name ?? (name ? (liveNameError ?? undefined) : undefined)
               }
               onKeyDown={(e) => {
                 if (e.key === "Enter") {
@@ -315,7 +314,10 @@ export function CreateTemplateDialog({
           <Button variant="outline" onClick={() => setOpen(false)}>
             Cancel
           </Button>
-          <Button onClick={handleCreate} disabled={!isValid || create.isPending}>
+          <Button
+            onClick={handleCreate}
+            disabled={!isValid || create.isPending}
+          >
             {create.isPending ? "Creating…" : "Create & build"}
           </Button>
         </DialogFooter>

--- a/apps/console/src/components/templates/delete-template-dialog.tsx
+++ b/apps/console/src/components/templates/delete-template-dialog.tsx
@@ -48,7 +48,7 @@ export function DeleteTemplateDialog({
         </DialogHeader>
         <div className="px-6 pb-2 text-sm text-muted">
           This will soft-delete{" "}
-          <span className="font-mono text-foreground">{template?.alias}</span>.
+          <span className="font-mono text-foreground">{template?.name}</span>.
           Sandboxes still using this template will block the delete — stop or
           delete them first.
         </div>

--- a/apps/console/src/components/templates/template-row-actions.tsx
+++ b/apps/console/src/components/templates/template-row-actions.tsx
@@ -68,9 +68,9 @@ export function TemplateRowActions({
               Rebuild
             </MenuItem>
           )}
-          <MenuItem onClick={() => copy(template.alias, "Alias")}>
+          <MenuItem onClick={() => copy(template.name, "Name")}>
             <CopyIcon className="size-4" weight="light" />
-            Copy alias
+            Copy name
           </MenuItem>
           <MenuItem onClick={() => copy(template.id, "ID")}>
             <CopyIcon className="size-4" weight="light" />

--- a/apps/console/src/components/templates/template-table-row.tsx
+++ b/apps/console/src/components/templates/template-table-row.tsx
@@ -16,7 +16,7 @@ export function TemplateTableRow({ template }: { template: TemplateResponse }) {
   const system = isSystemTemplate(template)
 
   const handleLaunch = (t: TemplateResponse) => {
-    router.push(`/sandboxes?from_template=${encodeURIComponent(t.alias)}`)
+    router.push(`/sandboxes?from_template=${encodeURIComponent(t.name)}`)
   }
 
   const handleRowClick = (e: React.MouseEvent) => {
@@ -38,7 +38,7 @@ export function TemplateTableRow({ template }: { template: TemplateResponse }) {
         <div className="flex flex-col gap-0.5">
           <div className="flex items-center gap-2">
             <span className="font-mono text-foreground/80">
-              {template.alias}
+              {template.name}
             </span>
             {system && <Badge variant="muted">System</Badge>}
           </div>

--- a/apps/console/src/hooks/use-templates.ts
+++ b/apps/console/src/hooks/use-templates.ts
@@ -79,7 +79,7 @@ export function useCreateTemplate() {
     mutationFn: (data: CreateTemplateRequest) => createTemplate(data),
     onSuccess: (created) => {
       queryClient.invalidateQueries({ queryKey: templateKeys.all })
-      addToast(`Template "${created.alias}" created — build queued`, "success")
+      addToast(`Template "${created.name}" created — build queued`, "success")
     },
     onError: (error) => {
       const message =

--- a/apps/console/src/lib/api/query-keys.ts
+++ b/apps/console/src/lib/api/query-keys.ts
@@ -35,7 +35,7 @@ export const auditLogKeys = {
 export const templateKeys = {
   all: ["templates"] as const,
   lists: () => [...templateKeys.all, "list"] as const,
-  list: (filters?: { alias_prefix?: string }) =>
+  list: (filters?: { name_prefix?: string }) =>
     [...templateKeys.lists(), filters ?? {}] as const,
   details: () => [...templateKeys.all, "detail"] as const,
   detail: (id: string) => [...templateKeys.details(), id] as const,

--- a/apps/console/src/lib/api/templates.ts
+++ b/apps/console/src/lib/api/templates.ts
@@ -7,10 +7,10 @@ import type {
 } from "./types"
 
 export async function listTemplates(params?: {
-  alias_prefix?: string
+  name_prefix?: string
 }): Promise<TemplateResponse[]> {
   const query = new URLSearchParams()
-  if (params?.alias_prefix) query.set("alias_prefix", params.alias_prefix)
+  if (params?.name_prefix) query.set("name_prefix", params.name_prefix)
   const suffix = query.toString()
   return apiClient<TemplateResponse[]>(
     `/templates${suffix ? `?${suffix}` : ""}`,

--- a/apps/console/src/lib/api/types.ts
+++ b/apps/console/src/lib/api/types.ts
@@ -30,7 +30,7 @@ export interface ResumeResponse {
 
 export interface CreateSandboxRequest {
   name: string
-  /** Template UUID or alias to boot from. */
+  /** Template UUID or name to boot from. */
   from_template?: string
   from_snapshot?: string
   timeout_seconds?: number
@@ -123,7 +123,7 @@ export interface BuildSpec {
 }
 
 export interface CreateTemplateRequest {
-  alias: string
+  name: string
   vcpu?: number
   memory_mib?: number
   disk_mib?: number
@@ -133,7 +133,7 @@ export interface CreateTemplateRequest {
 export interface CreateTemplateResponse {
   id: string
   team_id: string
-  alias: string
+  name: string
   status: Exclude<TemplateStatus, "pending">
   vcpu: number
   memory_mib: number
@@ -145,7 +145,7 @@ export interface CreateTemplateResponse {
 export interface TemplateResponse {
   id: string
   team_id: string
-  alias: string
+  name: string
   status: TemplateStatus
   vcpu: number
   memory_mib: number

--- a/apps/console/src/lib/templates/is-system-template.test.ts
+++ b/apps/console/src/lib/templates/is-system-template.test.ts
@@ -2,18 +2,18 @@ import { describe, expect, it } from "vitest"
 import { isSystemTemplate } from "./is-system-template"
 
 describe("isSystemTemplate", () => {
-  it("returns true for superserve/ prefixed aliases", () => {
-    expect(isSystemTemplate({ alias: "superserve/base" })).toBe(true)
-    expect(isSystemTemplate({ alias: "superserve/python-3.11" })).toBe(true)
+  it("returns true for superserve/ prefixed names", () => {
+    expect(isSystemTemplate({ name: "superserve/base" })).toBe(true)
+    expect(isSystemTemplate({ name: "superserve/python-3.11" })).toBe(true)
   })
 
-  it("returns false for user aliases", () => {
-    expect(isSystemTemplate({ alias: "my-template" })).toBe(false)
-    expect(isSystemTemplate({ alias: "team/custom" })).toBe(false)
-    expect(isSystemTemplate({ alias: "ss/base" })).toBe(false)
+  it("returns false for user names", () => {
+    expect(isSystemTemplate({ name: "my-template" })).toBe(false)
+    expect(isSystemTemplate({ name: "team/custom" })).toBe(false)
+    expect(isSystemTemplate({ name: "ss/base" })).toBe(false)
   })
 
   it("does not treat a trailing superserve/ as a system template", () => {
-    expect(isSystemTemplate({ alias: "foo/superserve/bar" })).toBe(false)
+    expect(isSystemTemplate({ name: "foo/superserve/bar" })).toBe(false)
   })
 })

--- a/apps/console/src/lib/templates/is-system-template.ts
+++ b/apps/console/src/lib/templates/is-system-template.ts
@@ -3,12 +3,12 @@ import type { TemplateResponse } from "../api/types"
 export const SYSTEM_TEMPLATE_PREFIX = "superserve/"
 
 /**
- * System (curated) templates are identified by the `superserve/` alias prefix.
+ * System (curated) templates are identified by the `superserve/` name prefix.
  * They're shared across all teams and can't be rebuilt or deleted from
  * the console.
  */
 export function isSystemTemplate(
-  template: Pick<TemplateResponse, "alias">,
+  template: Pick<TemplateResponse, "name">,
 ): boolean {
-  return template.alias.startsWith(SYSTEM_TEMPLATE_PREFIX)
+  return template.name.startsWith(SYSTEM_TEMPLATE_PREFIX)
 }

--- a/docs/sandbox/create.mdx
+++ b/docs/sandbox/create.mdx
@@ -70,14 +70,14 @@ See the [Sandbox reference](/sdk-reference/sandbox#sandbox-create) for every opt
 
 ## Create from a template
 
-Boot a sandbox from a system or team template via `fromTemplate` (alias, UUID, or `Template` instance).
+Boot a sandbox from a system or team template via `fromTemplate` (name, UUID, or `Template` instance).
 
 <CodeGroup>
 
 ```typescript TypeScript
 const sandbox = await Sandbox.create({
   name: "my-sandbox",
-  fromTemplate: "superserve/python-3.11",  // alias
+  fromTemplate: "superserve/python-3.11",  // name
 })
 ```
 

--- a/docs/sdk-reference/sandbox.mdx
+++ b/docs/sdk-reference/sandbox.mdx
@@ -67,7 +67,7 @@ sandbox = Sandbox.create(
 | Option | Type | Description |
 |---|---|---|
 | `name` | `string` | **Required.** Human-readable sandbox name. |
-| `fromTemplate` / `from_template` | `string \| Template` | Template alias, UUID, or `Template` instance to boot from. Defaults to `superserve/base`. |
+| `fromTemplate` / `from_template` | `string \| Template` | Template name, UUID, or `Template` instance to boot from. Defaults to `superserve/base`. |
 | `fromSnapshot` / `from_snapshot` | `string` | Snapshot UUID to boot from. |
 | `timeoutSeconds` / `timeout_seconds` | `number` | Max active lifetime before auto-pause. API-side upper bound (subject to change). |
 | `metadata` | `Record<string, string>` | String tags. |

--- a/docs/sdk-reference/template.mdx
+++ b/docs/sdk-reference/template.mdx
@@ -31,7 +31,7 @@ Register a new template and queue its first build. Returns as soon as the templa
 <CodeGroup>
 ```typescript TypeScript
 const template = await Template.create({
-  alias: "my-python-env",
+  name: "my-python-env",
   vcpu: 2,
   memoryMib: 2048,
   diskMib: 4096,
@@ -51,7 +51,7 @@ const template = await Template.create({
 from superserve import Template, RunStep, EnvStep, EnvStepValue, WorkdirStep, UserStep, UserStepValue
 
 template = Template.create(
-    alias="my-python-env",
+    name="my-python-env",
     vcpu=2,
     memory_mib=2048,
     disk_mib=4096,
@@ -72,7 +72,7 @@ template = Template.create(
 
 | Option | Type | Description |
 |---|---|---|
-| `alias` | `string` | **Required.** Team-scoped identifier. Must not start with `superserve/`. |
+| `name` | `string` | **Required.** Team-scoped identifier. Must not start with `superserve/`. Names are unique per team among non-deleted templates and are released for reuse the moment a template is deleted. |
 | `from` / `from_` | `string` | **Required.** OCI base image (e.g. `python:3.11`). See [BuildSpec](/templates/build-spec#from-base-image). |
 | `vcpu` | `number` | 1-4. Default `1`. |
 | `memoryMib` / `memory_mib` | `number` | 256-4096. Default `1024`. |
@@ -88,19 +88,15 @@ Throws `SandboxError` if the API response is missing `build_id`.
 
 ### `Template.connect`
 
-Load an existing template by alias or UUID. The backend resolves either form.
+Load an existing template by UUID.
 
 <CodeGroup>
 ```typescript TypeScript
-const template = await Template.connect("my-python-env")
-// or by UUID
-const template2 = await Template.connect("7a3f2b8c-1234-...")
+const template = await Template.connect("7a3f2b8c-1234-...")
 ```
 
 ```python Python
-template = Template.connect("my-python-env")
-# or by UUID
-template2 = Template.connect("7a3f2b8c-1234-...")
+template = Template.connect("7a3f2b8c-1234-...")
 ```
 </CodeGroup>
 
@@ -111,12 +107,12 @@ List all templates visible to the authenticated team (includes system templates)
 <CodeGroup>
 ```typescript TypeScript
 const all = await Template.list()
-const mine = await Template.list({ aliasPrefix: "my-" })
+const mine = await Template.list({ namePrefix: "my-" })
 ```
 
 ```python Python
 all_templates = Template.list()
-mine = Template.list(alias_prefix="my-")
+mine = Template.list(name_prefix="my-")
 ```
 </CodeGroup>
 
@@ -124,19 +120,19 @@ Returns an array of [`TemplateInfo`](#templateinfo).
 
 ### `Template.deleteById` / `Template.delete_by_id`
 
-Delete a template by alias or UUID without instantiating it. Idempotent on `404`.
+Delete a template by UUID without instantiating it. Idempotent on `404`.
 
 <CodeGroup>
 ```typescript TypeScript
-await Template.deleteById("my-python-env")
+await Template.deleteById("7a3f2b8c-1234-...")
 ```
 
 ```python Python
-Template.delete_by_id("my-python-env")
+Template.delete_by_id("7a3f2b8c-1234-...")
 ```
 </CodeGroup>
 
-Throws `ConflictError` if any non-destroyed sandbox still references the template.
+Throws `ConflictError` if any non-destroyed sandbox still references the template. The template's name is released for reuse as soon as the call succeeds.
 
 ## Methods on `template`
 
@@ -309,7 +305,7 @@ All properties are read-only snapshots taken at construction. Call `getInfo()` /
 | Property | Type | Description |
 |---|---|---|
 | `id` | `string` | Template UUID. |
-| `alias` | `string` | Team-scoped identifier. |
+| `name` | `string` | Team-scoped identifier. |
 | `teamId` / `team_id` | `string` | Owning team UUID. |
 | `status` | `TemplateStatus` | Status at construction time. |
 | `vcpu` | `number` | vCPU count the template boots with. |
@@ -378,7 +374,7 @@ class TemplateBuildStatus(str, Enum):
 ```typescript TypeScript
 interface TemplateInfo {
   id: string
-  alias: string
+  name: string
   teamId: string
   status: TemplateStatus
   vcpu: number
@@ -398,7 +394,7 @@ from pydantic import BaseModel
 
 class TemplateInfo(BaseModel):
     id: str
-    alias: str
+    name: str
     team_id: str
     status: TemplateStatus
     vcpu: int
@@ -548,7 +544,7 @@ GET and DELETE requests (including `Template.list`, `Template.connect`, `getInfo
 Template methods commonly raise:
 
 - `AuthenticationError` - missing or invalid API key
-- `ValidationError` - bad request body (invalid alias, unsupported base image, steps with multiple keys)
+- `ValidationError` - bad request body (invalid name, unsupported base image, steps with multiple keys)
 - `NotFoundError` - template or build doesn't exist (except `delete` / `deleteById` / `cancelBuild`, which swallow 404)
 - `ConflictError` - template has dependent sandboxes (on delete) or build was cancelled (on `waitUntilReady`)
 - `BuildError` - build transitioned to `failed` (from `waitUntilReady` only)

--- a/docs/templates/create.mdx
+++ b/docs/templates/create.mdx
@@ -15,7 +15,7 @@ Pass a base image via `from` and (optionally) a list of build steps that run ins
 import { Template } from "@superserve/sdk"
 
 const template = await Template.create({
-  alias: "my-python-env",
+  name: "my-python-env",
   vcpu: 2,
   memoryMib: 2048,
   from: "python:3.11",
@@ -32,7 +32,7 @@ from superserve import Template
 from superserve import RunStep, EnvStep, EnvStepValue, WorkdirStep
 
 template = Template.create(
-    alias="my-python-env",
+    name="my-python-env",
     vcpu=2,
     memory_mib=2048,
     from_="python:3.11",
@@ -77,7 +77,7 @@ On success, `waitUntilReady` returns the refreshed `TemplateInfo` with `status =
 
 ## Create a sandbox from the template
 
-Once ready, create sandboxes by passing the `Template` instance, the alias, or the UUID.
+Once ready, create sandboxes by passing the `Template` instance, the name, or the UUID.
 
 <CodeGroup>
 
@@ -86,7 +86,7 @@ import { Sandbox, Template } from "@superserve/sdk"
 
 // Create the template first (see the section above)
 const template = await Template.create({
-  alias: "my-python-env",
+  name: "my-python-env",
   from: "python:3.11",
 })
 await template.waitUntilReady()
@@ -97,7 +97,7 @@ const sandbox = await Sandbox.create({
   fromTemplate: template,
 })
 
-// Option 2: pass the alias
+// Option 2: pass the name
 const sandbox2 = await Sandbox.create({
   name: "run-2",
   fromTemplate: "my-python-env",
@@ -115,7 +115,7 @@ from superserve import Sandbox, Template
 
 # Create the template first (see the section above)
 template = Template.create(
-    alias="my-python-env",
+    name="my-python-env",
     from_="python:3.11",
 )
 template.wait_until_ready()
@@ -126,7 +126,7 @@ sandbox = Sandbox.create(
     from_template=template,
 )
 
-# Option 2: pass the alias
+# Option 2: pass the name
 sandbox2 = Sandbox.create(
     name="run-2",
     from_template="my-python-env",

--- a/docs/templates/lifecycle.mdx
+++ b/docs/templates/lifecycle.mdx
@@ -69,20 +69,20 @@ template.cancel_build(build.id)
 ```typescript TypeScript
 await template.delete()
 
-// Or by id / alias
-await Template.deleteById("my-python-env")
+// Or by UUID
+await Template.deleteById("7a3f2b8c-1234-...")
 ```
 
 ```python Python
 template.delete()
 
-# Or by id / alias
-Template.delete_by_id("my-python-env")
+# Or by UUID
+Template.delete_by_id("7a3f2b8c-1234-...")
 ```
 
 </CodeGroup>
 
-Both calls are idempotent on `404`. If any non-destroyed sandbox still references the template, the call raises `ConflictError`; destroy those sandboxes first.
+Both calls are idempotent on `404`. If any non-destroyed sandbox still references the template, the call raises `ConflictError`; destroy those sandboxes first. Once the delete succeeds the template's `name` is released for reuse — you can immediately create a new template with the same name.
 
 ## Related
 

--- a/docs/templates/overview.mdx
+++ b/docs/templates/overview.mdx
@@ -9,9 +9,9 @@ Every sandbox is created from a template. If you don't specify one, Superserve d
 
 ## System templates
 
-Curated by Superserve, available to every team. Identified by the `superserve/` alias prefix.
+Curated by Superserve, available to every team. Identified by the `superserve/` name prefix.
 
-| Alias | Base | Notes |
+| Name | Base | Notes |
 |---|---|---|
 | `superserve/base` | Ubuntu 24.04 | Python 3.12, Node.js 22, git, curl, build-essential. Default when `fromTemplate` is omitted. |
 | `superserve/python-3.11` | Python 3.11 | Python-focused image with common scientific libraries. |
@@ -19,13 +19,13 @@ Curated by Superserve, available to every team. Identified by the `superserve/` 
 
 ## Team templates
 
-Team-owned templates let you bake in team-specific dependencies (e.g. `my-python-env` with scientific libs pre-installed). They're created via `Template.create()` and referenced by alias.
+Team-owned templates let you bake in team-specific dependencies (e.g. `my-python-env` with scientific libs pre-installed). They're created via `Template.create()` and referenced by name.
 
-Team template aliases **cannot** start with `superserve/`; that prefix is reserved.
+Team template names **cannot** start with `superserve/`; that prefix is reserved. Names are unique per team among non-deleted templates and are released for reuse the moment a template is deleted.
 
-## Aliases vs UUIDs
+## Names vs UUIDs
 
-Both SDKs and the API accept **either** the template's alias (`my-python-env`) or its UUID. Aliases are more readable; UUIDs are stable if an alias gets renamed or deleted.
+When booting a sandbox, `Sandbox.create({ fromTemplate })` accepts either the template's name (`my-python-env`) or its UUID. Names are more readable; UUIDs are stable across rename/delete.
 
 ## Related
 

--- a/packages/python-sdk/src/superserve/async_sandbox.py
+++ b/packages/python-sdk/src/superserve/async_sandbox.py
@@ -66,9 +66,9 @@ class AsyncSandbox:
             if isinstance(from_template, str):
                 body["from_template"] = from_template
             else:
-                # Template / AsyncTemplate instance — extract alias (fallback to id)
+                # Template / AsyncTemplate instance — extract name (fallback to id)
                 body["from_template"] = (
-                    getattr(from_template, "alias", None) or from_template.id
+                    getattr(from_template, "name", None) or from_template.id
                 )
         if from_snapshot is not None:
             body["from_snapshot"] = from_snapshot

--- a/packages/python-sdk/src/superserve/async_template.py
+++ b/packages/python-sdk/src/superserve/async_template.py
@@ -7,7 +7,7 @@ from superserve import AsyncTemplate, AsyncSandbox
 
 async def main() -> None:
     template = await AsyncTemplate.create(
-        alias="my-python-env",
+        name="my-python-env",
         from_="python:3.11",
         steps=[{"run": "pip install numpy"}],
     )
@@ -47,7 +47,7 @@ class AsyncTemplate:
 
     def __init__(self, info: TemplateInfo, config: ResolvedConfig) -> None:
         self.id: str = info.id
-        self.alias: str = info.alias
+        self.name: str = info.name
         self.team_id: str = info.team_id
         self.status: TemplateStatus = info.status
         self.vcpu: int = info.vcpu
@@ -68,7 +68,7 @@ class AsyncTemplate:
     async def create(
         cls,
         *,
-        alias: str,
+        name: str,
         from_: str,
         vcpu: int | None = None,
         memory_mib: int | None = None,
@@ -90,7 +90,7 @@ class AsyncTemplate:
         if ready_cmd is not None:
             build_spec["ready_cmd"] = ready_cmd
 
-        body: dict[str, Any] = {"alias": alias, "build_spec": build_spec}
+        body: dict[str, Any] = {"name": name, "build_spec": build_spec}
         if vcpu is not None:
             body["vcpu"] = vcpu
         if memory_mib is not None:
@@ -114,16 +114,16 @@ class AsyncTemplate:
     @classmethod
     async def connect(
         cls,
-        alias_or_id: str,
+        name_or_id: str,
         *,
         api_key: str | None = None,
         base_url: str | None = None,
     ) -> AsyncTemplate:
-        """Connect to an existing template by alias or ID."""
+        """Connect to an existing template by name or ID."""
         config = resolve_config(api_key=api_key, base_url=base_url)
         raw = await async_api_request(
             "GET",
-            f"{config.base_url}/templates/{alias_or_id}",
+            f"{config.base_url}/templates/{name_or_id}",
             headers={"X-API-Key": config.api_key},
         )
         return cls(to_template_info(raw), config)
@@ -132,15 +132,15 @@ class AsyncTemplate:
     async def list(
         cls,
         *,
-        alias_prefix: str | None = None,
+        name_prefix: str | None = None,
         api_key: str | None = None,
         base_url: str | None = None,
     ) -> builtins.list[TemplateInfo]:
         """List all templates visible to the authenticated team."""
         config = resolve_config(api_key=api_key, base_url=base_url)
         url = f"{config.base_url}/templates"
-        if alias_prefix:
-            url += "?" + urlencode({"alias_prefix": alias_prefix})
+        if name_prefix:
+            url += "?" + urlencode({"name_prefix": name_prefix})
         raw = await async_api_request(
             "GET",
             url,
@@ -151,17 +151,17 @@ class AsyncTemplate:
     @classmethod
     async def delete_by_id(
         cls,
-        alias_or_id: str,
+        name_or_id: str,
         *,
         api_key: str | None = None,
         base_url: str | None = None,
     ) -> None:
-        """Delete a template by alias or ID. Idempotent on 404."""
+        """Delete a template by name or ID. Idempotent on 404."""
         config = resolve_config(api_key=api_key, base_url=base_url)
         try:
             await async_api_request(
                 "DELETE",
-                f"{config.base_url}/templates/{alias_or_id}",
+                f"{config.base_url}/templates/{name_or_id}",
                 headers={"X-API-Key": config.api_key},
             )
         except NotFoundError:
@@ -251,7 +251,7 @@ class AsyncTemplate:
         recent = await self.list_builds(limit=1)
         if not recent:
             raise SandboxError(
-                f"Template {self.alias} has no builds — call rebuild() first"
+                f"Template {self.name} has no builds — call rebuild() first"
             )
         return recent[0].id
 
@@ -375,6 +375,6 @@ class AsyncTemplate:
 
     def __repr__(self) -> str:
         return (
-            f"AsyncTemplate(id={self.id!r}, alias={self.alias!r}, "
+            f"AsyncTemplate(id={self.id!r}, name={self.name!r}, "
             f"status={self.status.value!r})"
         )

--- a/packages/python-sdk/src/superserve/sandbox.py
+++ b/packages/python-sdk/src/superserve/sandbox.py
@@ -66,9 +66,9 @@ class Sandbox:
             if isinstance(from_template, str):
                 body["from_template"] = from_template
             else:
-                # Template / AsyncTemplate instance — extract alias (fallback to id)
+                # Template / AsyncTemplate instance — extract name (fallback to id)
                 body["from_template"] = (
-                    getattr(from_template, "alias", None) or from_template.id
+                    getattr(from_template, "name", None) or from_template.id
                 )
         if from_snapshot is not None:
             body["from_snapshot"] = from_snapshot

--- a/packages/python-sdk/src/superserve/template.py
+++ b/packages/python-sdk/src/superserve/template.py
@@ -4,7 +4,7 @@
 from superserve import Template, Sandbox
 
 template = Template.create(
-    alias="my-python-env",
+    name="my-python-env",
     from_="python:3.11",
     steps=[{"run": "pip install numpy"}],
 )
@@ -41,7 +41,7 @@ class Template:
 
     def __init__(self, info: TemplateInfo, config: ResolvedConfig) -> None:
         self.id: str = info.id
-        self.alias: str = info.alias
+        self.name: str = info.name
         self.team_id: str = info.team_id
         self.status: TemplateStatus = info.status
         self.vcpu: int = info.vcpu
@@ -62,7 +62,7 @@ class Template:
     def create(
         cls,
         *,
-        alias: str,
+        name: str,
         from_: str,
         vcpu: int | None = None,
         memory_mib: int | None = None,
@@ -84,7 +84,7 @@ class Template:
         if ready_cmd is not None:
             build_spec["ready_cmd"] = ready_cmd
 
-        body: dict[str, Any] = {"alias": alias, "build_spec": build_spec}
+        body: dict[str, Any] = {"name": name, "build_spec": build_spec}
         if vcpu is not None:
             body["vcpu"] = vcpu
         if memory_mib is not None:
@@ -108,16 +108,16 @@ class Template:
     @classmethod
     def connect(
         cls,
-        alias_or_id: str,
+        name_or_id: str,
         *,
         api_key: str | None = None,
         base_url: str | None = None,
     ) -> Template:
-        """Connect to an existing template by alias or ID."""
+        """Connect to an existing template by name or ID."""
         config = resolve_config(api_key=api_key, base_url=base_url)
         raw = api_request(
             "GET",
-            f"{config.base_url}/templates/{alias_or_id}",
+            f"{config.base_url}/templates/{name_or_id}",
             headers={"X-API-Key": config.api_key},
         )
         return cls(to_template_info(raw), config)
@@ -126,15 +126,15 @@ class Template:
     def list(
         cls,
         *,
-        alias_prefix: str | None = None,
+        name_prefix: str | None = None,
         api_key: str | None = None,
         base_url: str | None = None,
     ) -> builtins.list[TemplateInfo]:
         """List all templates visible to the authenticated team."""
         config = resolve_config(api_key=api_key, base_url=base_url)
         url = f"{config.base_url}/templates"
-        if alias_prefix:
-            url += "?" + urlencode({"alias_prefix": alias_prefix})
+        if name_prefix:
+            url += "?" + urlencode({"name_prefix": name_prefix})
         raw = api_request(
             "GET",
             url,
@@ -145,17 +145,17 @@ class Template:
     @classmethod
     def delete_by_id(
         cls,
-        alias_or_id: str,
+        name_or_id: str,
         *,
         api_key: str | None = None,
         base_url: str | None = None,
     ) -> None:
-        """Delete a template by alias or ID. Idempotent on 404."""
+        """Delete a template by name or ID. Idempotent on 404."""
         config = resolve_config(api_key=api_key, base_url=base_url)
         try:
             api_request(
                 "DELETE",
-                f"{config.base_url}/templates/{alias_or_id}",
+                f"{config.base_url}/templates/{name_or_id}",
                 headers={"X-API-Key": config.api_key},
             )
         except NotFoundError:
@@ -245,7 +245,7 @@ class Template:
         recent = self.list_builds(limit=1)
         if not recent:
             raise SandboxError(
-                f"Template {self.alias} has no builds — call rebuild() first"
+                f"Template {self.name} has no builds — call rebuild() first"
             )
         return recent[0].id
 
@@ -358,6 +358,6 @@ class Template:
 
     def __repr__(self) -> str:
         return (
-            f"Template(id={self.id!r}, alias={self.alias!r}, "
+            f"Template(id={self.id!r}, name={self.name!r}, "
             f"status={self.status.value!r})"
         )

--- a/packages/python-sdk/src/superserve/types.py
+++ b/packages/python-sdk/src/superserve/types.py
@@ -106,7 +106,7 @@ class BuildLogStream(str, Enum):
 
 class TemplateInfo(BaseModel):
     id: str
-    alias: str
+    name: str
     team_id: str
     status: TemplateStatus
     vcpu: int = 0
@@ -179,8 +179,8 @@ def to_template_info(
 ) -> TemplateInfo:
     if not raw.get("id"):
         raise SandboxError("Invalid API response: missing template id")
-    if not raw.get("alias"):
-        raise SandboxError("Invalid API response: missing template alias")
+    if not raw.get("name"):
+        raise SandboxError("Invalid API response: missing template name")
     if not raw.get("status"):
         raise SandboxError("Invalid API response: missing template status")
     if not raw.get("team_id"):
@@ -190,7 +190,7 @@ def to_template_info(
 
     return TemplateInfo(
         id=raw["id"],
-        alias=raw["alias"],
+        name=raw["name"],
         team_id=raw["team_id"],
         status=TemplateStatus(raw["status"]),
         vcpu=raw.get("vcpu", 0),

--- a/packages/python-sdk/tests/test_async.py
+++ b/packages/python-sdk/tests/test_async.py
@@ -158,7 +158,7 @@ class TestAsyncCreateFromTemplate:
                     json={
                         "id": "t-1",
                         "team_id": "team-1",
-                        "alias": "my-env",
+                        "name": "my-env",
                         "status": "building",
                         "vcpu": 1,
                         "memory_mib": 1024,
@@ -168,7 +168,7 @@ class TestAsyncCreateFromTemplate:
                     },
                 )
             )
-            tpl = await AsyncTemplate.create(alias="my-env", from_="python:3.11")
+            tpl = await AsyncTemplate.create(name="my-env", from_="python:3.11")
             route = router.post(f"{API}/sandboxes").mock(
                 return_value=httpx.Response(200, json=_raw())
             )

--- a/packages/python-sdk/tests/test_async_template.py
+++ b/packages/python-sdk/tests/test_async_template.py
@@ -22,7 +22,7 @@ def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
 BASE = {
     "id": "t-1",
     "team_id": "team-1",
-    "alias": "my-env",
+    "name": "my-env",
     "status": "building",
     "vcpu": 1,
     "memory_mib": 1024,
@@ -56,7 +56,7 @@ class TestAsyncCreate:
                 return_value=httpx.Response(202, json={**BASE, "build_id": "b-1"})
             )
             t = await AsyncTemplate.create(
-                alias="my-env",
+                name="my-env",
                 vcpu=2,
                 memory_mib=2048,
                 disk_mib=4096,
@@ -76,7 +76,7 @@ class TestAsyncCreate:
                 return_value=httpx.Response(202, json=BASE)
             )
             with pytest.raises(Exception, match="missing build_id"):
-                await AsyncTemplate.create(alias="x", from_="python:3.11")
+                await AsyncTemplate.create(name="x", from_="python:3.11")
 
 
 class TestAsyncConnect:
@@ -86,7 +86,7 @@ class TestAsyncConnect:
                 return_value=httpx.Response(200, json=BASE)
             )
             t = await AsyncTemplate.connect("my-env")
-            assert t.alias == "my-env"
+            assert t.name == "my-env"
 
 
 class TestAsyncList:
@@ -97,14 +97,14 @@ class TestAsyncList:
             )
             lst = await AsyncTemplate.list()
             assert len(lst) == 1
-            assert lst[0].alias == "my-env"
+            assert lst[0].name == "my-env"
 
-    async def test_with_alias_prefix(self) -> None:
+    async def test_with_name_prefix(self) -> None:
         with respx.mock() as router:
-            route = router.get(f"{API}/templates", params={"alias_prefix": "my-"}).mock(
+            route = router.get(f"{API}/templates", params={"name_prefix": "my-"}).mock(
                 return_value=httpx.Response(200, json=[])
             )
-            await AsyncTemplate.list(alias_prefix="my-")
+            await AsyncTemplate.list(name_prefix="my-")
             assert route.call_count == 1
 
 
@@ -131,7 +131,7 @@ class TestAsyncInstanceMethods:
         router.post(f"{API}/templates").mock(
             return_value=httpx.Response(202, json={**BASE, "build_id": "b-1"})
         )
-        return await AsyncTemplate.create(alias="my-env", from_="python:3.11")
+        return await AsyncTemplate.create(name="my-env", from_="python:3.11")
 
     async def test_get_info(self) -> None:
         with respx.mock() as router:
@@ -193,7 +193,7 @@ class TestAsyncStreamBuildLogs:
             router.post(f"{API}/templates").mock(
                 return_value=httpx.Response(202, json={**BASE, "build_id": "b-1"})
             )
-            t = await AsyncTemplate.create(alias="my-env", from_="python:3.11")
+            t = await AsyncTemplate.create(name="my-env", from_="python:3.11")
             sse = _sse_text(
                 [
                     '{"timestamp":"2026-01-01T00:00:00Z","stream":"stdout","text":"hello"}',
@@ -222,7 +222,7 @@ class TestAsyncWaitUntilReady:
             router.post(f"{API}/templates").mock(
                 return_value=httpx.Response(202, json={**BASE, "build_id": "b-1"})
             )
-            t = await AsyncTemplate.create(alias="my-env", from_="python:3.11")
+            t = await AsyncTemplate.create(name="my-env", from_="python:3.11")
             router.get(f"{API}/templates/t-1/builds/b-1").mock(
                 return_value=httpx.Response(
                     200, json={**BUILD_BASE, "status": "ready"}
@@ -244,7 +244,7 @@ class TestAsyncWaitUntilReady:
             router.post(f"{API}/templates").mock(
                 return_value=httpx.Response(202, json={**BASE, "build_id": "b-1"})
             )
-            t = await AsyncTemplate.create(alias="my-env", from_="python:3.11")
+            t = await AsyncTemplate.create(name="my-env", from_="python:3.11")
             sse = _sse_text(
                 [
                     '{"timestamp":"2026-01-01T00:00:01Z","stream":"system","text":"done","finished":true,"status":"ready"}',
@@ -273,7 +273,7 @@ class TestAsyncWaitUntilReady:
             router.post(f"{API}/templates").mock(
                 return_value=httpx.Response(202, json={**BASE, "build_id": "b-1"})
             )
-            t = await AsyncTemplate.create(alias="my-env", from_="python:3.11")
+            t = await AsyncTemplate.create(name="my-env", from_="python:3.11")
             router.get(f"{API}/templates/t-1/builds/b-1").mock(
                 return_value=httpx.Response(
                     200,

--- a/packages/python-sdk/tests/test_build_logs.py
+++ b/packages/python-sdk/tests/test_build_logs.py
@@ -20,7 +20,7 @@ def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
 BASE = {
     "id": "t-1",
     "team_id": "team-1",
-    "alias": "my-env",
+    "name": "my-env",
     "status": "building",
     "vcpu": 1,
     "memory_mib": 1024,
@@ -40,7 +40,7 @@ def _make_template(router: respx.MockRouter) -> Template:
     router.post(f"{API}/templates").mock(
         return_value=httpx.Response(202, json={**BASE, "build_id": "b-1"})
     )
-    return Template.create(alias="my-env", from_="python:3.11")
+    return Template.create(name="my-env", from_="python:3.11")
 
 
 def _sse_text(events: list[str]) -> str:

--- a/packages/python-sdk/tests/test_sandbox.py
+++ b/packages/python-sdk/tests/test_sandbox.py
@@ -273,7 +273,7 @@ class TestCreateFromTemplate:
                     json={
                         "id": "t-1",
                         "team_id": "team-1",
-                        "alias": "my-env",
+                        "name": "my-env",
                         "status": "building",
                         "vcpu": 1,
                         "memory_mib": 1024,
@@ -283,7 +283,7 @@ class TestCreateFromTemplate:
                     },
                 )
             )
-            tpl = Template.create(alias="my-env", from_="python:3.11")
+            tpl = Template.create(name="my-env", from_="python:3.11")
             route = router.post(f"{API}/sandboxes").mock(
                 return_value=httpx.Response(200, json=_raw())
             )

--- a/packages/python-sdk/tests/test_template.py
+++ b/packages/python-sdk/tests/test_template.py
@@ -19,7 +19,7 @@ def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
 BASE = {
     "id": "t-1",
     "team_id": "team-1",
-    "alias": "my-env",
+    "name": "my-env",
     "status": "building",
     "vcpu": 1,
     "memory_mib": 1024,
@@ -35,7 +35,7 @@ class TestCreate:
                 return_value=httpx.Response(202, json={**BASE, "build_id": "b-1"})
             )
             t = Template.create(
-                alias="my-env",
+                name="my-env",
                 vcpu=2,
                 memory_mib=2048,
                 disk_mib=4096,
@@ -55,7 +55,7 @@ class TestCreate:
                 return_value=httpx.Response(202, json=BASE)
             )
             with pytest.raises(Exception, match="missing build_id"):
-                Template.create(alias="x", from_="python:3.11")
+                Template.create(name="x", from_="python:3.11")
 
 
 class TestConnect:
@@ -65,7 +65,7 @@ class TestConnect:
                 return_value=httpx.Response(200, json=BASE)
             )
             t = Template.connect("my-env")
-            assert t.alias == "my-env"
+            assert t.name == "my-env"
 
 
 class TestList:
@@ -76,14 +76,14 @@ class TestList:
             )
             lst = Template.list()
             assert len(lst) == 1
-            assert lst[0].alias == "my-env"
+            assert lst[0].name == "my-env"
 
-    def test_with_alias_prefix(self) -> None:
+    def test_with_name_prefix(self) -> None:
         with respx.mock() as router:
-            route = router.get(f"{API}/templates", params={"alias_prefix": "my-"}).mock(
+            route = router.get(f"{API}/templates", params={"name_prefix": "my-"}).mock(
                 return_value=httpx.Response(200, json=[])
             )
-            Template.list(alias_prefix="my-")
+            Template.list(name_prefix="my-")
             assert route.call_count == 1
 
 
@@ -110,7 +110,7 @@ class TestInstanceMethods:
         router.post(f"{API}/templates").mock(
             return_value=httpx.Response(202, json={**BASE, "build_id": "b-1"})
         )
-        return Template.create(alias="my-env", from_="python:3.11")
+        return Template.create(name="my-env", from_="python:3.11")
 
     def test_get_info(self) -> None:
         with respx.mock() as router:

--- a/packages/python-sdk/tests/test_types.py
+++ b/packages/python-sdk/tests/test_types.py
@@ -135,7 +135,7 @@ class TestToTemplateInfo:
             {
                 "id": "t-1",
                 "team_id": "team-1",
-                "alias": "my-env",
+                "name": "my-env",
                 "status": "ready",
                 "vcpu": 2,
                 "memory_mib": 2048,
@@ -146,7 +146,7 @@ class TestToTemplateInfo:
             }
         )
         assert info.id == "t-1"
-        assert info.alias == "my-env"
+        assert info.name == "my-env"
         assert info.status == TemplateStatus.READY
         assert info.vcpu == 2
         assert info.memory_mib == 2048
@@ -160,7 +160,7 @@ class TestToTemplateInfo:
             {
                 "id": "t-1",
                 "team_id": "team-1",
-                "alias": "my-env",
+                "name": "my-env",
                 "status": "building",
                 "vcpu": 1,
                 "memory_mib": 1024,

--- a/packages/sdk/src/Sandbox.ts
+++ b/packages/sdk/src/Sandbox.ts
@@ -100,7 +100,7 @@ export class Sandbox {
       body.from_template =
         typeof options.fromTemplate === "string"
           ? options.fromTemplate
-          : (options.fromTemplate.alias ?? options.fromTemplate.id)
+          : (options.fromTemplate.name ?? options.fromTemplate.id)
     }
     if (options.fromSnapshot !== undefined) {
       body.from_snapshot = options.fromSnapshot

--- a/packages/sdk/src/Template.ts
+++ b/packages/sdk/src/Template.ts
@@ -5,7 +5,7 @@
  * import { Template, Sandbox } from "@superserve/sdk"
  *
  * const template = await Template.create({
- *   alias: "my-python-env",
+ *   name: "my-python-env",
  *   from: "python:3.11",
  *   steps: [{ run: "pip install numpy" }],
  * })
@@ -46,7 +46,7 @@ import {
 
 export class Template {
   readonly id: string
-  readonly alias: string
+  readonly name: string
   readonly teamId: string
   readonly status: TemplateStatus
   readonly vcpu: number
@@ -63,7 +63,7 @@ export class Template {
   /** @internal — use `Template.create()` / `Template.connect()` instead. */
   private constructor(info: TemplateInfo, config: ResolvedConfig) {
     this.id = info.id
-    this.alias = info.alias
+    this.name = info.name
     this.teamId = info.teamId
     this.status = info.status
     this.vcpu = info.vcpu
@@ -91,7 +91,7 @@ export class Template {
     if (options.readyCmd !== undefined) buildSpec.ready_cmd = options.readyCmd
 
     const body: Record<string, unknown> = {
-      alias: options.alias,
+      name: options.name,
       build_spec: buildSpec,
     }
     if (options.vcpu !== undefined) body.vcpu = options.vcpu
@@ -115,13 +115,13 @@ export class Template {
   }
 
   static async connect(
-    aliasOrId: string,
+    nameOrId: string,
     options: ConnectionOptions = {},
   ): Promise<Template> {
     const config = resolveConfig(options)
     const raw = await request<ApiTemplateResponse>({
       method: "GET",
-      url: `${config.baseUrl}/templates/${encodeURIComponent(aliasOrId)}`,
+      url: `${config.baseUrl}/templates/${encodeURIComponent(nameOrId)}`,
       headers: { "X-API-Key": config.apiKey },
       signal: options.signal,
     })
@@ -133,8 +133,8 @@ export class Template {
   ): Promise<TemplateInfo[]> {
     const config = resolveConfig(options)
     let url = `${config.baseUrl}/templates`
-    if (options.aliasPrefix) {
-      const qs = new URLSearchParams({ alias_prefix: options.aliasPrefix })
+    if (options.namePrefix) {
+      const qs = new URLSearchParams({ name_prefix: options.namePrefix })
       url += `?${qs.toString()}`
     }
 
@@ -148,14 +148,14 @@ export class Template {
   }
 
   static async deleteById(
-    aliasOrId: string,
+    nameOrId: string,
     options: ConnectionOptions = {},
   ): Promise<void> {
     const config = resolveConfig(options)
     try {
       await requestVoid({
         method: "DELETE",
-        url: `${config.baseUrl}/templates/${encodeURIComponent(aliasOrId)}`,
+        url: `${config.baseUrl}/templates/${encodeURIComponent(nameOrId)}`,
         headers: { "X-API-Key": config.apiKey },
         signal: options.signal,
       })
@@ -247,7 +247,7 @@ export class Template {
     const recent = await this.listBuilds({ limit: 1 })
     if (recent.length === 0) {
       throw new SandboxError(
-        `Template ${this.alias} has no builds — call rebuild() first`,
+        `Template ${this.name} has no builds — call rebuild() first`,
       )
     }
     return recent[0].id

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -42,8 +42,8 @@ export interface ConnectionOptions {
 
 export interface SandboxCreateOptions extends ConnectionOptions {
   name: string
-  /** Template alias, UUID, or Template instance. */
-  fromTemplate?: string | { alias?: string; id: string }
+  /** Template name, UUID, or Template instance. */
+  fromTemplate?: string | { name?: string; id: string }
   /** Snapshot UUID. */
   fromSnapshot?: string
   timeoutSeconds?: number
@@ -183,7 +183,7 @@ export type BuildLogStream = "stdout" | "stderr" | "system"
 
 export interface TemplateInfo {
   id: string
-  alias: string
+  name: string
   teamId: string
   status: TemplateStatus
   vcpu: number
@@ -223,7 +223,7 @@ export type BuildStep =
   | { user: { name: string; sudo?: boolean } }
 
 export interface TemplateCreateOptions extends ConnectionOptions {
-  alias: string
+  name: string
   vcpu?: number
   memoryMib?: number
   diskMib?: number
@@ -234,7 +234,7 @@ export interface TemplateCreateOptions extends ConnectionOptions {
 }
 
 export interface TemplateListOptions extends ConnectionOptions {
-  aliasPrefix?: string
+  namePrefix?: string
 }
 
 export interface TemplateBuildsListOptions extends ConnectionOptions {
@@ -261,7 +261,7 @@ export interface WaitUntilReadyOptions {
 export interface ApiTemplateResponse {
   id?: string
   team_id?: string
-  alias?: string
+  name?: string
   status?: string
   vcpu?: number
   memory_mib?: number
@@ -310,8 +310,8 @@ export function toTemplateInfo(
   if (!raw.id) {
     throw new SandboxError("Invalid API response: missing template id")
   }
-  if (!raw.alias) {
-    throw new SandboxError("Invalid API response: missing template alias")
+  if (!raw.name) {
+    throw new SandboxError("Invalid API response: missing template name")
   }
   if (!raw.status) {
     throw new SandboxError("Invalid API response: missing template status")
@@ -325,7 +325,7 @@ export function toTemplateInfo(
 
   return {
     id: raw.id,
-    alias: raw.alias,
+    name: raw.name,
     teamId: raw.team_id,
     status: raw.status as TemplateStatus,
     vcpu: raw.vcpu ?? 0,

--- a/packages/sdk/tests/build-logs.test.ts
+++ b/packages/sdk/tests/build-logs.test.ts
@@ -22,7 +22,7 @@ function sseStream(lines: string[]): ReadableStream {
 const baseTemplate = {
   id: "t-1",
   team_id: "team-1",
-  alias: "my-env",
+  name: "my-env",
   status: "building",
   vcpu: 1,
   memory_mib: 1024,
@@ -38,7 +38,7 @@ async function makeTemplate() {
   )
   const t = await Template.create({
     ...commonOpts,
-    alias: "my-env",
+    name: "my-env",
     from: "python:3.11",
   })
   vi.unstubAllGlobals()

--- a/packages/sdk/tests/sandbox.test.ts
+++ b/packages/sdk/tests/sandbox.test.ts
@@ -245,14 +245,14 @@ describe("Sandbox.create fromTemplate / fromSnapshot", () => {
     expect(body.from_template).toBe("superserve/python-3.11")
   })
 
-  it("extracts alias from Template-like instance", async () => {
+  it("extracts name from Template-like instance", async () => {
     const mock = vi.fn(async () => jsonResponse(baseSandbox))
     vi.stubGlobal("fetch", mock)
 
     await Sandbox.create({
       ...commonOpts,
       name: "my-sandbox",
-      fromTemplate: { alias: "my-env", id: "t-1" },
+      fromTemplate: { name: "my-env", id: "t-1" },
     })
 
     const [, init] = mock.mock.calls[0] as [string, RequestInit]
@@ -260,7 +260,7 @@ describe("Sandbox.create fromTemplate / fromSnapshot", () => {
     expect(body.from_template).toBe("my-env")
   })
 
-  it("falls back to id when alias is undefined", async () => {
+  it("falls back to id when name is undefined", async () => {
     const mock = vi.fn(async () => jsonResponse(baseSandbox))
     vi.stubGlobal("fetch", mock)
 

--- a/packages/sdk/tests/template.test.ts
+++ b/packages/sdk/tests/template.test.ts
@@ -26,7 +26,7 @@ function errorResponse(
 const baseTemplate = {
   id: "t-1",
   team_id: "team-1",
-  alias: "my-env",
+  name: "my-env",
   status: "building",
   vcpu: 1,
   memory_mib: 1024,
@@ -50,7 +50,7 @@ describe("Template.create", () => {
 
     const template = await Template.create({
       ...commonOpts,
-      alias: "my-env",
+      name: "my-env",
       vcpu: 2,
       memoryMib: 2048,
       diskMib: 4096,
@@ -64,7 +64,7 @@ describe("Template.create", () => {
     })
 
     expect(template.id).toBe("t-1")
-    expect(template.alias).toBe("my-env")
+    expect(template.name).toBe("my-env")
     expect(template.latestBuildId).toBe("b-1")
 
     const [url, init] = mock.mock.calls[0] as [string, RequestInit]
@@ -72,7 +72,7 @@ describe("Template.create", () => {
     expect(init.method).toBe("POST")
     const body = JSON.parse(init.body as string)
     expect(body).toEqual({
-      alias: "my-env",
+      name: "my-env",
       vcpu: 2,
       memory_mib: 2048,
       disk_mib: 4096,
@@ -94,11 +94,11 @@ describe("Template.create", () => {
     )
     vi.stubGlobal("fetch", mock)
 
-    await Template.create({ ...commonOpts, alias: "x", from: "python:3.11" })
+    await Template.create({ ...commonOpts, name: "x", from: "python:3.11" })
 
     const [, init] = mock.mock.calls[0] as [string, RequestInit]
     const body = JSON.parse(init.body as string)
-    expect(body).toEqual({ alias: "x", build_spec: { from: "python:3.11" } })
+    expect(body).toEqual({ name: "x", build_spec: { from: "python:3.11" } })
   })
 
   it("throws when build_id missing from response", async () => {
@@ -107,7 +107,7 @@ describe("Template.create", () => {
       vi.fn(async () => jsonResponse(baseTemplate)),
     )
     await expect(
-      Template.create({ ...commonOpts, alias: "x", from: "python:3.11" }),
+      Template.create({ ...commonOpts, name: "x", from: "python:3.11" }),
     ).rejects.toThrow(/missing build_id/)
   })
 })
@@ -137,18 +137,18 @@ describe("Template.list", () => {
 
     const list = await Template.list(commonOpts)
     expect(list).toHaveLength(1)
-    expect(list[0].alias).toBe("my-env")
+    expect(list[0].name).toBe("my-env")
     const [url] = mock.mock.calls[0] as [string]
     expect(url).toBe("https://api.superserve.ai/templates")
   })
 
-  it("appends alias_prefix query param", async () => {
+  it("appends name_prefix query param", async () => {
     const mock = vi.fn(async () => jsonResponse([]))
     vi.stubGlobal("fetch", mock)
 
-    await Template.list({ ...commonOpts, aliasPrefix: "my-" })
+    await Template.list({ ...commonOpts, namePrefix: "my-" })
     const [url] = mock.mock.calls[0] as [string]
-    expect(url).toBe("https://api.superserve.ai/templates?alias_prefix=my-")
+    expect(url).toBe("https://api.superserve.ai/templates?name_prefix=my-")
   })
 })
 
@@ -196,7 +196,7 @@ describe("Template instance methods", () => {
     )
     const t = await Template.create({
       ...commonOpts,
-      alias: "my-env",
+      name: "my-env",
       from: "python:3.11",
     })
     vi.unstubAllGlobals()

--- a/packages/sdk/tests/types.test.ts
+++ b/packages/sdk/tests/types.test.ts
@@ -76,7 +76,7 @@ describe("toTemplateInfo", () => {
     const info = toTemplateInfo({
       id: "t-1",
       team_id: "team-1",
-      alias: "my-env",
+      name: "my-env",
       status: "ready",
       vcpu: 2,
       memory_mib: 2048,
@@ -86,7 +86,7 @@ describe("toTemplateInfo", () => {
       built_at: "2026-01-01T00:01:00Z",
     })
     expect(info.id).toBe("t-1")
-    expect(info.alias).toBe("my-env")
+    expect(info.name).toBe("my-env")
     expect(info.status).toBe("ready")
     expect(info.vcpu).toBe(2)
     expect(info.memoryMib).toBe(2048)
@@ -100,7 +100,7 @@ describe("toTemplateInfo", () => {
     const info = toTemplateInfo({
       id: "t-1",
       team_id: "team-1",
-      alias: "my-env",
+      name: "my-env",
       status: "building",
       vcpu: 1,
       memory_mib: 1024,
@@ -115,7 +115,7 @@ describe("toTemplateInfo", () => {
   it("throws on missing id", () => {
     expect(() =>
       toTemplateInfo({
-        alias: "x",
+        name: "x",
         status: "ready",
         team_id: "t",
         created_at: "2026-01-01T00:00:00Z",
@@ -123,7 +123,7 @@ describe("toTemplateInfo", () => {
     ).toThrow(/missing template id/)
   })
 
-  it("throws on missing alias", () => {
+  it("throws on missing name", () => {
     expect(() =>
       toTemplateInfo({
         id: "t-1",
@@ -131,7 +131,7 @@ describe("toTemplateInfo", () => {
         status: "ready",
         created_at: "2026-01-01T00:00:00Z",
       }),
-    ).toThrow(/missing template alias/)
+    ).toThrow(/missing template name/)
   })
 
   it("throws on missing status", () => {
@@ -139,7 +139,7 @@ describe("toTemplateInfo", () => {
       toTemplateInfo({
         id: "t-1",
         team_id: "team-1",
-        alias: "x",
+        name: "x",
         created_at: "2026-01-01T00:00:00Z",
       }),
     ).toThrow(/missing template status/)
@@ -149,7 +149,7 @@ describe("toTemplateInfo", () => {
     expect(() =>
       toTemplateInfo({
         id: "t-1",
-        alias: "x",
+        name: "x",
         status: "ready",
         created_at: "2026-01-01T00:00:00Z",
       }),
@@ -161,7 +161,7 @@ describe("toTemplateInfo", () => {
       toTemplateInfo({
         id: "t-1",
         team_id: "team-1",
-        alias: "x",
+        name: "x",
         status: "ready",
       }),
     ).toThrow(/missing created_at/)

--- a/tests/sdk-e2e-py/test_templates.py
+++ b/tests/sdk-e2e-py/test_templates.py
@@ -18,15 +18,15 @@ pytestmark = SKIP_IF_NO_CREDS
 def test_list_includes_system_templates(connection_opts):
     templates = Template.list(**connection_opts)
     assert len(templates) > 0
-    assert any(t.alias.startswith("superserve/") for t in templates)
+    assert any(t.name.startswith("superserve/") for t in templates)
 
 
 def test_full_lifecycle(connection_opts, run_id):
     """Multi-step build, launch, verify env/workdir propagate, rebuild
     idempotency, conflict-on-delete-while-referenced."""
-    alias = f"sdk-e2e-py-tpl-{run_id}"
+    name = f"sdk-e2e-py-tpl-{run_id}"
     template = Template.create(
-        alias=alias,
+        name=name,
         vcpu=2,
         memory_mib=2048,
         disk_mib=4096,
@@ -40,7 +40,7 @@ def test_full_lifecycle(connection_opts, run_id):
         ],
         **connection_opts,
     )
-    assert template.alias == alias
+    assert template.name == name
     assert template.vcpu == 2
     assert template.memory_mib == 2048
 
@@ -107,9 +107,9 @@ def test_full_lifecycle(connection_opts, run_id):
 
 def test_build_error_on_failed_step(connection_opts, run_id):
     """A build with a failing step raises BuildError."""
-    alias = f"sdk-e2e-py-tpl-fail-{run_id}"
+    name = f"sdk-e2e-py-tpl-fail-{run_id}"
     template = Template.create(
-        alias=alias,
+        name=name,
         from_="python:3.11",
         # Force a step failure as quickly as possible: `false` exits 1.
         steps=[RunStep(run="false")],

--- a/tests/sdk-e2e-ts/scripts/test-template.ts
+++ b/tests/sdk-e2e-ts/scripts/test-template.ts
@@ -28,15 +28,15 @@ async function main() {
     process.exit(1)
   }
 
-  const alias = `test-tpl-${Date.now().toString(36)}`
-  console.log(`Creating template: ${alias}`)
+  const name = `test-tpl-${Date.now().toString(36)}`
+  console.log(`Creating template: ${name}`)
   console.log(`Target: ${BASE_URL}`)
   console.log()
 
   const template = await Template.create({
     apiKey: API_KEY,
     baseUrl: BASE_URL,
-    alias,
+    name,
     vcpu: 2,
     memoryMib: 2048,
     diskMib: 4096,
@@ -65,7 +65,9 @@ async function main() {
     })
     const fresh = await template.getInfo()
     console.log("\n--- end logs ---")
-    console.log(`Build succeeded. status=${fresh.status} built_at=${fresh.builtAt?.toISOString()}`)
+    console.log(
+      `Build succeeded. status=${fresh.status} built_at=${fresh.builtAt?.toISOString()}`,
+    )
     console.log(`Size: ${fresh.sizeBytes ?? "n/a"} bytes`)
   } catch (err) {
     console.log("\n--- end logs ---")
@@ -87,7 +89,7 @@ async function main() {
     // } catch (err) {
     //   console.error(`Cleanup failed for template ${template.id}:`, err)
     // }
-    console.log(`Template left in place: ${template.id} (${template.alias})`)
+    console.log(`Template left in place: ${template.id} (${template.name})`)
   }
 }
 

--- a/tests/sdk-e2e-ts/tests/templates.test.ts
+++ b/tests/sdk-e2e-ts/tests/templates.test.ts
@@ -10,123 +10,115 @@ describe.skipIf(!hasCredentials())("templates", () => {
   it("lists templates (includes system templates)", async () => {
     const list = await Template.list(opts)
     expect(list.length).toBeGreaterThan(0)
-    expect(list.some((t) => t.alias.startsWith("superserve/"))).toBe(true)
+    expect(list.some((t) => t.name.startsWith("superserve/"))).toBe(true)
   })
 
-  it(
-    "full lifecycle: multi-step build, launch, verify, rebuild idempotency, conflict-on-delete",
-    async () => {
-      const alias = `sdk-e2e-tpl-${RUN_ID}`
-      const template = await Template.create({
-        ...opts,
-        alias,
-        vcpu: 2,
-        memoryMib: 2048,
-        diskMib: 4096,
-        from: "python:3.11",
-        steps: [
-          { run: "mkdir -p /srv/app" },
-          { workdir: "/srv/app" },
-          { env: { key: "GREETING", value: "hello-from-build" } },
-          { run: 'sh -c "echo $GREETING > /srv/app/greet.txt"' },
-          { run: "python --version > /srv/app/pyver.txt 2>&1" },
-        ],
-      })
-      expect(template.alias).toBe(alias)
-      expect(template.vcpu).toBe(2)
-      expect(template.memoryMib).toBe(2048)
+  it("full lifecycle: multi-step build, launch, verify, rebuild idempotency, conflict-on-delete", async () => {
+    const name = `sdk-e2e-tpl-${RUN_ID}`
+    const template = await Template.create({
+      ...opts,
+      name,
+      vcpu: 2,
+      memoryMib: 2048,
+      diskMib: 4096,
+      from: "python:3.11",
+      steps: [
+        { run: "mkdir -p /srv/app" },
+        { workdir: "/srv/app" },
+        { env: { key: "GREETING", value: "hello-from-build" } },
+        { run: 'sh -c "echo $GREETING > /srv/app/greet.txt"' },
+        { run: "python --version > /srv/app/pyver.txt 2>&1" },
+      ],
+    })
+    expect(template.name).toBe(name)
+    expect(template.vcpu).toBe(2)
+    expect(template.memoryMib).toBe(2048)
 
-      try {
-        await template.waitUntilReady({
-          onLog: (ev) => {
-            if (ev.stream === "stdout" || ev.stream === "stderr") {
-              process.stdout.write(ev.text)
-            }
-          },
-        })
-
-        const fresh = await template.getInfo()
-        expect(fresh.status).toBe("ready")
-        expect(fresh.builtAt).toBeInstanceOf(Date)
-
-        // listBuilds shows the build that just finished
-        const builds = await template.listBuilds()
-        expect(builds.length).toBeGreaterThanOrEqual(1)
-        expect(builds[0].status).toBe("ready")
-
-        // Rebuild with same spec → idempotent (same hash returns existing build)
-        const rebuilt = await template.rebuild()
-        expect(rebuilt.buildSpecHash).toBe(builds[0].buildSpecHash)
-
-        // Launch a sandbox, verify all build-step effects propagate to runtime
-        const sandbox = await Sandbox.create({
-          ...opts,
-          name: `sdk-e2e-tpl-sbx-${RUN_ID}`,
-          fromTemplate: template,
-        })
-        try {
-          // env var from build step persists at runtime
-          const env = await sandbox.commands.run("printenv GREETING")
-          expect(env.stdout.trim()).toBe("hello-from-build")
-
-          // workdir from build step is the runtime cwd
-          const cwd = await sandbox.commands.run("pwd")
-          expect(cwd.stdout.trim()).toBe("/srv/app")
-
-          // file written during build is present
-          const greet = await sandbox.commands.run("cat /srv/app/greet.txt")
-          expect(greet.stdout.trim()).toBe("hello-from-build")
-
-          // python build-step output is on disk
-          const pyver = await sandbox.commands.run("cat /srv/app/pyver.txt")
-          expect(pyver.exitCode).toBe(0)
-          expect(pyver.stdout.trim()).toMatch(/^Python 3\.11/)
-
-          // Deleting the template while the sandbox still references it → 409
-          await expect(template.delete()).rejects.toBeInstanceOf(ConflictError)
-        } finally {
-          try {
-            await sandbox.kill()
-          } catch (err) {
-            console.error(`Cleanup failed for sandbox ${sandbox.id}:`, err)
+    try {
+      await template.waitUntilReady({
+        onLog: (ev) => {
+          if (ev.stream === "stdout" || ev.stream === "stderr") {
+            process.stdout.write(ev.text)
           }
-        }
-      } finally {
-        try {
-          await template.delete()
-        } catch (err) {
-          console.error(`Cleanup failed for template ${template.id}:`, err)
-        }
-      }
-    },
-    600_000,
-  )
-
-  it(
-    "BuildError: failed build raises BuildError with parsed code",
-    async () => {
-      const alias = `sdk-e2e-tpl-fail-${RUN_ID}`
-      const template = await Template.create({
-        ...opts,
-        alias,
-        from: "python:3.11",
-        // Force a step failure as quickly as possible: `false` exits 1.
-        steps: [{ run: "false" }],
+        },
       })
 
+      const fresh = await template.getInfo()
+      expect(fresh.status).toBe("ready")
+      expect(fresh.builtAt).toBeInstanceOf(Date)
+
+      // listBuilds shows the build that just finished
+      const builds = await template.listBuilds()
+      expect(builds.length).toBeGreaterThanOrEqual(1)
+      expect(builds[0].status).toBe("ready")
+
+      // Rebuild with same spec → idempotent (same hash returns existing build)
+      const rebuilt = await template.rebuild()
+      expect(rebuilt.buildSpecHash).toBe(builds[0].buildSpecHash)
+
+      // Launch a sandbox, verify all build-step effects propagate to runtime
+      const sandbox = await Sandbox.create({
+        ...opts,
+        name: `sdk-e2e-tpl-sbx-${RUN_ID}`,
+        fromTemplate: template,
+      })
       try {
-        await expect(template.waitUntilReady()).rejects.toMatchObject({
-          name: "BuildError",
-          templateId: template.id,
-        })
+        // env var from build step persists at runtime
+        const env = await sandbox.commands.run("printenv GREETING")
+        expect(env.stdout.trim()).toBe("hello-from-build")
+
+        // workdir from build step is the runtime cwd
+        const cwd = await sandbox.commands.run("pwd")
+        expect(cwd.stdout.trim()).toBe("/srv/app")
+
+        // file written during build is present
+        const greet = await sandbox.commands.run("cat /srv/app/greet.txt")
+        expect(greet.stdout.trim()).toBe("hello-from-build")
+
+        // python build-step output is on disk
+        const pyver = await sandbox.commands.run("cat /srv/app/pyver.txt")
+        expect(pyver.exitCode).toBe(0)
+        expect(pyver.stdout.trim()).toMatch(/^Python 3\.11/)
+
+        // Deleting the template while the sandbox still references it → 409
+        await expect(template.delete()).rejects.toBeInstanceOf(ConflictError)
       } finally {
         try {
-          await template.delete()
+          await sandbox.kill()
         } catch (err) {
-          console.error(`Cleanup failed for template ${template.id}:`, err)
+          console.error(`Cleanup failed for sandbox ${sandbox.id}:`, err)
         }
       }
-    },
-    300_000,
-  )
+    } finally {
+      try {
+        await template.delete()
+      } catch (err) {
+        console.error(`Cleanup failed for template ${template.id}:`, err)
+      }
+    }
+  }, 600_000)
+
+  it("BuildError: failed build raises BuildError with parsed code", async () => {
+    const name = `sdk-e2e-tpl-fail-${RUN_ID}`
+    const template = await Template.create({
+      ...opts,
+      name,
+      from: "python:3.11",
+      // Force a step failure as quickly as possible: `false` exits 1.
+      steps: [{ run: "false" }],
+    })
+
+    try {
+      await expect(template.waitUntilReady()).rejects.toMatchObject({
+        name: "BuildError",
+        templateId: template.id,
+      })
+    } finally {
+      try {
+        await template.delete()
+      } catch (err) {
+        console.error(`Cleanup failed for template ${template.id}:`, err)
+      }
+    }
+  }, 300_000)
 })


### PR DESCRIPTION
## Summary

- Renames the template `alias` field to `name` across the TypeScript SDK, Python SDK (sync + async), and console UI to match the backend rename in [superserve-ai/sandbox#42](https://github.com/superserve-ai/sandbox/pull/42).
- Renames the list filter query param `alias_prefix` → `name_prefix` and the corresponding SDK options (`aliasPrefix` → `namePrefix`, `alias_prefix` → `name_prefix`).
- Updates docs and example snippets to use `name` everywhere; adds a note in the lifecycle/overview docs that names are released for reuse the moment a template is deleted.

## Wire format alignment

| Path | TS SDK | Python SDK |
|---|---|---|
| POST `/templates` request body | `{ name: options.name }` | `{"name": name}` |
| GET `/templates` query param | `?name_prefix=...` from `namePrefix` | `?name_prefix=...` from `name_prefix` |
| Response parser | reads `raw.name`; throws "missing template name" | reads `raw["name"]`; throws "missing template name" |
| `Sandbox.create({ fromTemplate })` instance shape | `{ name?, id }` | `getattr(t, "name", None)` |