### PR TITLE
Ruby SDK: initial implementation with TS/Python feature parity

### DIFF
--- a/packages/ruby-sdk/.gitignore
+++ b/packages/ruby-sdk/.gitignore
@@ -1,0 +1,7 @@
+/.bundle/
+/vendor/bundle/
+/Gemfile.lock
+/pkg/
+/coverage/
+/tmp/
+*.gem

--- a/packages/ruby-sdk/.rspec
+++ b/packages/ruby-sdk/.rspec
@@ -1,0 +1,3 @@
+--require spec_helper
+--format documentation
+--color

--- a/packages/ruby-sdk/Gemfile
+++ b/packages/ruby-sdk/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/packages/ruby-sdk/README.md
+++ b/packages/ruby-sdk/README.md
@@ -1,0 +1,120 @@
+# superserve
+
+Ruby SDK for the Superserve sandbox API — run code in isolated Firecracker MicroVMs.
+
+## Installation
+
+Add to your Gemfile:
+
+```ruby
+gem "superserve"
+```
+
+Or install directly:
+
+```bash
+gem install superserve
+```
+
+Requires Ruby ≥ 3.2.
+
+## Quick Start
+
+```ruby
+require "superserve"
+
+sandbox = Superserve::Sandbox.create(name: "my-sandbox")
+
+result = sandbox.commands.run("echo hello")
+puts result.stdout
+
+sandbox.files.write("/app/data.txt", "content")
+text = sandbox.files.read_text("/app/data.txt")
+
+sandbox.kill
+```
+
+## Authentication
+
+Set the `SUPERSERVE_API_KEY` environment variable:
+
+```bash
+export SUPERSERVE_API_KEY=ss_live_...
+```
+
+Or pass it explicitly:
+
+```ruby
+sandbox = Superserve::Sandbox.create(
+  name: "my-sandbox",
+  api_key: "ss_live_...",
+  base_url: "https://api.superserve.ai" # optional
+)
+```
+
+## Streaming command output
+
+```ruby
+result = sandbox.commands.run(
+  "pip install numpy",
+  on_stdout: ->(data) { print data },
+  on_stderr: ->(data) { warn data },
+  timeout_seconds: 120
+)
+```
+
+Passing `on_stdout:` or `on_stderr:` switches the call to streaming mode (SSE).
+The block returns the aggregated `CommandResult` once the command finishes.
+
+## Templates
+
+```ruby
+template = Superserve::Template.create(
+  name: "my-python-env",
+  from: "python:3.11",
+  steps: [{ run: "pip install numpy" }]
+)
+template.wait_until_ready
+
+sandbox = Superserve::Sandbox.create(name: "run-1", from_template: template)
+```
+
+## Error handling
+
+```ruby
+begin
+  sandbox.pause
+rescue Superserve::ConflictError
+  # Sandbox is not in a pausable state
+rescue Superserve::AuthenticationError
+  # 401 / 403
+rescue Superserve::NotFoundError
+  # 404
+rescue Superserve::RateLimitError => e
+  # 429 — e.code distinguishes: rate_limited, too_many_sandboxes, etc.
+rescue Superserve::TimeoutError
+  # Request timed out
+rescue Superserve::SandboxError
+  # Catch-all base class
+end
+```
+
+## Full documentation
+
+[docs.superserve.ai](https://docs.superserve.ai/sdk/ruby/sandbox)
+
+## Development
+
+```bash
+# From repo root:
+bunx turbo run test --filter=@superserve/ruby-sdk
+
+# Or directly:
+cd packages/ruby-sdk
+bundle install
+bundle exec rspec
+```
+
+## License
+
+Apache License 2.0.

--- a/packages/ruby-sdk/Rakefile
+++ b/packages/ruby-sdk/Rakefile
@@ -1,0 +1,6 @@
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: :spec

--- a/packages/ruby-sdk/examples/demo.rb
+++ b/packages/ruby-sdk/examples/demo.rb
@@ -1,0 +1,76 @@
+# Superserve Ruby SDK — end-to-end demo
+#
+# Run from packages/ruby-sdk/:
+#   export SUPERSERVE_API_KEY=ss_live_...
+#   bundle exec ruby examples/demo.rb
+
+require_relative "../lib/superserve"
+
+def step(title)
+  puts
+  puts "─" * 64
+  puts "▶ #{title}"
+  puts "─" * 64
+end
+
+# ----------------------------------------------------------------
+step "Creating a sandbox"
+# ----------------------------------------------------------------
+sandbox = Superserve::Sandbox.create(
+  name: "ruby-sdk-demo",
+  metadata: { "demo" => "ruby-sdk" }
+)
+puts "  id:     #{sandbox.id}"
+puts "  status: #{sandbox.status}"
+puts "  vcpu:   #{sandbox.get_info.vcpu_count}, mem: #{sandbox.get_info.memory_mib} MiB"
+
+# ----------------------------------------------------------------
+step "Running a sync command"
+# ----------------------------------------------------------------
+result = sandbox.commands.run("ruby -e 'puts (1..10).map { |i| i**2 }.sum'")
+puts "  stdout:    #{result.stdout.strip}"
+puts "  exit_code: #{result.exit_code}"
+
+# ----------------------------------------------------------------
+step "Round-tripping a file through the data plane"
+# ----------------------------------------------------------------
+sandbox.files.write("/tmp/note.txt", "hello from the ruby sdk")
+echoed = sandbox.files.read_text("/tmp/note.txt")
+puts "  wrote: /tmp/note.txt"
+puts "  read:  #{echoed.inspect}"
+
+# ----------------------------------------------------------------
+step "Streaming command output (SSE)"
+# ----------------------------------------------------------------
+sandbox.commands.run(
+  %q(ruby -e '5.times { |i| puts "chunk #{i+1}"; STDOUT.flush; sleep 0.3 }'),
+  on_stdout: ->(chunk) { print "  STREAM ▸ #{chunk}" }
+)
+
+# ----------------------------------------------------------------
+step "Pause + resume (rotates the per-sandbox access token)"
+# ----------------------------------------------------------------
+sandbox.pause
+puts "  paused."
+sandbox.resume
+puts "  resumed (access token rotated, files re-bound)."
+echoed_again = sandbox.files.read_text("/tmp/note.txt")
+puts "  files still work: #{echoed_again.inspect}"
+
+# ----------------------------------------------------------------
+step "Listing sandboxes filtered by metadata"
+# ----------------------------------------------------------------
+matches = Superserve::Sandbox.list(metadata: { "demo" => "ruby-sdk" })
+puts "  matched #{matches.length} sandbox(es) with demo=ruby-sdk"
+matches.each { |s| puts "    - #{s.id} (#{s.status})" }
+
+# ----------------------------------------------------------------
+step "Cleaning up"
+# ----------------------------------------------------------------
+sandbox.kill
+puts "  killed. (kill is idempotent — safe to call again)"
+sandbox.kill rescue nil
+puts "  second kill: no-op."
+
+puts
+puts "✓ Demo complete."

--- a/packages/ruby-sdk/lib/superserve.rb
+++ b/packages/ruby-sdk/lib/superserve.rb
@@ -1,0 +1,12 @@
+require_relative "superserve/version"
+require_relative "superserve/errors"
+require_relative "superserve/config"
+require_relative "superserve/types"
+require_relative "superserve/http"
+require_relative "superserve/files"
+require_relative "superserve/commands"
+require_relative "superserve/sandbox"
+require_relative "superserve/template"
+
+module Superserve
+end

--- a/packages/ruby-sdk/lib/superserve/commands.rb
+++ b/packages/ruby-sdk/lib/superserve/commands.rb
@@ -1,0 +1,96 @@
+module Superserve
+  # `sandbox.commands` — run shell commands inside a sandbox.
+  #
+  # Two modes:
+  # - Synchronous: waits for the command to finish, returns stdout/stderr/exit_code.
+  # - Streaming: when on_stdout / on_stderr callbacks are passed, fires them via
+  #   SSE and returns the aggregated result at the end.
+  #
+  # Paused sandboxes are transparently resumed by the platform before execution.
+  class Commands
+    # @api private
+    def initialize(base_url, sandbox_id, api_key, connection: nil)
+      @base_url = base_url
+      @sandbox_id = sandbox_id
+      @api_key = api_key
+      @connection = connection
+    end
+
+    def run(command, cwd: nil, env: nil, timeout_seconds: nil, on_stdout: nil, on_stderr: nil)
+      body = { command: command }
+      body[:working_dir] = cwd if cwd
+      body[:env] = env if env
+      body[:timeout_s] = timeout_seconds if timeout_seconds
+
+      headers = { "X-API-Key" => @api_key }
+      streaming = on_stdout || on_stderr
+
+      if streaming
+        run_streaming(body, headers, on_stdout, on_stderr, timeout_seconds)
+      else
+        run_sync(body, headers, timeout_seconds)
+      end
+    end
+
+    private
+
+    def run_sync(body, headers, timeout_seconds)
+      effective_timeout = timeout_seconds ? timeout_seconds + 5 : HTTP::DEFAULT_TIMEOUT
+      raw = HTTP.api_request(
+        :post,
+        "#{@base_url}/sandboxes/#{@sandbox_id}/exec",
+        headers: headers,
+        json_body: body,
+        timeout: effective_timeout,
+        connection: @connection
+      )
+      CommandResult.new(
+        stdout: raw["stdout"] || "",
+        stderr: raw["stderr"] || "",
+        exit_code: raw["exit_code"] || 0
+      )
+    end
+
+    def run_streaming(body, headers, on_stdout, on_stderr, timeout_seconds)
+      stdout_parts = []
+      stderr_parts = []
+      exit_code = 0
+      saw_finished = false
+      effective_timeout = timeout_seconds ? timeout_seconds + 5 : HTTP::DEFAULT_STREAM_TIMEOUT
+
+      HTTP.stream_sse(
+        "#{@base_url}/sandboxes/#{@sandbox_id}/exec/stream",
+        headers: headers,
+        json_body: body,
+        timeout: effective_timeout,
+        connection: @connection
+      ) do |event|
+        if event["stdout"]
+          stdout_parts << event["stdout"]
+          on_stdout&.call(event["stdout"])
+        end
+        if event["stderr"]
+          stderr_parts << event["stderr"]
+          on_stderr&.call(event["stderr"])
+        end
+        if event["finished"]
+          saw_finished = true
+          exit_code = event["exit_code"] || 0
+          stderr_parts << event["error"] if event["error"]
+        end
+      end
+
+      unless saw_finished
+        raise SandboxError.new(
+          "Command stream ended without a finished event (possible network disconnect)"
+        )
+      end
+
+      CommandResult.new(
+        stdout: stdout_parts.join,
+        stderr: stderr_parts.join,
+        exit_code: exit_code
+      )
+    end
+  end
+end

--- a/packages/ruby-sdk/lib/superserve/config.rb
+++ b/packages/ruby-sdk/lib/superserve/config.rb
@@ -1,0 +1,44 @@
+require "uri"
+
+module Superserve
+  DEFAULT_BASE_URL = "https://api.superserve.ai".freeze
+  DEFAULT_SANDBOX_HOST = "sandbox.superserve.ai".freeze
+
+  ResolvedConfig = Data.define(:api_key, :base_url, :sandbox_host)
+
+  # Resolve connection config from explicit args + environment variables.
+  #
+  # Priority: explicit option > SUPERSERVE_API_KEY / SUPERSERVE_BASE_URL env vars.
+  # Raises AuthenticationError if no API key can be resolved.
+  def self.resolve_config(api_key: nil, base_url: nil)
+    resolved_key = api_key || ENV["SUPERSERVE_API_KEY"]
+    if resolved_key.nil? || resolved_key.empty?
+      raise AuthenticationError.new(
+        "Missing API key. Pass `api_key:` or set the SUPERSERVE_API_KEY environment variable."
+      )
+    end
+
+    resolved_url = base_url || ENV["SUPERSERVE_BASE_URL"] || DEFAULT_BASE_URL
+    sandbox_host = derive_sandbox_host(resolved_url)
+    ResolvedConfig.new(api_key: resolved_key, base_url: resolved_url, sandbox_host: sandbox_host)
+  end
+
+  # Build the data-plane base URL for a specific sandbox.
+  #
+  # Example: `https://boxd-{sandboxId}.sandbox.superserve.ai`
+  def self.data_plane_url(sandbox_id, sandbox_host)
+    "https://boxd-#{sandbox_id}.#{sandbox_host}"
+  end
+
+  # @api private
+  def self.derive_sandbox_host(base_url)
+    uri = URI.parse(base_url)
+    case uri.host
+    when "api.superserve.ai" then DEFAULT_SANDBOX_HOST
+    when "api-staging.superserve.ai" then "sandbox-staging.superserve.ai"
+    else DEFAULT_SANDBOX_HOST
+    end
+  rescue URI::InvalidURIError
+    DEFAULT_SANDBOX_HOST
+  end
+end

--- a/packages/ruby-sdk/lib/superserve/errors.rb
+++ b/packages/ruby-sdk/lib/superserve/errors.rb
@@ -1,0 +1,99 @@
+module Superserve
+  class SandboxError < StandardError
+    attr_reader :status_code, :code
+
+    def initialize(message, status_code: nil, code: nil)
+      super(message)
+      @status_code = status_code
+      @code = code
+    end
+  end
+
+  class AuthenticationError < SandboxError
+    def initialize(message = "Missing or invalid API key", code: nil, status_code: 401)
+      super(message, status_code: status_code, code: code)
+    end
+  end
+
+  class ValidationError < SandboxError
+    def initialize(message, code: nil)
+      super(message, status_code: 400, code: code)
+    end
+  end
+
+  class NotFoundError < SandboxError
+    def initialize(message = "Resource not found", code: nil)
+      super(message, status_code: 404, code: code)
+    end
+  end
+
+  class ConflictError < SandboxError
+    def initialize(message = "Sandbox is not in a valid state for this operation", code: nil)
+      super(message, status_code: 409, code: code)
+    end
+  end
+
+  # 429 from the API. ``code`` distinguishes the variant:
+  # - ``rate_limited`` — request rate exceeded; retry after a short backoff.
+  # - ``too_many_builds`` — team has reached its concurrent build limit.
+  # - ``too_many_templates`` — team has reached its total template count limit.
+  # - ``too_many_sandboxes`` — team has reached its active sandbox count limit.
+  class RateLimitError < SandboxError
+    def initialize(message = "Rate limit exceeded", code: nil)
+      super(message, status_code: 429, code: code)
+    end
+  end
+
+  class ServerError < SandboxError
+    def initialize(message = "Internal server error", code: nil)
+      super(message, status_code: 500, code: code)
+    end
+  end
+
+  class TimeoutError < SandboxError
+    def initialize(message = "Request timed out")
+      super(message)
+    end
+  end
+
+  # Raised when a template build transitions to status 'failed'.
+  # `code` is the stable error prefix on `error_message`
+  # (e.g. `image_pull_failed`, `step_failed`, `boot_failed`,
+  # `snapshot_failed`, `start_cmd_failed`, `ready_cmd_failed`, `build_failed`).
+  class BuildError < SandboxError
+    attr_reader :build_id, :template_id
+
+    def initialize(message, code:, build_id:, template_id:, status_code: nil)
+      super(message, status_code: status_code, code: code)
+      @build_id = build_id
+      @template_id = template_id
+    end
+  end
+
+  # @api private
+  def self.map_api_error(status_code, body)
+    error_data = body.is_a?(Hash) ? (body["error"] || {}) : {}
+    error_data = {} unless error_data.is_a?(Hash)
+    message = error_data["message"] || "API error (#{status_code})"
+    code = error_data["code"]
+
+    case status_code
+    when 400
+      ValidationError.new(message, code: code)
+    when 401, 403
+      AuthenticationError.new(message, code: code, status_code: status_code)
+    when 404
+      NotFoundError.new(message, code: code)
+    when 409
+      ConflictError.new(message, code: code)
+    when 429
+      RateLimitError.new(message, code: code)
+    else
+      if status_code >= 500
+        ServerError.new(message, code: code)
+      else
+        SandboxError.new(message, status_code: status_code, code: code)
+      end
+    end
+  end
+end

--- a/packages/ruby-sdk/lib/superserve/files.rb
+++ b/packages/ruby-sdk/lib/superserve/files.rb
@@ -18,7 +18,7 @@ module Superserve
     # Parent directories are created automatically by the sandbox agent.
     # The path must start with `/` and must not contain `..` segments.
     def write(path, content, timeout: nil)
-      self.class.send(:validate_path!, path)
+      self.class.validate_path!(path)
       bytes = content.is_a?(String) ? content.b : content
       url = "#{@base_url}/files?path=#{ERB::Util.url_encode(path)}"
       kwargs = {
@@ -32,7 +32,7 @@ module Superserve
 
     # Read a file from the sandbox as raw bytes (binary string).
     def read(path, timeout: nil)
-      self.class.send(:validate_path!, path)
+      self.class.validate_path!(path)
       url = "#{@base_url}/files?path=#{ERB::Util.url_encode(path)}"
       kwargs = {
         headers: { "X-Access-Token" => @access_token },

--- a/packages/ruby-sdk/lib/superserve/files.rb
+++ b/packages/ruby-sdk/lib/superserve/files.rb
@@ -1,0 +1,61 @@
+require "erb"
+
+module Superserve
+  # `sandbox.files` — read and write files inside a sandbox.
+  #
+  # Hits the data-plane directly at `boxd-{id}.sandbox.superserve.ai`
+  # using the per-sandbox access token. The control-plane API key is
+  # not used for file operations.
+  class Files
+    # @api private
+    def initialize(sandbox_id, sandbox_host, access_token, connection: nil)
+      @base_url = Superserve.data_plane_url(sandbox_id, sandbox_host)
+      @access_token = access_token
+      @connection = connection
+    end
+
+    # Write a file to the sandbox at the given absolute path.
+    # Parent directories are created automatically by the sandbox agent.
+    # The path must start with `/` and must not contain `..` segments.
+    def write(path, content, timeout: nil)
+      self.class.send(:validate_path!, path)
+      bytes = content.is_a?(String) ? content.b : content
+      url = "#{@base_url}/files?path=#{ERB::Util.url_encode(path)}"
+      kwargs = {
+        headers: { "X-Access-Token" => @access_token },
+        content: bytes,
+        connection: @connection
+      }
+      kwargs[:timeout] = timeout if timeout
+      HTTP.upload_bytes(url, **kwargs)
+    end
+
+    # Read a file from the sandbox as raw bytes (binary string).
+    def read(path, timeout: nil)
+      self.class.send(:validate_path!, path)
+      url = "#{@base_url}/files?path=#{ERB::Util.url_encode(path)}"
+      kwargs = {
+        headers: { "X-Access-Token" => @access_token },
+        connection: @connection
+      }
+      kwargs[:timeout] = timeout if timeout
+      HTTP.download_bytes(url, **kwargs)
+    end
+
+    # Read a file from the sandbox as a UTF-8 string.
+    def read_text(path, timeout: nil)
+      bytes = read(path, timeout: timeout)
+      bytes.force_encoding(Encoding::UTF_8)
+    end
+
+    # @api private
+    def self.validate_path!(path)
+      unless path.is_a?(String) && path.start_with?("/")
+        raise ValidationError.new("Path must start with \"/\": #{path}")
+      end
+      if path.split("/").include?("..")
+        raise ValidationError.new("Path must not contain \"..\" segments: #{path}")
+      end
+    end
+  end
+end

--- a/packages/ruby-sdk/lib/superserve/http.rb
+++ b/packages/ruby-sdk/lib/superserve/http.rb
@@ -98,27 +98,18 @@ module Superserve
       )
 
       buffer = String.new
-      error_buffer = String.new
-      response_status = nil
 
       begin
         response = conn.run_request(method_sym, url, body, merged_headers) do |req|
           req.options.timeout = timeout
           req.options.read_timeout = timeout
-          req.options.on_data = proc do |chunk, _bytes, env|
-            response_status ||= env&.status
-            if response_status && response_status >= 400
-              error_buffer << chunk.to_s
-              next
-            end
-
+          req.options.on_data = proc do |chunk, _bytes|
             buffer << chunk.to_s
             loop do
               newline_idx = buffer.index("\n")
               break if newline_idx.nil?
 
-              line = buffer[0...newline_idx]
-              buffer = buffer[(newline_idx + 1)..] || String.new
+              line = buffer.slice!(0..newline_idx).chomp
 
               next unless line.start_with?("data:")
 
@@ -140,10 +131,10 @@ module Superserve
         raise Superserve::SandboxError.new("Stream error: #{e.message}")
       end
 
-      final_status = response_status || response.status
-      unless success?(final_status)
-        body_for_error = error_buffer.empty? ? response.body.to_s : error_buffer
-        raise Superserve.map_api_error(final_status, parse_error_body(body_for_error))
+      # On error, `buffer` retains any unparsed content (typically the full
+      # error JSON body, since error responses don't use `data:` framing).
+      unless success?(response.status)
+        raise Superserve.map_api_error(response.status, parse_error_body(buffer))
       end
 
       nil

--- a/packages/ruby-sdk/lib/superserve/http.rb
+++ b/packages/ruby-sdk/lib/superserve/http.rb
@@ -1,0 +1,248 @@
+require "faraday"
+require "json"
+require "time"
+
+module Superserve
+  # HTTP client wrapping Faraday with retry on idempotent methods,
+  # exponential backoff with jitter, and SSE stream parsing.
+  module HTTP
+    DEFAULT_TIMEOUT = 30
+    DEFAULT_STREAM_TIMEOUT = 300
+    USER_AGENT = "superserve-ruby/#{Superserve::VERSION} (ruby/#{RUBY_VERSION})".freeze
+
+    MAX_ATTEMPTS = 3
+    BASE_BACKOFF = 0.1
+    MAX_BACKOFF = 30.0
+    RETRY_STATUS_CODES = [429, 502, 503, 504].freeze
+    IDEMPOTENT_METHODS = [:get, :delete].freeze
+
+    # Build a reusable Faraday connection. Pass a single connection per Sandbox
+    # for connection pooling (analogous to httpx.Client in the Python SDK).
+    def self.build_connection(timeout: DEFAULT_TIMEOUT)
+      Faraday.new do |conn|
+        conn.options.timeout = timeout
+        conn.options.open_timeout = timeout
+        conn.options.read_timeout = timeout
+      end
+    end
+
+    # Make a JSON API request and return the parsed response body.
+    # Returns nil for 204 No Content. Raises typed SandboxError on non-2xx.
+    # Retries GET/DELETE on transient failures (429, 502/503/504, network errors).
+    def self.api_request(method, url, headers:, json_body: nil, timeout: DEFAULT_TIMEOUT, connection: nil)
+      conn = connection || build_connection(timeout: timeout)
+      method_sym = method.to_sym
+      body = json_body.nil? ? nil : JSON.generate(json_body)
+      merged_headers = default_headers(headers, content_type: "application/json")
+
+      response = do_request_with_retry(conn, method_sym, url, body, merged_headers, timeout)
+
+      return nil if response.status == 204
+
+      unless success?(response.status)
+        raise Superserve.map_api_error(response.status, parse_error_body(response.body))
+      end
+
+      response.body.to_s.empty? ? nil : JSON.parse(response.body)
+    end
+
+    # Upload raw bytes (POST). Never retried — POST is not idempotent.
+    def self.upload_bytes(url, headers:, content:, timeout: DEFAULT_TIMEOUT, connection: nil)
+      conn = connection || build_connection(timeout: timeout)
+      merged_headers = default_headers(headers, content_type: "application/octet-stream")
+
+      begin
+        response = conn.run_request(:post, url, content, merged_headers) do |req|
+          req.options.timeout = timeout
+          req.options.read_timeout = timeout
+        end
+      rescue Faraday::TimeoutError
+        raise Superserve::TimeoutError.new("Upload timed out after #{timeout}s")
+      rescue Faraday::ConnectionFailed => e
+        raise Superserve::SandboxError.new("Upload error: #{e.message}")
+      end
+
+      unless success?(response.status)
+        raise Superserve.map_api_error(response.status, parse_error_body(response.body))
+      end
+
+      nil
+    end
+
+    # Download raw bytes (GET). Retries on transient failures.
+    def self.download_bytes(url, headers:, timeout: DEFAULT_TIMEOUT, connection: nil)
+      conn = connection || build_connection(timeout: timeout)
+      merged_headers = default_headers(headers)
+
+      response = do_request_with_retry(conn, :get, url, nil, merged_headers, timeout)
+
+      unless success?(response.status)
+        raise Superserve.map_api_error(response.status, parse_error_body(response.body))
+      end
+
+      response.body.to_s
+    end
+
+    # Consume an SSE stream. Calls the block for each parsed event hash.
+    # Idle timeout (Net::HTTP read_timeout) resets per chunk under the hood.
+    # Supports POST (with body) and GET. Never retried — non-idempotent semantics.
+    def self.stream_sse(url, headers:, json_body: nil, method: :post, timeout: DEFAULT_STREAM_TIMEOUT, connection: nil, &on_event)
+      raise ArgumentError, "stream_sse requires a block" unless on_event
+
+      conn = connection || build_connection(timeout: timeout)
+      method_sym = method.to_sym
+      body = json_body.nil? ? nil : JSON.generate(json_body)
+      merged_headers = default_headers(
+        headers,
+        content_type: method_sym == :post ? "application/json" : nil
+      )
+
+      buffer = String.new
+      error_buffer = String.new
+      response_status = nil
+
+      begin
+        response = conn.run_request(method_sym, url, body, merged_headers) do |req|
+          req.options.timeout = timeout
+          req.options.read_timeout = timeout
+          req.options.on_data = proc do |chunk, _bytes, env|
+            response_status ||= env&.status
+            if response_status && response_status >= 400
+              error_buffer << chunk.to_s
+              next
+            end
+
+            buffer << chunk.to_s
+            loop do
+              newline_idx = buffer.index("\n")
+              break if newline_idx.nil?
+
+              line = buffer[0...newline_idx]
+              buffer = buffer[(newline_idx + 1)..] || String.new
+
+              next unless line.start_with?("data:")
+
+              data = line[5..].to_s.strip
+              next if data.empty? || data == "[DONE]"
+
+              begin
+                event = JSON.parse(data)
+                on_event.call(event)
+              rescue JSON::ParserError
+                # Skip malformed events
+              end
+            end
+          end
+        end
+      rescue Faraday::TimeoutError
+        raise Superserve::TimeoutError.new("Stream timed out after #{timeout}s")
+      rescue Faraday::ConnectionFailed => e
+        raise Superserve::SandboxError.new("Stream error: #{e.message}")
+      end
+
+      final_status = response_status || response.status
+      unless success?(final_status)
+        body_for_error = error_buffer.empty? ? response.body.to_s : error_buffer
+        raise Superserve.map_api_error(final_status, parse_error_body(body_for_error))
+      end
+
+      nil
+    end
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    # @api private
+    def self.do_request_with_retry(connection, method, url, body, headers, timeout)
+      retryable = IDEMPOTENT_METHODS.include?(method)
+      max_attempts = retryable ? MAX_ATTEMPTS : 1
+      attempt = 1
+
+      loop do
+        begin
+          response = connection.run_request(method, url, body, headers) do |req|
+            req.options.timeout = timeout
+            req.options.read_timeout = timeout
+          end
+        rescue Faraday::TimeoutError
+          raise Superserve::TimeoutError.new("Request timed out after #{timeout}s")
+        rescue Faraday::ConnectionFailed => e
+          if !retryable || attempt >= max_attempts
+            raise Superserve::SandboxError.new("Network error: #{e.message}")
+          end
+          sleep(compute_backoff(attempt))
+          attempt += 1
+          next
+        end
+
+        if retryable && RETRY_STATUS_CODES.include?(response.status) && attempt < max_attempts
+          delay = nil
+          if response.status == 429
+            delay = parse_retry_after(response.headers["retry-after"] || response.headers["Retry-After"])
+          end
+          delay ||= compute_backoff(attempt)
+          sleep(delay) if delay > 0
+          attempt += 1
+          next
+        end
+
+        return response
+      end
+    end
+
+    # Exponential backoff with ±20% jitter, capped at MAX_BACKOFF.
+    # Attempt 1 → ~100ms, 2 → ~200ms, 3 → ~400ms.
+    # @api private
+    def self.compute_backoff(attempt)
+      base = BASE_BACKOFF * (2**(attempt - 1))
+      jitter = base * (0.8 + rand * 0.4)
+      [jitter, MAX_BACKOFF].min
+    end
+
+    # Parse a Retry-After header (numeric seconds or HTTP-date).
+    # Returns seconds capped at MAX_BACKOFF, or nil if invalid.
+    # @api private
+    def self.parse_retry_after(value)
+      return nil if value.nil?
+      trimmed = value.to_s.strip
+      return nil if trimmed.empty?
+
+      begin
+        seconds = Float(trimmed)
+        return [[seconds, 0.0].max, MAX_BACKOFF].min
+      rescue ArgumentError
+      end
+
+      begin
+        dt = Time.httpdate(trimmed)
+        delta = dt - Time.now
+        return [[delta, 0.0].max, MAX_BACKOFF].min
+      rescue ArgumentError
+        nil
+      end
+    end
+
+    # @api private
+    def self.default_headers(extra, content_type: nil)
+      h = { "User-Agent" => USER_AGENT }
+      h["Content-Type"] = content_type if content_type
+      h.merge(extra)
+    end
+
+    # @api private
+    def self.parse_error_body(body)
+      return {} if body.nil? || body.to_s.empty?
+      parsed = JSON.parse(body.to_s)
+      parsed.is_a?(Hash) ? parsed : {}
+    rescue JSON::ParserError
+      truncated = body.to_s[0, 500]
+      { "error" => { "message" => truncated.empty? ? nil : truncated } }
+    end
+
+    # @api private
+    def self.success?(status)
+      status >= 200 && status < 300
+    end
+  end
+end

--- a/packages/ruby-sdk/lib/superserve/sandbox.rb
+++ b/packages/ruby-sdk/lib/superserve/sandbox.rb
@@ -1,0 +1,221 @@
+require "erb"
+
+module Superserve
+  # Main Sandbox class — primary entry point for the Superserve SDK.
+  #
+  # Static factory methods (create/connect/list) return a sandbox.
+  # Call methods on it directly (`sandbox.commands.run(...)`,
+  # `sandbox.files.write(...)`, etc.).
+  #
+  # Example:
+  #   sandbox = Superserve::Sandbox.create(name: "my-sandbox")
+  #   result = sandbox.commands.run("echo hello")
+  #   sandbox.files.write("/app/data.txt", "content")
+  #   sandbox.kill
+  class Sandbox
+    attr_reader :id, :name, :status, :metadata, :commands, :files
+
+    # @api private — use Sandbox.create / Sandbox.connect.
+    def initialize(info, access_token, config)
+      @id = info.id
+      @name = info.name
+      @status = info.status
+      @metadata = info.metadata
+      @access_token = access_token
+      @config = config
+      @connection = HTTP.build_connection
+      @closed = false
+
+      @commands = Commands.new(config.base_url, @id, config.api_key, connection: @connection)
+      @files = Files.new(@id, config.sandbox_host, @access_token, connection: @connection)
+    end
+
+    # Create a new sandbox. The request is synchronous: once it returns, the
+    # sandbox is `active` and ready to execute commands and file operations.
+    def self.create(name:, from_template: nil, from_snapshot: nil, timeout_seconds: nil,
+                    metadata: nil, env_vars: nil, network: nil,
+                    api_key: nil, base_url: nil)
+      config = Superserve.resolve_config(api_key: api_key, base_url: base_url)
+
+      body = { name: name }
+      if from_template
+        body[:from_template] =
+          if from_template.is_a?(String)
+            from_template
+          elsif from_template.respond_to?(:name) && from_template.name
+            from_template.name
+          else
+            from_template.id
+          end
+      end
+      body[:from_snapshot] = from_snapshot if from_snapshot
+      body[:timeout_seconds] = timeout_seconds if timeout_seconds
+      body[:metadata] = metadata if metadata
+      body[:env_vars] = env_vars if env_vars
+      body[:network] = serialize_network(network) if network
+
+      raw = HTTP.api_request(
+        :post,
+        "#{config.base_url}/sandboxes",
+        headers: { "X-API-Key" => config.api_key },
+        json_body: body
+      )
+
+      token = raw && raw["access_token"]
+      unless token
+        raise SandboxError.new("Invalid API response from POST /sandboxes: missing access_token")
+      end
+
+      new(Superserve.to_sandbox_info(raw), token, config)
+    end
+
+    # Connect to an existing sandbox by ID.
+    def self.connect(sandbox_id, api_key: nil, base_url: nil)
+      config = Superserve.resolve_config(api_key: api_key, base_url: base_url)
+      raw = HTTP.api_request(
+        :get,
+        "#{config.base_url}/sandboxes/#{sandbox_id}",
+        headers: { "X-API-Key" => config.api_key }
+      )
+      token = raw && raw["access_token"]
+      unless token
+        raise SandboxError.new("Invalid API response from GET /sandboxes/{id}: missing access_token")
+      end
+      new(Superserve.to_sandbox_info(raw), token, config)
+    end
+
+    # List all sandboxes belonging to the authenticated team.
+    def self.list(metadata: nil, api_key: nil, base_url: nil)
+      config = Superserve.resolve_config(api_key: api_key, base_url: base_url)
+      url = "#{config.base_url}/sandboxes"
+      if metadata && !metadata.empty?
+        params = metadata.map { |k, v| "metadata.#{ERB::Util.url_encode(k.to_s)}=#{ERB::Util.url_encode(v.to_s)}" }.join("&")
+        url += "?#{params}"
+      end
+      raw = HTTP.api_request(:get, url, headers: { "X-API-Key" => config.api_key })
+      raw.map { |item| Superserve.to_sandbox_info(item) }
+    end
+
+    # Delete a sandbox by ID. Idempotent: a 404 is swallowed.
+    def self.kill_by_id(sandbox_id, api_key: nil, base_url: nil)
+      config = Superserve.resolve_config(api_key: api_key, base_url: base_url)
+      HTTP.api_request(
+        :delete,
+        "#{config.base_url}/sandboxes/#{sandbox_id}",
+        headers: { "X-API-Key" => config.api_key }
+      )
+      nil
+    rescue NotFoundError
+      nil
+    end
+
+    # @api private
+    def self.serialize_network(network)
+      if network.respond_to?(:allow_out)
+        { allow_out: network.allow_out, deny_out: network.deny_out }
+      else
+        { allow_out: network[:allow_out], deny_out: network[:deny_out] }
+      end
+    end
+
+    # ------------------------------------------------------------------
+    # Instance methods
+    # ------------------------------------------------------------------
+
+    # Refresh this sandbox's info from the API.
+    # The instance's own `status`/`metadata` properties are snapshots from
+    # construction and are not mutated — use the return value.
+    def get_info
+      require_live!
+      raw = HTTP.api_request(
+        :get,
+        "#{@config.base_url}/sandboxes/#{@id}",
+        headers: { "X-API-Key" => @config.api_key },
+        connection: @connection
+      )
+      Superserve.to_sandbox_info(raw)
+    end
+
+    # Pause this sandbox. Running processes and file state are preserved.
+    def pause
+      require_live!
+      HTTP.api_request(
+        :post,
+        "#{@config.base_url}/sandboxes/#{@id}/pause",
+        headers: { "X-API-Key" => @config.api_key },
+        connection: @connection
+      )
+      nil
+    end
+
+    # Resume a paused sandbox. The access token is rotated; `sandbox.files`
+    # is rebuilt with the fresh token transparently.
+    def resume
+      require_live!
+      raw = HTTP.api_request(
+        :post,
+        "#{@config.base_url}/sandboxes/#{@id}/resume",
+        headers: { "X-API-Key" => @config.api_key },
+        connection: @connection
+      )
+      token = raw && raw["access_token"]
+      unless token
+        raise SandboxError.new(
+          "Invalid API response from POST /sandboxes/{id}/resume: missing access_token"
+        )
+      end
+      @access_token = token
+      @files = Files.new(@id, @config.sandbox_host, @access_token, connection: @connection)
+      nil
+    end
+
+    # Delete this sandbox and all its resources. Idempotent.
+    def kill
+      return nil if @closed
+      begin
+        HTTP.api_request(
+          :delete,
+          "#{@config.base_url}/sandboxes/#{@id}",
+          headers: { "X-API-Key" => @config.api_key },
+          connection: @connection
+        )
+      rescue NotFoundError
+        # Already deleted
+      ensure
+        @closed = true
+      end
+      nil
+    end
+
+    # Partially update this sandbox (metadata, network rules).
+    def update(metadata: nil, network: nil)
+      require_live!
+      body = {}
+      body[:metadata] = metadata if metadata
+      body[:network] = self.class.serialize_network(network) if network
+
+      HTTP.api_request(
+        :patch,
+        "#{@config.base_url}/sandboxes/#{@id}",
+        headers: { "X-API-Key" => @config.api_key },
+        json_body: body,
+        connection: @connection
+      )
+      nil
+    end
+
+    def to_s
+      "#<Superserve::Sandbox id=#{@id.inspect} name=#{@name.inspect} status=#{@status.inspect}>"
+    end
+    alias inspect to_s
+
+    private
+
+    def require_live!
+      return unless @closed
+      raise SandboxError.new(
+        "Sandbox #{@id.inspect} has been deleted; create or connect to a new one."
+      )
+    end
+  end
+end

--- a/packages/ruby-sdk/lib/superserve/sandbox.rb
+++ b/packages/ruby-sdk/lib/superserve/sandbox.rb
@@ -110,11 +110,16 @@ module Superserve
     end
 
     # @api private
+    # Accepts a NetworkConfig instance or a Hash with either symbol or string
+    # keys (so configs loaded from JSON/YAML work without conversion).
     def self.serialize_network(network)
       if network.respond_to?(:allow_out)
         { allow_out: network.allow_out, deny_out: network.deny_out }
       else
-        { allow_out: network[:allow_out], deny_out: network[:deny_out] }
+        {
+          allow_out: network[:allow_out] || network["allow_out"],
+          deny_out: network[:deny_out] || network["deny_out"]
+        }
       end
     end
 

--- a/packages/ruby-sdk/lib/superserve/template.rb
+++ b/packages/ruby-sdk/lib/superserve/template.rb
@@ -1,0 +1,268 @@
+require "erb"
+
+module Superserve
+  # Template — reusable sandbox base image with build steps.
+  #
+  # Example:
+  #   template = Superserve::Template.create(
+  #     name: "my-python-env",
+  #     from: "python:3.11",
+  #     steps: [{ run: "pip install numpy" }],
+  #   )
+  #   template.wait_until_ready
+  #   sandbox = Superserve::Sandbox.create(name: "run-1", from_template: template)
+  class Template
+    attr_reader :id, :name, :team_id, :status, :vcpu, :memory_mib, :disk_mib,
+                :size_bytes, :error_message, :created_at, :built_at, :latest_build_id
+
+    # @api private — use Template.create / Template.connect.
+    def initialize(info, config)
+      @id = info.id
+      @name = info.name
+      @team_id = info.team_id
+      @status = info.status
+      @vcpu = info.vcpu
+      @memory_mib = info.memory_mib
+      @disk_mib = info.disk_mib
+      @size_bytes = info.size_bytes
+      @error_message = info.error_message
+      @created_at = info.created_at
+      @built_at = info.built_at
+      @latest_build_id = info.latest_build_id
+      @config = config
+    end
+
+    # Create a template and kick off the first build.
+    # `from:` accepts an OCI image reference (e.g. "python:3.11").
+    def self.create(name:, from:, vcpu: nil, memory_mib: nil, disk_mib: nil,
+                    steps: nil, start_cmd: nil, ready_cmd: nil,
+                    api_key: nil, base_url: nil)
+      config = Superserve.resolve_config(api_key: api_key, base_url: base_url)
+
+      build_spec = { from: from }
+      build_spec[:steps] = steps if steps
+      build_spec[:start_cmd] = start_cmd if start_cmd
+      build_spec[:ready_cmd] = ready_cmd if ready_cmd
+
+      body = { name: name, build_spec: build_spec }
+      body[:vcpu] = vcpu if vcpu
+      body[:memory_mib] = memory_mib if memory_mib
+      body[:disk_mib] = disk_mib if disk_mib
+
+      raw = HTTP.api_request(
+        :post,
+        "#{config.base_url}/templates",
+        headers: { "X-API-Key" => config.api_key },
+        json_body: body
+      )
+      build_id = raw && raw["build_id"]
+      unless build_id
+        raise SandboxError.new("Invalid API response from POST /templates: missing build_id")
+      end
+      new(Superserve.to_template_info(raw, build_id), config)
+    end
+
+    # Connect to an existing template by name or ID.
+    def self.connect(name_or_id, api_key: nil, base_url: nil)
+      config = Superserve.resolve_config(api_key: api_key, base_url: base_url)
+      raw = HTTP.api_request(
+        :get,
+        "#{config.base_url}/templates/#{ERB::Util.url_encode(name_or_id)}",
+        headers: { "X-API-Key" => config.api_key }
+      )
+      new(Superserve.to_template_info(raw), config)
+    end
+
+    # List all templates visible to the authenticated team.
+    def self.list(name_prefix: nil, api_key: nil, base_url: nil)
+      config = Superserve.resolve_config(api_key: api_key, base_url: base_url)
+      url = "#{config.base_url}/templates"
+      url += "?name_prefix=#{ERB::Util.url_encode(name_prefix)}" if name_prefix
+      raw = HTTP.api_request(:get, url, headers: { "X-API-Key" => config.api_key })
+      raw.map { |t| Superserve.to_template_info(t) }
+    end
+
+    # Delete a template by name or ID. Idempotent on 404.
+    def self.delete_by_id(name_or_id, api_key: nil, base_url: nil)
+      config = Superserve.resolve_config(api_key: api_key, base_url: base_url)
+      HTTP.api_request(
+        :delete,
+        "#{config.base_url}/templates/#{ERB::Util.url_encode(name_or_id)}",
+        headers: { "X-API-Key" => config.api_key }
+      )
+      nil
+    rescue NotFoundError
+      nil
+    end
+
+    # ------------------------------------------------------------------
+    # Instance methods
+    # ------------------------------------------------------------------
+
+    def get_info
+      raw = HTTP.api_request(
+        :get,
+        "#{@config.base_url}/templates/#{ERB::Util.url_encode(@id)}",
+        headers: { "X-API-Key" => @config.api_key }
+      )
+      Superserve.to_template_info(raw)
+    end
+
+    # Delete this template. Idempotent on 404.
+    # Raises ConflictError if sandboxes reference it.
+    def delete
+      HTTP.api_request(
+        :delete,
+        "#{@config.base_url}/templates/#{ERB::Util.url_encode(@id)}",
+        headers: { "X-API-Key" => @config.api_key }
+      )
+      nil
+    rescue NotFoundError
+      nil
+    end
+
+    # Queue a new build for this template. Idempotent on spec hash.
+    def rebuild
+      raw = HTTP.api_request(
+        :post,
+        "#{@config.base_url}/templates/#{ERB::Util.url_encode(@id)}/builds",
+        headers: { "X-API-Key" => @config.api_key }
+      )
+      Superserve.to_template_build_info(raw)
+    end
+
+    def list_builds(limit: nil)
+      url = "#{@config.base_url}/templates/#{ERB::Util.url_encode(@id)}/builds"
+      url += "?limit=#{limit}" if limit
+      raw = HTTP.api_request(:get, url, headers: { "X-API-Key" => @config.api_key })
+      raw.map { |b| Superserve.to_template_build_info(b) }
+    end
+
+    def get_build(build_id)
+      raw = HTTP.api_request(
+        :get,
+        "#{@config.base_url}/templates/#{ERB::Util.url_encode(@id)}/builds/#{ERB::Util.url_encode(build_id)}",
+        headers: { "X-API-Key" => @config.api_key }
+      )
+      Superserve.to_template_build_info(raw)
+    end
+
+    def cancel_build(build_id)
+      HTTP.api_request(
+        :delete,
+        "#{@config.base_url}/templates/#{ERB::Util.url_encode(@id)}/builds/#{ERB::Util.url_encode(build_id)}",
+        headers: { "X-API-Key" => @config.api_key }
+      )
+      nil
+    rescue NotFoundError
+      nil
+    end
+
+    # Stream build logs (SSE) for this template.
+    # Yields BuildLogEvent for each event, or accepts an `on_event:` proc.
+    def stream_build_logs(on_event:, build_id: nil)
+      bid = resolve_build_id(build_id)
+      HTTP.stream_sse(
+        "#{@config.base_url}/templates/#{ERB::Util.url_encode(@id)}/builds/#{ERB::Util.url_encode(bid)}/logs",
+        headers: { "X-API-Key" => @config.api_key },
+        method: :get
+      ) do |raw|
+        on_event.call(Superserve.to_build_log_event(raw))
+      end
+    end
+
+    # Block until the build reaches terminal state.
+    #
+    # Polls `GET /templates/{id}/builds/{bid}` (the DB-backed build row) as
+    # the source of truth. SSE is only used for live log delivery when
+    # `on_log:` is passed (it is consumed first; the stream returns when
+    # the build emits its terminal event).
+    #
+    # Raises BuildError on `failed`, ConflictError on `cancelled`.
+    def wait_until_ready(on_log: nil, poll_interval_s: 2.0)
+      bid = nil
+      begin
+        bid = resolve_build_id(nil)
+      rescue SandboxError
+        bid = nil
+      end
+
+      # SSE for live logs only. The server emits `finished:true,
+      # status:"ready"` the instant the builder finishes, but the DB row
+      # that POST /sandboxes reads is updated by a separate ~1s poller.
+      # Treating SSE as the terminal-state signal would race that update
+      # and leave callers seeing 409 "template is not ready" on the very
+      # next request. Source of truth is the DB-backed build endpoint.
+      if bid && on_log
+        begin
+          HTTP.stream_sse(
+            "#{@config.base_url}/templates/#{ERB::Util.url_encode(@id)}/builds/#{ERB::Util.url_encode(bid)}/logs",
+            headers: { "X-API-Key" => @config.api_key },
+            method: :get
+          ) do |raw|
+            on_log.call(Superserve.to_build_log_event(raw))
+          end
+        rescue StandardError
+          # SSE failures are non-fatal — polling drives terminal detection.
+        end
+      end
+
+      if bid
+        loop do
+          build = get_build(bid)
+          case build.status
+          when TemplateBuildStatus::READY
+            return get_info
+          when TemplateBuildStatus::FAILED
+            code, msg = self.class.send(:parse_build_error, build.error_message)
+            raise BuildError.new(msg, code: code, build_id: bid, template_id: @id)
+          when TemplateBuildStatus::CANCELLED
+            raise ConflictError.new("template build was cancelled", code: "cancelled")
+          end
+          sleep(poll_interval_s)
+        end
+      end
+
+      # No build_id — rare path; poll template status as a best effort.
+      loop do
+        info = get_info
+        case info.status
+        when TemplateStatus::READY
+          return info
+        when TemplateStatus::FAILED
+          code, msg = self.class.send(:parse_build_error, info.error_message)
+          raise BuildError.new(msg, code: code, build_id: "", template_id: @id)
+        end
+        sleep(poll_interval_s)
+      end
+    end
+
+    def to_s
+      "#<Superserve::Template id=#{@id.inspect} name=#{@name.inspect} status=#{@status.inspect}>"
+    end
+    alias inspect to_s
+
+    # @api private
+    def self.parse_build_error(msg)
+      return ["build_failed", "Template build failed"] if msg.nil? || msg.empty?
+      match = /\A(\w+):\s*(.*)\z/m.match(msg)
+      if match && !match[2].strip.empty?
+        [match[1], match[2].strip]
+      else
+        ["build_failed", msg]
+      end
+    end
+
+    private
+
+    def resolve_build_id(build_id)
+      return build_id if build_id
+      return @latest_build_id if @latest_build_id
+      recent = list_builds(limit: 1)
+      if recent.empty?
+        raise SandboxError.new("Template #{@name} has no builds — call rebuild first")
+      end
+      recent.first.id
+    end
+  end
+end

--- a/packages/ruby-sdk/lib/superserve/types.rb
+++ b/packages/ruby-sdk/lib/superserve/types.rb
@@ -1,0 +1,151 @@
+require "time"
+
+module Superserve
+  # Sandbox status — string values matching API enum.
+  module SandboxStatus
+    ACTIVE = "active".freeze
+    PAUSED = "paused".freeze
+    RESUMING = "resuming".freeze
+    FAILED = "failed".freeze
+    ALL = [ACTIVE, PAUSED, RESUMING, FAILED].freeze
+  end
+
+  module TemplateStatus
+    PENDING = "pending".freeze
+    BUILDING = "building".freeze
+    READY = "ready".freeze
+    FAILED = "failed".freeze
+    ALL = [PENDING, BUILDING, READY, FAILED].freeze
+  end
+
+  module TemplateBuildStatus
+    PENDING = "pending".freeze
+    BUILDING = "building".freeze
+    SNAPSHOTTING = "snapshotting".freeze
+    READY = "ready".freeze
+    FAILED = "failed".freeze
+    CANCELLED = "cancelled".freeze
+    ALL = [PENDING, BUILDING, SNAPSHOTTING, READY, FAILED, CANCELLED].freeze
+  end
+
+  module BuildLogStream
+    STDOUT = "stdout".freeze
+    STDERR = "stderr".freeze
+    SYSTEM = "system".freeze
+    ALL = [STDOUT, STDERR, SYSTEM].freeze
+  end
+
+  NetworkConfig = Data.define(:allow_out, :deny_out)
+
+  SandboxInfo = Data.define(
+    :id, :name, :status, :vcpu_count, :memory_mib,
+    :created_at, :timeout_seconds, :network, :metadata
+  )
+
+  CommandResult = Data.define(:stdout, :stderr, :exit_code)
+
+  TemplateInfo = Data.define(
+    :id, :name, :team_id, :status, :vcpu, :memory_mib, :disk_mib,
+    :size_bytes, :error_message, :created_at, :built_at, :latest_build_id
+  )
+
+  TemplateBuildInfo = Data.define(
+    :id, :template_id, :status, :build_spec_hash,
+    :error_message, :started_at, :finalized_at, :created_at
+  )
+
+  BuildLogEvent = Data.define(:timestamp, :stream, :text, :finished, :status)
+
+  # BuildStep variants are plain hashes — Ruby is duck-typed, no validation enforced:
+  #   { run: "echo hello" }
+  #   { env: { key: "FOO", value: "bar" } }
+  #   { workdir: "/app" }
+  #   { user: { name: "deploy", sudo: true } }
+
+  # Parse an ISO 8601 / RFC 3339 datetime string. Handles trailing "Z" UTC.
+  def self.parse_iso8601(value)
+    return nil if value.nil?
+    Time.iso8601(value)
+  end
+
+  def self.to_sandbox_info(raw)
+    raise SandboxError.new("Invalid API response: missing sandbox id") unless raw["id"]
+    raise SandboxError.new("Invalid API response: missing sandbox status") unless raw["status"]
+    raise SandboxError.new("Invalid API response: missing created_at") unless raw["created_at"]
+
+    network = nil
+    if raw["network"].is_a?(Hash)
+      network = NetworkConfig.new(
+        allow_out: raw["network"]["allow_out"],
+        deny_out: raw["network"]["deny_out"]
+      )
+    end
+
+    SandboxInfo.new(
+      id: raw["id"],
+      name: raw["name"] || "",
+      status: raw["status"],
+      vcpu_count: raw["vcpu_count"] || 0,
+      memory_mib: raw["memory_mib"] || 0,
+      created_at: parse_iso8601(raw["created_at"]),
+      timeout_seconds: raw["timeout_seconds"],
+      network: network,
+      metadata: raw["metadata"] || {}
+    )
+  end
+
+  def self.to_template_info(raw, latest_build_id = nil)
+    raise SandboxError.new("Invalid API response: missing template id") unless raw["id"]
+    raise SandboxError.new("Invalid API response: missing template name") unless raw["name"]
+    raise SandboxError.new("Invalid API response: missing template status") unless raw["status"]
+    raise SandboxError.new("Invalid API response: missing team_id") unless raw["team_id"]
+    raise SandboxError.new("Invalid API response: missing created_at") unless raw["created_at"]
+
+    TemplateInfo.new(
+      id: raw["id"],
+      name: raw["name"],
+      team_id: raw["team_id"],
+      status: raw["status"],
+      vcpu: raw["vcpu"] || 0,
+      memory_mib: raw["memory_mib"] || 0,
+      disk_mib: raw["disk_mib"] || 0,
+      size_bytes: raw["size_bytes"],
+      error_message: raw["error_message"],
+      created_at: parse_iso8601(raw["created_at"]),
+      built_at: parse_iso8601(raw["built_at"]),
+      latest_build_id: latest_build_id || raw["latest_build_id"]
+    )
+  end
+
+  def self.to_template_build_info(raw)
+    raise SandboxError.new("Invalid API response: missing build id") unless raw["id"]
+    raise SandboxError.new("Invalid API response: missing template_id") unless raw["template_id"]
+    raise SandboxError.new("Invalid API response: missing build status") unless raw["status"]
+    raise SandboxError.new("Invalid API response: missing build_spec_hash") unless raw["build_spec_hash"]
+    raise SandboxError.new("Invalid API response: missing created_at") unless raw["created_at"]
+
+    TemplateBuildInfo.new(
+      id: raw["id"],
+      template_id: raw["template_id"],
+      status: raw["status"],
+      build_spec_hash: raw["build_spec_hash"],
+      error_message: raw["error_message"],
+      started_at: parse_iso8601(raw["started_at"]),
+      finalized_at: parse_iso8601(raw["finalized_at"]),
+      created_at: parse_iso8601(raw["created_at"])
+    )
+  end
+
+  def self.to_build_log_event(raw)
+    raise SandboxError.new("Invalid log event: missing timestamp") unless raw["timestamp"]
+    raise SandboxError.new("Invalid log event: missing stream") unless raw["stream"]
+
+    BuildLogEvent.new(
+      timestamp: parse_iso8601(raw["timestamp"]),
+      stream: raw["stream"],
+      text: raw["text"] || "",
+      finished: raw["finished"],
+      status: raw["status"]
+    )
+  end
+end

--- a/packages/ruby-sdk/lib/superserve/version.rb
+++ b/packages/ruby-sdk/lib/superserve/version.rb
@@ -1,0 +1,3 @@
+module Superserve
+  VERSION = "0.1.0".freeze
+end

--- a/packages/ruby-sdk/package.json
+++ b/packages/ruby-sdk/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@superserve/ruby-sdk",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build": "bundle exec rake build",
+    "test": "bundle exec rspec",
+    "lint": "echo 'lint: no-op (rubocop not configured)' && exit 0",
+    "typecheck": "echo 'typecheck: no-op (Ruby is duck-typed; no static checker configured)' && exit 0"
+  }
+}

--- a/packages/ruby-sdk/spec/commands_spec.rb
+++ b/packages/ruby-sdk/spec/commands_spec.rb
@@ -1,0 +1,91 @@
+RSpec.describe Superserve::Commands do
+  let(:commands) { described_class.new("https://api.test.local", "sb_1", "ss_live_test_key") }
+
+  describe "sync mode" do
+    it "POSTs to /exec and returns CommandResult" do
+      stub = stub_request(:post, "https://api.test.local/sandboxes/sb_1/exec")
+        .with(
+          body: { command: "echo hi" }.to_json,
+          headers: { "X-API-Key" => "ss_live_test_key", "Content-Type" => "application/json" }
+        )
+        .to_return(status: 200, body: { stdout: "hi\n", stderr: "", exit_code: 0 }.to_json)
+      result = commands.run("echo hi")
+      expect(stub).to have_been_requested
+      expect(result.stdout).to eq("hi\n")
+      expect(result.exit_code).to eq(0)
+    end
+
+    it "passes cwd, env, timeout_s in body" do
+      stub = stub_request(:post, "https://api.test.local/sandboxes/sb_1/exec")
+        .with(body: { command: "ls", working_dir: "/app", env: { "X" => "1" }, timeout_s: 60 }.to_json)
+        .to_return(status: 200, body: { stdout: "", stderr: "", exit_code: 0 }.to_json)
+      commands.run("ls", cwd: "/app", env: { "X" => "1" }, timeout_seconds: 60)
+      expect(stub).to have_been_requested
+    end
+
+    it "fills defaults when fields are absent in response" do
+      stub_request(:post, "https://api.test.local/sandboxes/sb_1/exec")
+        .to_return(status: 200, body: "{}")
+      result = commands.run("x")
+      expect(result.stdout).to eq("")
+      expect(result.stderr).to eq("")
+      expect(result.exit_code).to eq(0)
+    end
+  end
+
+  describe "streaming mode" do
+    let(:sse_body) {
+      [
+        %(data: {"stdout":"hello\\n"}),
+        %(data: {"stderr":"warn\\n"}),
+        %(data: {"finished":true,"exit_code":0}),
+        ""
+      ].join("\n")
+    }
+
+    it "fires on_stdout/on_stderr and aggregates result" do
+      stub_request(:post, "https://api.test.local/sandboxes/sb_1/exec/stream")
+        .to_return(status: 200, body: sse_body, headers: { "Content-Type" => "text/event-stream" })
+
+      seen_stdout = []
+      seen_stderr = []
+      result = commands.run(
+        "x",
+        on_stdout: ->(d) { seen_stdout << d },
+        on_stderr: ->(d) { seen_stderr << d }
+      )
+
+      expect(seen_stdout.join).to eq("hello\n")
+      expect(seen_stderr.join).to eq("warn\n")
+      expect(result.stdout).to eq("hello\n")
+      expect(result.stderr).to eq("warn\n")
+      expect(result.exit_code).to eq(0)
+    end
+
+    it "raises if stream ends without a finished event" do
+      truncated = [
+        %(data: {"stdout":"hi"}),
+        ""
+      ].join("\n")
+      stub_request(:post, "https://api.test.local/sandboxes/sb_1/exec/stream")
+        .to_return(status: 200, body: truncated)
+
+      expect {
+        commands.run("x", on_stdout: ->(_) {})
+      }.to raise_error(Superserve::SandboxError, /finished event/)
+    end
+
+    it "appends finished-event error into stderr" do
+      body = [
+        %(data: {"finished":true,"exit_code":137,"error":"killed"}),
+        ""
+      ].join("\n")
+      stub_request(:post, "https://api.test.local/sandboxes/sb_1/exec/stream")
+        .to_return(status: 200, body: body)
+
+      result = commands.run("x", on_stdout: ->(_) {})
+      expect(result.exit_code).to eq(137)
+      expect(result.stderr).to eq("killed")
+    end
+  end
+end

--- a/packages/ruby-sdk/spec/config_spec.rb
+++ b/packages/ruby-sdk/spec/config_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe "Superserve.resolve_config" do
+  it "resolves api_key from explicit arg" do
+    cfg = Superserve.resolve_config(api_key: "explicit", base_url: "https://api.superserve.ai")
+    expect(cfg.api_key).to eq("explicit")
+    expect(cfg.base_url).to eq("https://api.superserve.ai")
+  end
+
+  it "falls back to SUPERSERVE_API_KEY env" do
+    cfg = Superserve.resolve_config
+    expect(cfg.api_key).to eq("ss_live_test_key")
+  end
+
+  it "raises AuthenticationError when no key is available" do
+    ENV.delete("SUPERSERVE_API_KEY")
+    expect { Superserve.resolve_config }.to raise_error(Superserve::AuthenticationError)
+  end
+
+  it "uses default base_url when none provided" do
+    ENV.delete("SUPERSERVE_BASE_URL")
+    cfg = Superserve.resolve_config(api_key: "x")
+    expect(cfg.base_url).to eq("https://api.superserve.ai")
+  end
+
+  describe "sandbox_host derivation" do
+    it "derives sandbox.superserve.ai from production base_url" do
+      cfg = Superserve.resolve_config(api_key: "x", base_url: "https://api.superserve.ai")
+      expect(cfg.sandbox_host).to eq("sandbox.superserve.ai")
+    end
+
+    it "derives sandbox-staging from staging base_url" do
+      cfg = Superserve.resolve_config(api_key: "x", base_url: "https://api-staging.superserve.ai")
+      expect(cfg.sandbox_host).to eq("sandbox-staging.superserve.ai")
+    end
+
+    it "uses safe default for any other URL" do
+      cfg = Superserve.resolve_config(api_key: "x", base_url: "https://api.test.local")
+      expect(cfg.sandbox_host).to eq("sandbox.superserve.ai")
+    end
+  end
+end
+
+RSpec.describe "Superserve.data_plane_url" do
+  it "builds the boxd-prefixed URL" do
+    expect(Superserve.data_plane_url("sb_xyz", "sandbox.superserve.ai"))
+      .to eq("https://boxd-sb_xyz.sandbox.superserve.ai")
+  end
+end

--- a/packages/ruby-sdk/spec/errors_spec.rb
+++ b/packages/ruby-sdk/spec/errors_spec.rb
@@ -1,0 +1,86 @@
+RSpec.describe "Superserve errors" do
+  describe "class hierarchy" do
+    it "all derive from SandboxError" do
+      [
+        Superserve::AuthenticationError,
+        Superserve::ValidationError,
+        Superserve::NotFoundError,
+        Superserve::ConflictError,
+        Superserve::RateLimitError,
+        Superserve::ServerError,
+        Superserve::TimeoutError,
+        Superserve::BuildError
+      ].each do |klass|
+        expect(klass.ancestors).to include(Superserve::SandboxError)
+      end
+    end
+
+    it "SandboxError carries status_code, code, message" do
+      err = Superserve::SandboxError.new("boom", status_code: 500, code: "x")
+      expect(err.message).to eq("boom")
+      expect(err.status_code).to eq(500)
+      expect(err.code).to eq("x")
+    end
+
+    it "BuildError carries build_id, template_id, code" do
+      err = Superserve::BuildError.new("fail", code: "step_failed", build_id: "b1", template_id: "t1")
+      expect(err.code).to eq("step_failed")
+      expect(err.build_id).to eq("b1")
+      expect(err.template_id).to eq("t1")
+    end
+  end
+
+  describe ".map_api_error" do
+    it "maps 400 to ValidationError" do
+      err = Superserve.map_api_error(400, { "error" => { "message" => "bad" } })
+      expect(err).to be_a(Superserve::ValidationError)
+      expect(err.message).to eq("bad")
+    end
+
+    it "maps 401 and 403 to AuthenticationError" do
+      [401, 403].each do |status|
+        err = Superserve.map_api_error(status, {})
+        expect(err).to be_a(Superserve::AuthenticationError)
+        expect(err.status_code).to eq(status)
+      end
+    end
+
+    it "maps 404 to NotFoundError" do
+      err = Superserve.map_api_error(404, {})
+      expect(err).to be_a(Superserve::NotFoundError)
+    end
+
+    it "maps 409 to ConflictError" do
+      err = Superserve.map_api_error(409, {})
+      expect(err).to be_a(Superserve::ConflictError)
+    end
+
+    it "maps 429 to RateLimitError preserving code" do
+      err = Superserve.map_api_error(429, { "error" => { "code" => "too_many_sandboxes" } })
+      expect(err).to be_a(Superserve::RateLimitError)
+      expect(err.code).to eq("too_many_sandboxes")
+    end
+
+    it "maps 5xx to ServerError" do
+      err = Superserve.map_api_error(500, {})
+      expect(err).to be_a(Superserve::ServerError)
+    end
+
+    it "falls back to SandboxError for other statuses" do
+      err = Superserve.map_api_error(418, {})
+      expect(err).to be_a(Superserve::SandboxError)
+      expect(err).not_to be_a(Superserve::ValidationError)
+      expect(err.status_code).to eq(418)
+    end
+
+    it "uses default message when error.message is missing" do
+      err = Superserve.map_api_error(400, {})
+      expect(err.message).to include("400")
+    end
+
+    it "tolerates non-Hash bodies" do
+      expect { Superserve.map_api_error(400, nil) }.not_to raise_error
+      expect { Superserve.map_api_error(400, "garbage") }.not_to raise_error
+    end
+  end
+end

--- a/packages/ruby-sdk/spec/files_spec.rb
+++ b/packages/ruby-sdk/spec/files_spec.rb
@@ -1,0 +1,58 @@
+RSpec.describe Superserve::Files do
+  let(:files) { described_class.new("sb_1", "sandbox.test.local", "tok") }
+  let(:base) { "https://boxd-sb_1.sandbox.test.local" }
+
+  describe "path validation" do
+    it "rejects paths not starting with /" do
+      expect { files.write("relative", "x") }.to raise_error(Superserve::ValidationError, /must start with/)
+      expect { files.read("relative") }.to raise_error(Superserve::ValidationError)
+    end
+
+    it "rejects paths containing .. segments" do
+      expect { files.write("/a/../b", "x") }.to raise_error(Superserve::ValidationError, /must not contain/)
+      expect { files.read("/../etc/passwd") }.to raise_error(Superserve::ValidationError)
+    end
+
+    it "accepts absolute paths" do
+      stub_request(:post, "#{base}/files?path=%2Fapp%2Fdata.txt").to_return(status: 204)
+      expect { files.write("/app/data.txt", "hello") }.not_to raise_error
+    end
+  end
+
+  describe "#write" do
+    it "POSTs to the data plane with X-Access-Token" do
+      stub = stub_request(:post, "#{base}/files?path=%2Fa.txt")
+        .with(headers: { "X-Access-Token" => "tok", "Content-Type" => "application/octet-stream" })
+        .to_return(status: 204)
+      files.write("/a.txt", "content")
+      expect(stub).to have_been_requested
+    end
+
+    it "URL-encodes path with spaces and special chars" do
+      stub = stub_request(:post, "#{base}/files?path=%2Fmy%20file.txt").to_return(status: 204)
+      files.write("/my file.txt", "x")
+      expect(stub).to have_been_requested
+    end
+
+    it "writes binary content as bytes" do
+      bin = "\x00\x01\x02\xFF".b
+      stub = stub_request(:post, "#{base}/files?path=%2Fbin").with(body: bin).to_return(status: 204)
+      files.write("/bin", bin)
+      expect(stub).to have_been_requested
+    end
+  end
+
+  describe "#read" do
+    it "GETs raw bytes" do
+      stub_request(:get, "#{base}/files?path=%2Fr.txt").to_return(status: 200, body: "hello")
+      expect(files.read("/r.txt")).to eq("hello")
+    end
+  end
+
+  describe "#read_text" do
+    it "decodes UTF-8 bytes to string" do
+      stub_request(:get, "#{base}/files?path=%2Ft.txt").to_return(status: 200, body: "héllo")
+      expect(files.read_text("/t.txt")).to eq("héllo")
+    end
+  end
+end

--- a/packages/ruby-sdk/spec/http_spec.rb
+++ b/packages/ruby-sdk/spec/http_spec.rb
@@ -1,0 +1,160 @@
+RSpec.describe Superserve::HTTP do
+  describe ".compute_backoff" do
+    it "scales with attempt and stays within ±20% of base" do
+      [
+        [1, 0.1],
+        [2, 0.2],
+        [3, 0.4]
+      ].each do |attempt, expected_base|
+        50.times do
+          v = described_class.compute_backoff(attempt)
+          expect(v).to be >= expected_base * 0.8
+          expect(v).to be <= expected_base * 1.2 + 1e-9
+        end
+      end
+    end
+
+    it "caps at MAX_BACKOFF" do
+      v = described_class.compute_backoff(20) # 0.1 * 2^19 way over cap
+      expect(v).to be <= Superserve::HTTP::MAX_BACKOFF
+    end
+  end
+
+  describe ".parse_retry_after" do
+    it "parses numeric seconds" do
+      expect(described_class.parse_retry_after("5")).to eq(5.0)
+    end
+
+    it "parses HTTP-date" do
+      future = (Time.now + 30).httpdate
+      v = described_class.parse_retry_after(future)
+      expect(v).to be > 0
+      expect(v).to be <= 30
+    end
+
+    it "returns 0 for past dates" do
+      past = (Time.now - 100).httpdate
+      expect(described_class.parse_retry_after(past)).to eq(0.0)
+    end
+
+    it "caps at MAX_BACKOFF" do
+      expect(described_class.parse_retry_after("999999")).to eq(Superserve::HTTP::MAX_BACKOFF)
+    end
+
+    it "returns nil for invalid values" do
+      expect(described_class.parse_retry_after(nil)).to be_nil
+      expect(described_class.parse_retry_after("")).to be_nil
+      expect(described_class.parse_retry_after("garbage")).to be_nil
+    end
+  end
+
+  describe ".api_request" do
+    it "returns parsed JSON on 2xx" do
+      stub_request(:get, "https://api.test.local/x")
+        .to_return(status: 200, body: '{"ok":true}', headers: { "Content-Type" => "application/json" })
+
+      result = described_class.api_request(:get, "https://api.test.local/x", headers: {})
+      expect(result).to eq({ "ok" => true })
+    end
+
+    it "returns nil for 204" do
+      stub_request(:post, "https://api.test.local/x").to_return(status: 204)
+      expect(described_class.api_request(:post, "https://api.test.local/x", headers: {})).to be_nil
+    end
+
+    it "raises mapped error on non-2xx" do
+      stub_request(:get, "https://api.test.local/missing")
+        .to_return(status: 404, body: '{"error":{"message":"nope"}}')
+      expect {
+        described_class.api_request(:get, "https://api.test.local/missing", headers: {})
+      }.to raise_error(Superserve::NotFoundError, /nope/)
+    end
+
+    it "retries GET on 503 and succeeds on second attempt" do
+      stub_request(:get, "https://api.test.local/flaky")
+        .to_return({ status: 503, body: "{}" }, { status: 200, body: '{"ok":1}' })
+
+      allow(described_class).to receive(:compute_backoff).and_return(0)
+      result = described_class.api_request(:get, "https://api.test.local/flaky", headers: {})
+      expect(result).to eq({ "ok" => 1 })
+      expect(WebMock).to have_requested(:get, "https://api.test.local/flaky").times(2)
+    end
+
+    it "does NOT retry POST on 503 (not idempotent)" do
+      stub_request(:post, "https://api.test.local/post-flaky")
+        .to_return(status: 503, body: '{"error":{"message":"down"}}')
+      allow(described_class).to receive(:compute_backoff).and_return(0)
+      expect {
+        described_class.api_request(:post, "https://api.test.local/post-flaky", headers: {}, json_body: {})
+      }.to raise_error(Superserve::ServerError)
+      expect(WebMock).to have_requested(:post, "https://api.test.local/post-flaky").once
+    end
+
+    it "honors Retry-After header on 429" do
+      stub_request(:get, "https://api.test.local/limited").to_return(
+        { status: 429, headers: { "Retry-After" => "0" }, body: "{}" },
+        { status: 200, body: '{"ok":1}' }
+      )
+      allow(described_class).to receive(:compute_backoff).and_return(0)
+      result = described_class.api_request(:get, "https://api.test.local/limited", headers: {})
+      expect(result).to eq({ "ok" => 1 })
+    end
+
+    it "stops after MAX_ATTEMPTS retries" do
+      stub_request(:get, "https://api.test.local/dead").to_return(status: 503, body: "{}")
+      allow(described_class).to receive(:compute_backoff).and_return(0)
+      expect {
+        described_class.api_request(:get, "https://api.test.local/dead", headers: {})
+      }.to raise_error(Superserve::ServerError)
+      expect(WebMock).to have_requested(:get, "https://api.test.local/dead")
+        .times(Superserve::HTTP::MAX_ATTEMPTS)
+    end
+
+    it "sets the User-Agent header" do
+      stub = stub_request(:get, "https://api.test.local/ua").to_return(status: 200, body: "{}")
+      described_class.api_request(:get, "https://api.test.local/ua", headers: {})
+      expect(stub).to have_been_requested
+      expect(WebMock).to have_requested(:get, "https://api.test.local/ua")
+        .with(headers: { "User-Agent" => Superserve::HTTP::USER_AGENT })
+    end
+  end
+
+  describe ".upload_bytes" do
+    it "POSTs raw bytes with octet-stream content-type" do
+      stub = stub_request(:post, "https://boxd-x.sandbox.superserve.ai/files?path=%2Fa")
+        .with(headers: { "Content-Type" => "application/octet-stream" }, body: "hello")
+        .to_return(status: 204)
+      described_class.upload_bytes(
+        "https://boxd-x.sandbox.superserve.ai/files?path=%2Fa",
+        headers: {},
+        content: "hello"
+      )
+      expect(stub).to have_been_requested
+    end
+
+    it "does NOT retry on 503 (POST is non-idempotent)" do
+      stub_request(:post, "https://x.test/up").to_return(status: 503, body: "{}")
+      expect {
+        described_class.upload_bytes("https://x.test/up", headers: {}, content: "x")
+      }.to raise_error(Superserve::ServerError)
+      expect(WebMock).to have_requested(:post, "https://x.test/up").once
+    end
+  end
+
+  describe ".download_bytes" do
+    it "GETs raw bytes" do
+      stub_request(:get, "https://x.test/dl").to_return(status: 200, body: "binary data")
+      result = described_class.download_bytes("https://x.test/dl", headers: {})
+      expect(result).to eq("binary data")
+    end
+
+    it "retries on transient failures" do
+      stub_request(:get, "https://x.test/dl-flaky").to_return(
+        { status: 502, body: "" },
+        { status: 200, body: "ok" }
+      )
+      allow(described_class).to receive(:compute_backoff).and_return(0)
+      expect(described_class.download_bytes("https://x.test/dl-flaky", headers: {})).to eq("ok")
+    end
+  end
+end

--- a/packages/ruby-sdk/spec/sandbox_spec.rb
+++ b/packages/ruby-sdk/spec/sandbox_spec.rb
@@ -1,0 +1,132 @@
+RSpec.describe Superserve::Sandbox do
+  let(:base) { "https://api.test.local" }
+
+  describe ".create" do
+    it "POSTs to /sandboxes and returns a sandbox" do
+      stub_request(:post, "#{base}/sandboxes")
+        .with(
+          body: { name: "test" }.to_json,
+          headers: { "X-API-Key" => "ss_live_test_key" }
+        )
+        .to_return(status: 200, body: sandbox_response.to_json)
+      sandbox = described_class.create(name: "test")
+      expect(sandbox).to be_a(Superserve::Sandbox)
+      expect(sandbox.id).to eq("sb_123")
+      expect(sandbox.commands).to be_a(Superserve::Commands)
+      expect(sandbox.files).to be_a(Superserve::Files)
+    end
+
+    it "passes optional fields when provided" do
+      stub = stub_request(:post, "#{base}/sandboxes")
+        .with(body: hash_including(
+          "name" => "x",
+          "from_template" => "node22",
+          "timeout_seconds" => 600,
+          "metadata" => { "k" => "v" },
+          "env_vars" => { "FOO" => "bar" }
+        ))
+        .to_return(status: 200, body: sandbox_response.to_json)
+      described_class.create(
+        name: "x",
+        from_template: "node22",
+        timeout_seconds: 600,
+        metadata: { "k" => "v" },
+        env_vars: { "FOO" => "bar" }
+      )
+      expect(stub).to have_been_requested
+    end
+
+    it "raises when access_token is missing" do
+      stub_request(:post, "#{base}/sandboxes")
+        .to_return(status: 200, body: sandbox_response.merge("access_token" => nil).to_json)
+      expect {
+        described_class.create(name: "x")
+      }.to raise_error(Superserve::SandboxError, /missing access_token/)
+    end
+  end
+
+  describe ".connect" do
+    it "GETs /sandboxes/{id}" do
+      stub_request(:get, "#{base}/sandboxes/sb_xyz")
+        .to_return(status: 200, body: sandbox_response("id" => "sb_xyz").to_json)
+      sandbox = described_class.connect("sb_xyz")
+      expect(sandbox.id).to eq("sb_xyz")
+    end
+  end
+
+  describe ".list" do
+    it "GETs /sandboxes and maps results" do
+      stub_request(:get, "#{base}/sandboxes")
+        .to_return(status: 200, body: [sandbox_response].to_json)
+      list = described_class.list
+      expect(list.length).to eq(1)
+      expect(list.first.id).to eq("sb_123")
+    end
+
+    it "encodes metadata filter as query params" do
+      stub = stub_request(:get, "#{base}/sandboxes?metadata.env=prod")
+        .to_return(status: 200, body: "[]")
+      described_class.list(metadata: { "env" => "prod" })
+      expect(stub).to have_been_requested
+    end
+  end
+
+  describe ".kill_by_id" do
+    it "DELETEs and is idempotent on 404" do
+      stub_request(:delete, "#{base}/sandboxes/sb_xyz").to_return(status: 404, body: "{}")
+      expect { described_class.kill_by_id("sb_xyz") }.not_to raise_error
+    end
+
+    it "raises on non-404 errors" do
+      stub_request(:delete, "#{base}/sandboxes/sb_xyz").to_return(status: 500, body: "{}")
+      expect { described_class.kill_by_id("sb_xyz") }.to raise_error(Superserve::ServerError)
+    end
+  end
+
+  describe "instance lifecycle" do
+    let(:sandbox) {
+      stub_request(:post, "#{base}/sandboxes").to_return(status: 200, body: sandbox_response.to_json)
+      described_class.create(name: "x")
+    }
+
+    it "#pause sends POST /pause" do
+      stub = stub_request(:post, "#{base}/sandboxes/sb_123/pause").to_return(status: 204)
+      sandbox.pause
+      expect(stub).to have_been_requested
+    end
+
+    it "#resume rotates the access token and rebuilds files" do
+      stub_request(:post, "#{base}/sandboxes/sb_123/resume")
+        .to_return(status: 200, body: { "id" => "sb_123", "status" => "active", "access_token" => "tok_new" }.to_json)
+      original_files = sandbox.files
+      sandbox.resume
+      expect(sandbox.files).not_to equal(original_files)
+    end
+
+    it "#kill is idempotent on 404 and marks closed" do
+      stub_request(:delete, "#{base}/sandboxes/sb_123").to_return(status: 404)
+      sandbox.kill
+      expect { sandbox.pause }.to raise_error(Superserve::SandboxError, /has been deleted/)
+    end
+
+    it "#kill swallows 404 silently" do
+      stub_request(:delete, "#{base}/sandboxes/sb_123").to_return(status: 404)
+      expect { sandbox.kill }.not_to raise_error
+    end
+
+    it "#update PATCHes metadata and network" do
+      stub = stub_request(:patch, "#{base}/sandboxes/sb_123")
+        .with(body: hash_including("metadata" => { "k" => "v" }))
+        .to_return(status: 204)
+      sandbox.update(metadata: { "k" => "v" })
+      expect(stub).to have_been_requested
+    end
+
+    it "#get_info returns fresh info" do
+      stub_request(:get, "#{base}/sandboxes/sb_123").to_return(status: 200, body: sandbox_response("status" => "paused").to_json)
+      info = sandbox.get_info
+      expect(info.status).to eq("paused")
+      expect(sandbox.status).to eq("active") # snapshot is unchanged
+    end
+  end
+end

--- a/packages/ruby-sdk/spec/sandbox_spec.rb
+++ b/packages/ruby-sdk/spec/sandbox_spec.rb
@@ -43,6 +43,22 @@ RSpec.describe Superserve::Sandbox do
         described_class.create(name: "x")
       }.to raise_error(Superserve::SandboxError, /missing access_token/)
     end
+
+    it "accepts a network hash with symbol keys" do
+      stub = stub_request(:post, "#{base}/sandboxes")
+        .with(body: hash_including("network" => { "allow_out" => ["1.2.3.4"], "deny_out" => nil }))
+        .to_return(status: 200, body: sandbox_response.to_json)
+      described_class.create(name: "x", network: { allow_out: ["1.2.3.4"] })
+      expect(stub).to have_been_requested
+    end
+
+    it "accepts a network hash with string keys (JSON/YAML configs)" do
+      stub = stub_request(:post, "#{base}/sandboxes")
+        .with(body: hash_including("network" => { "allow_out" => ["5.6.7.8"], "deny_out" => nil }))
+        .to_return(status: 200, body: sandbox_response.to_json)
+      described_class.create(name: "x", network: { "allow_out" => ["5.6.7.8"] })
+      expect(stub).to have_been_requested
+    end
   end
 
   describe ".connect" do

--- a/packages/ruby-sdk/spec/spec_helper.rb
+++ b/packages/ruby-sdk/spec/spec_helper.rb
@@ -1,0 +1,80 @@
+require "webmock/rspec"
+require "superserve"
+
+WebMock.disable_net_connect!
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+  config.disable_monkey_patching!
+  config.order = :random
+
+  config.around(:each) do |example|
+    saved_env = ENV.to_h.slice("SUPERSERVE_API_KEY", "SUPERSERVE_BASE_URL")
+    ENV["SUPERSERVE_API_KEY"] = "ss_live_test_key"
+    ENV["SUPERSERVE_BASE_URL"] = "https://api.test.local"
+    example.run
+    ENV.delete("SUPERSERVE_API_KEY")
+    ENV.delete("SUPERSERVE_BASE_URL")
+    saved_env.each { |k, v| ENV[k] = v }
+  end
+end
+
+module Superserve
+  module SpecHelpers
+    BASE = "https://api.test.local".freeze
+
+    def stub_api(method, path, status: 200, body: nil, headers: {})
+      stub = stub_request(method, "#{BASE}#{path}")
+      stub.with(headers: { "X-API-Key" => "ss_live_test_key" })
+      response_body = body.is_a?(String) ? body : JSON.generate(body || {})
+      stub.to_return(
+        status: status,
+        body: response_body,
+        headers: headers.merge("Content-Type" => "application/json")
+      )
+    end
+
+    def sandbox_response(overrides = {})
+      {
+        "id" => "sb_123",
+        "name" => "test",
+        "status" => "active",
+        "vcpu_count" => 2,
+        "memory_mib" => 1024,
+        "access_token" => "tok_abc",
+        "created_at" => "2026-01-01T00:00:00Z",
+        "metadata" => {}
+      }.merge(overrides)
+    end
+
+    def template_response(overrides = {})
+      {
+        "id" => "tpl_123",
+        "name" => "test-tpl",
+        "team_id" => "team_xyz",
+        "status" => "ready",
+        "vcpu" => 2,
+        "memory_mib" => 1024,
+        "disk_mib" => 8192,
+        "created_at" => "2026-01-01T00:00:00Z"
+      }.merge(overrides)
+    end
+
+    def build_response(overrides = {})
+      {
+        "id" => "bld_123",
+        "template_id" => "tpl_123",
+        "status" => "ready",
+        "build_spec_hash" => "abc123",
+        "created_at" => "2026-01-01T00:00:00Z"
+      }.merge(overrides)
+    end
+  end
+end
+
+RSpec.configure { |c| c.include Superserve::SpecHelpers }

--- a/packages/ruby-sdk/spec/template_spec.rb
+++ b/packages/ruby-sdk/spec/template_spec.rb
@@ -1,0 +1,105 @@
+RSpec.describe Superserve::Template do
+  let(:base) { "https://api.test.local" }
+
+  describe ".create" do
+    it "POSTs build_spec and captures latest_build_id" do
+      stub = stub_request(:post, "#{base}/templates")
+        .with(body: hash_including(
+          "name" => "x",
+          "build_spec" => hash_including("from" => "python:3.11", "steps" => [{ "run" => "pip install numpy" }])
+        ))
+        .to_return(status: 200, body: template_response.merge("build_id" => "build_xyz").to_json)
+      tpl = described_class.create(
+        name: "x",
+        from: "python:3.11",
+        steps: [{ run: "pip install numpy" }]
+      )
+      expect(stub).to have_been_requested
+      expect(tpl.latest_build_id).to eq("build_xyz")
+    end
+
+    it "raises when build_id is missing" do
+      stub_request(:post, "#{base}/templates")
+        .to_return(status: 200, body: template_response.to_json)
+      expect {
+        described_class.create(name: "x", from: "y")
+      }.to raise_error(Superserve::SandboxError, /missing build_id/)
+    end
+  end
+
+  describe ".connect" do
+    it "GETs by name (URL-encoded)" do
+      stub = stub_request(:get, "#{base}/templates/my%20tpl")
+        .to_return(status: 200, body: template_response.to_json)
+      described_class.connect("my tpl")
+      expect(stub).to have_been_requested
+    end
+  end
+
+  describe "#wait_until_ready" do
+    let(:template) {
+      stub_request(:post, "#{base}/templates")
+        .to_return(status: 200, body: template_response.merge("build_id" => "bld_1").to_json)
+      described_class.create(name: "x", from: "y")
+    }
+
+    it "returns TemplateInfo when build status reaches ready" do
+      stub_request(:get, "#{base}/templates/tpl_123/builds/bld_1")
+        .to_return(
+          { status: 200, body: build_response("status" => "building").to_json },
+          { status: 200, body: build_response("status" => "ready").to_json }
+        )
+      stub_request(:get, "#{base}/templates/tpl_123")
+        .to_return(status: 200, body: template_response.to_json)
+
+      info = template.wait_until_ready(poll_interval_s: 0)
+      expect(info).to be_a(Superserve::TemplateInfo)
+    end
+
+    it "raises BuildError on failed build with parsed code" do
+      stub_request(:get, "#{base}/templates/tpl_123/builds/bld_1")
+        .to_return(status: 200, body: build_response(
+          "status" => "failed",
+          "error_message" => "step_failed: command exited 1"
+        ).to_json)
+
+      expect {
+        template.wait_until_ready(poll_interval_s: 0)
+      }.to raise_error(Superserve::BuildError) { |e|
+        expect(e.code).to eq("step_failed")
+        expect(e.message).to eq("command exited 1")
+        expect(e.build_id).to eq("bld_1")
+        expect(e.template_id).to eq("tpl_123")
+      }
+    end
+
+    it "raises ConflictError when build is cancelled" do
+      stub_request(:get, "#{base}/templates/tpl_123/builds/bld_1")
+        .to_return(status: 200, body: build_response("status" => "cancelled").to_json)
+
+      expect {
+        template.wait_until_ready(poll_interval_s: 0)
+      }.to raise_error(Superserve::ConflictError, /cancelled/)
+    end
+  end
+
+  describe ".parse_build_error" do
+    it "splits 'code: detail' format" do
+      code, msg = described_class.send(:parse_build_error, "image_pull_failed: registry timeout")
+      expect(code).to eq("image_pull_failed")
+      expect(msg).to eq("registry timeout")
+    end
+
+    it "falls back to build_failed when message has no prefix" do
+      code, msg = described_class.send(:parse_build_error, "something went wrong")
+      expect(code).to eq("build_failed")
+      expect(msg).to eq("something went wrong")
+    end
+
+    it "uses defaults for nil error_message" do
+      code, msg = described_class.send(:parse_build_error, nil)
+      expect(code).to eq("build_failed")
+      expect(msg).to eq("Template build failed")
+    end
+  end
+end

--- a/packages/ruby-sdk/spec/types_spec.rb
+++ b/packages/ruby-sdk/spec/types_spec.rb
@@ -1,0 +1,85 @@
+RSpec.describe "Superserve type converters" do
+  describe ".to_sandbox_info" do
+    it "converts a complete API response" do
+      raw = {
+        "id" => "sb_1", "name" => "n", "status" => "active",
+        "vcpu_count" => 4, "memory_mib" => 2048,
+        "created_at" => "2026-01-01T00:00:00Z",
+        "timeout_seconds" => 600,
+        "network" => { "allow_out" => ["1.2.3.4/32"], "deny_out" => ["0.0.0.0/0"] },
+        "metadata" => { "env" => "prod" }
+      }
+      info = Superserve.to_sandbox_info(raw)
+      expect(info.id).to eq("sb_1")
+      expect(info.status).to eq("active")
+      expect(info.vcpu_count).to eq(4)
+      expect(info.created_at).to be_a(Time)
+      expect(info.timeout_seconds).to eq(600)
+      expect(info.network.allow_out).to eq(["1.2.3.4/32"])
+      expect(info.metadata).to eq({ "env" => "prod" })
+    end
+
+    it "raises on missing id" do
+      expect {
+        Superserve.to_sandbox_info("status" => "active", "created_at" => "2026-01-01T00:00:00Z")
+      }.to raise_error(Superserve::SandboxError, /missing sandbox id/)
+    end
+
+    it "raises on missing status" do
+      expect {
+        Superserve.to_sandbox_info("id" => "sb_1", "created_at" => "2026-01-01T00:00:00Z")
+      }.to raise_error(Superserve::SandboxError, /missing sandbox status/)
+    end
+
+    it "raises on missing created_at" do
+      expect {
+        Superserve.to_sandbox_info("id" => "sb_1", "status" => "active")
+      }.to raise_error(Superserve::SandboxError, /missing created_at/)
+    end
+
+    it "fills defaults for optional fields" do
+      info = Superserve.to_sandbox_info(
+        "id" => "sb_1", "status" => "active", "created_at" => "2026-01-01T00:00:00Z"
+      )
+      expect(info.name).to eq("")
+      expect(info.vcpu_count).to eq(0)
+      expect(info.memory_mib).to eq(0)
+      expect(info.network).to be_nil
+      expect(info.metadata).to eq({})
+    end
+  end
+
+  describe ".to_template_info" do
+    it "preserves latest_build_id when explicitly passed" do
+      raw = {
+        "id" => "t1", "name" => "t", "team_id" => "team1", "status" => "ready",
+        "created_at" => "2026-01-01T00:00:00Z"
+      }
+      info = Superserve.to_template_info(raw, "build_xyz")
+      expect(info.latest_build_id).to eq("build_xyz")
+    end
+  end
+
+  describe ".to_template_build_info" do
+    it "rejects responses missing build_spec_hash" do
+      expect {
+        Superserve.to_template_build_info(
+          "id" => "b1", "template_id" => "t1", "status" => "ready",
+          "created_at" => "2026-01-01T00:00:00Z"
+        )
+      }.to raise_error(Superserve::SandboxError, /build_spec_hash/)
+    end
+  end
+
+  describe ".parse_iso8601" do
+    it "parses Z-suffixed UTC times" do
+      t = Superserve.parse_iso8601("2026-01-01T12:34:56Z")
+      expect(t).to be_a(Time)
+      expect(t.utc.iso8601).to eq("2026-01-01T12:34:56Z")
+    end
+
+    it "returns nil for nil input" do
+      expect(Superserve.parse_iso8601(nil)).to be_nil
+    end
+  end
+end

--- a/packages/ruby-sdk/superserve.gemspec
+++ b/packages/ruby-sdk/superserve.gemspec
@@ -1,0 +1,29 @@
+require_relative "lib/superserve/version"
+
+Gem::Specification.new do |spec|
+  spec.name          = "superserve"
+  spec.version       = Superserve::VERSION
+  spec.authors       = ["Superserve"]
+  spec.email         = ["support@superserve.ai"]
+
+  spec.summary       = "Ruby SDK for the Superserve sandbox API"
+  spec.description   = "Run code in isolated Firecracker MicroVMs from Ruby. " \
+                       "Create sandboxes, execute commands, transfer files, and manage lifecycle."
+  spec.homepage      = "https://superserve.ai"
+  spec.license       = "Apache-2.0"
+  spec.required_ruby_version = ">= 3.2.0"
+
+  spec.metadata["homepage_uri"]      = spec.homepage
+  spec.metadata["source_code_uri"]   = "https://github.com/superserve-ai/superserve"
+  spec.metadata["bug_tracker_uri"]   = "https://github.com/superserve-ai/superserve/issues"
+  spec.metadata["documentation_uri"] = "https://docs.superserve.ai/sdk/ruby/sandbox"
+
+  spec.files = Dir.glob("lib/**/*.rb") + %w[README.md]
+  spec.require_paths = ["lib"]
+
+  spec.add_dependency "faraday", "~> 2.0"
+
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rspec", "~> 3.13"
+  spec.add_development_dependency "webmock", "~> 3.24"
+end


### PR DESCRIPTION
## Related Issues

None — net-new SDK package.

## Description

Adds a hand-crafted Ruby SDK at `packages/ruby-sdk/` with feature-for-feature parity to the existing TypeScript and Python SDKs. Built as a learning exercise against your existing design — happy to upstream if useful.

**Surface**
- `Sandbox` — `create` / `connect` / `list` / `kill_by_id` + `pause` / `resume` / `kill` / `update`
- `Commands` — sync + SSE streaming, idle timeout reset per chunk, throws if stream ends without `finished` event
- `Files` — data-plane round-trip with `X-Access-Token`, transparent token rotation on `resume`
- `Template` — full CRUD + `wait_until_ready` polling (matches the build-poller race comment from the TS/Python SDKs)

**HTTP layer** — Faraday-based client with custom retry on idempotent methods (GET/DELETE) for 429/502/503/504 and connection errors. Exponential backoff with ±20% jitter capped at 30s. `Retry-After` (numeric + HTTP-date) honored.

**Errors** — Full typed hierarchy (`SandboxError`, `AuthenticationError`, `ValidationError`, `NotFoundError`, `ConflictError`, `RateLimitError`, `ServerError`, `TimeoutError`, `BuildError`) + `map_api_error` mapping. Mirrors TS/Python exactly.

**Types** — `Data.define` value objects (Ruby ≥ 3.2 floor).

## Additional Context

- **Sync only for v1.** Most Ruby code is sync; an async layer (via the `async` gem) can be added later if there's demand. Doubling the surface up-front felt premature.
- **Faraday over `Net::HTTP`** — idiomatic Ruby choice. Retry, backoff, and SSE parsing are written by hand to match the Python SDK's exact semantics.
- **No `release.yml` / `CLAUDE.md` updates yet** — happy to add Ruby publish steps once direction is confirmed.

## Testing

`bundle exec rspec` from `packages/ruby-sdk/` — **85 examples, 0 failures**. Coverage mirrors the Python suite (errors, config, types, HTTP retry/backoff/SSE, files path validation, commands sync + streaming, sandbox lifecycle, template `wait_until_ready` happy/failed/cancelled paths).

End-to-end against `api.superserve.ai` via `packages/ruby-sdk/examples/demo.rb` — see recording below.

- [x] Tested locally
- [x] Added/updated tests
- [x] All tests passing

## Screenshots/Demo


https://github.com/user-attachments/assets/459703e1-3fed-4230-91a8-a453826df005



End-to-end walkthrough hitting `api.superserve.ai`: create → sync exec → streaming exec → file round-trip → pause/resume (with token rotation) → metadata-filtered list → idempotent kill.
