### PR TITLE
sdk: fix staging data-plane hostname (sandbox-staging → staging-sandbox)

### DIFF
--- a/packages/python-sdk/src/superserve/_config.py
+++ b/packages/python-sdk/src/superserve/_config.py
@@ -48,14 +48,14 @@ def _derive_sandbox_host(base_url: str) -> str:
     """Derive the data-plane sandbox host from the control-plane base URL.
 
     https://api.superserve.ai         -> sandbox.superserve.ai
-    https://api-staging.superserve.ai -> sandbox-staging.superserve.ai
+    https://api-staging.superserve.ai -> staging-sandbox.superserve.ai
     Any other URL                      -> sandbox.superserve.ai (safe default)
     """
     try:
         parsed = urlparse(base_url)
         host = parsed.hostname or ""
         if host == "api-staging.superserve.ai":
-            return "sandbox-staging.superserve.ai"
+            return "staging-sandbox.superserve.ai"
         if host == "api.superserve.ai":
             return DEFAULT_SANDBOX_HOST
     except ValueError:

--- a/packages/python-sdk/tests/test_config.py
+++ b/packages/python-sdk/tests/test_config.py
@@ -59,7 +59,7 @@ class TestDeriveSandboxHost:
     def test_staging(self) -> None:
         assert (
             _derive_sandbox_host("https://api-staging.superserve.ai")
-            == "sandbox-staging.superserve.ai"
+            == "staging-sandbox.superserve.ai"
         )
 
     def test_other(self) -> None:

--- a/packages/sdk/src/config.ts
+++ b/packages/sdk/src/config.ts
@@ -51,7 +51,7 @@ export function dataPlaneUrl(sandboxId: string, sandboxHost: string): string {
  * Derive the data-plane sandbox host from the control-plane base URL.
  *
  * `https://api.superserve.ai`         → `sandbox.superserve.ai`
- * `https://api-staging.superserve.ai` → `sandbox-staging.superserve.ai`
+ * `https://api-staging.superserve.ai` → `staging-sandbox.superserve.ai`
  * Any other URL                        → `sandbox.superserve.ai` (safe default)
  */
 function deriveSandboxHost(baseUrl: string): string {
@@ -59,7 +59,7 @@ function deriveSandboxHost(baseUrl: string): string {
     const url = new URL(baseUrl)
     const host = url.hostname
     if (host === "api-staging.superserve.ai") {
-      return "sandbox-staging.superserve.ai"
+      return "staging-sandbox.superserve.ai"
     }
     if (host === "api.superserve.ai") {
       return "sandbox.superserve.ai"

--- a/packages/sdk/tests/config.test.ts
+++ b/packages/sdk/tests/config.test.ts
@@ -72,7 +72,7 @@ describe("resolveConfig", () => {
       apiKey: "k",
       baseUrl: "https://api-staging.superserve.ai",
     })
-    expect(cfg.sandboxHost).toBe("sandbox-staging.superserve.ai")
+    expect(cfg.sandboxHost).toBe("staging-sandbox.superserve.ai")
   })
 
   it("derives sandboxHost falls back to default for unknown URL", () => {
@@ -92,8 +92,8 @@ describe("dataPlaneUrl", () => {
   })
 
   it("builds staging data plane URL", () => {
-    expect(dataPlaneUrl("xyz", "sandbox-staging.superserve.ai")).toBe(
-      "https://boxd-xyz.sandbox-staging.superserve.ai",
+    expect(dataPlaneUrl("xyz", "staging-sandbox.superserve.ai")).toBe(
+      "https://boxd-xyz.staging-sandbox.superserve.ai",
     )
   })
 })


### PR DESCRIPTION
Both SDKs constructed `boxd-{id}.sandbox-staging.superserve.ai` but the Vercel DNS wildcard is `*.staging-sandbox.superserve.ai` — staging data-plane unreachable via SDK. Prod (`sandbox.superserve.ai`) is unaffected.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superserve-ai/superserve/pull/194">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->