### PR TITLE
sdk: route commands.run through data-plane /exec, connect via /activate

### DIFF
--- a/docs/sandbox/connect.mdx
+++ b/docs/sandbox/connect.mdx
@@ -6,8 +6,8 @@ description: Reconnect to a sandbox you created earlier using its ID, and list s
 
 A sandbox outlives the process that created it. Store `sandbox.id` somewhere durable (a database, a queue message), and reconnect later with `Sandbox.connect()`.
 
-- `Sandbox.connect(id)` - returns a live `sandbox` with `commands` and `files` ready to use
-- `sandbox.getInfo()` - fetch the current status and metadata for a sandbox you already have
+- `Sandbox.connect(id)` - returns a live `sandbox` with `commands` and `files` ready to use. If the sandbox is `paused`, it's auto-resumed before returning.
+- `sandbox.getInfo()` - fetch the current status and metadata for a sandbox you already have (read-only, no state change)
 
 <CodeGroup>
 ```typescript TypeScript

--- a/docs/sandbox/lifecycle.mdx
+++ b/docs/sandbox/lifecycle.mdx
@@ -39,34 +39,30 @@ sandbox.pause()
 
 ## Resume
 
-`resume()` restores a `paused` sandbox. Processes pick up where they left off.
+`resume()` restores a `paused` sandbox you already hold a reference to. Processes pick up where they left off.
 
 <CodeGroup>
-```typescript TypeScript {7}
+```typescript TypeScript {5}
 import { Sandbox } from "@superserve/sdk"
 
-const sandbox = await Sandbox.connect("7a3f2b8c-1234-...")
-
-// sandbox is currently paused
-
+const sandbox = await Sandbox.create({ name: "long-job" })
+await sandbox.pause()
 await sandbox.resume()
 await sandbox.commands.run("ls /tmp")
 ```
 
-```python Python {7}
+```python Python {5}
 from superserve import Sandbox
 
-sandbox = Sandbox.connect("7a3f2b8c-1234-...")
-
-# sandbox is currently paused
-
+sandbox = Sandbox.create(name="long-job")
+sandbox.pause()
 sandbox.resume()
 sandbox.commands.run("ls /tmp")
 ```
 </CodeGroup>
 
 <Tip>
-You don't need to call `resume()` before running a command. `commands.run()` on a `paused` sandbox transparently resumes it and executes. Call `resume()` explicitly only when you want the sandbox to be ready in advance.
+A paused sandbox is auto-resumed by both `Sandbox.connect()` and `commands.run()`.
 </Tip>
 
 Resume rotates the sandbox's per-sandbox access token on the backend. The SDK re-injects the new token into `sandbox.files` transparently - nothing changes in your code.

--- a/docs/sdk-reference/sandbox.mdx
+++ b/docs/sdk-reference/sandbox.mdx
@@ -79,7 +79,7 @@ sandbox = Sandbox.create(
 
 ### `Sandbox.connect`
 
-Reconnect to an existing sandbox by ID. Fetches info and a fresh access token.
+Reconnect to an existing sandbox by ID. Returns a live `sandbox` with a fresh access token. If the sandbox is currently `paused`, it is auto-resumed before returning so it's immediately usable.
 
 <CodeGroup>
 ```typescript TypeScript

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "superserve",
   "private": true,
-  "packageManager": "bun@1.3.5",
   "workspaces": [
     "apps/*",
     "packages/*",
@@ -21,20 +20,6 @@
     "docs:build": "mintlify build --dir docs",
     "prepare": "husky"
   },
-  "lint-staged": {
-    "*.{ts,tsx,js,jsx,json,jsonc,md,css,yaml,yml}": [
-      "bunx oxlint --fix",
-      "bunx oxfmt --write"
-    ]
-  },
-  "devDependencies": {
-    "husky": "^9.1.7",
-    "lint-staged": "^16.4.0",
-    "mintlify": "^4.0.0",
-    "oxfmt": "0.49.0",
-    "oxlint": "1.64.0",
-    "turbo": "^2.9.4"
-  },
   "dependencies": {
     "@react-email/components": "^1.0.11",
     "@supabase/ssr": "^0.10.0",
@@ -51,5 +36,22 @@
     "resend": "^6.10.0",
     "tailwindcss": "^4.2.2",
     "vitest": "^4.1.2"
-  }
+  },
+  "devDependencies": {
+    "husky": "^9.1.7",
+    "lint-staged": "^16.4.0",
+    "mintlify": "^4.0.0",
+    "oxfmt": "0.49.0",
+    "oxlint": "1.64.0",
+    "turbo": "^2.9.4"
+  },
+  "lint-staged": {
+    "*.{ts,tsx,js,jsx}": [
+      "bunx oxlint --fix"
+    ],
+    "*.{ts,tsx,js,jsx,json,jsonc,md,css,yaml,yml}": [
+      "bunx oxfmt --write"
+    ]
+  },
+  "packageManager": "bun@1.3.5"
 }

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "superserve"
-version = "0.7.1"
+version = "0.7.2"
 description = "Python SDK for the Superserve sandbox API"
 license = "Apache-2.0"
 readme = "README.md"

--- a/packages/python-sdk/src/superserve/__init__.py
+++ b/packages/python-sdk/src/superserve/__init__.py
@@ -35,7 +35,7 @@ from .types import (
     WorkdirStep,
 )
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"
 
 __all__ = [
     "AsyncSandbox",

--- a/packages/python-sdk/src/superserve/async_sandbox.py
+++ b/packages/python-sdk/src/superserve/async_sandbox.py
@@ -61,7 +61,7 @@ class AsyncSandbox:
             client=self._http_client,
         )
         token = raw.get("access_token") if raw else None
-        if not token:
+        if not isinstance(token, str) or not token:
             raise SandboxError(
                 f"Invalid API response from POST /sandboxes/{self.id}/{endpoint}: "
                 "missing access_token"

--- a/packages/python-sdk/src/superserve/async_sandbox.py
+++ b/packages/python-sdk/src/superserve/async_sandbox.py
@@ -9,7 +9,7 @@ import httpx
 
 from ._config import ResolvedConfig, resolve_config
 from ._http import async_api_request
-from .commands import AsyncCommands
+from .commands import AsyncCommands, AsyncCommandsDeps
 from .errors import NotFoundError, SandboxError
 from .files import AsyncFiles
 from .types import NetworkConfig, SandboxInfo, SandboxStatus, to_sandbox_info
@@ -38,11 +38,44 @@ class AsyncSandbox:
         self._closed = False
 
         self.commands = AsyncCommands(
-            config.base_url, self.id, config.api_key, client=self._http_client
+            AsyncCommandsDeps(
+                sandbox_id=self.id,
+                sandbox_host=config.sandbox_host,
+                get_access_token=lambda: self._access_token,
+                refresh_activate=self._refresh_activate,
+            ),
+            client=self._http_client,
         )
         self.files = AsyncFiles(
             self.id, config.sandbox_host, self._access_token, client=self._http_client
         )
+
+    async def _post_and_rotate_token(self, endpoint: str) -> str:
+        """Async variant of Sandbox._post_and_rotate_token."""
+        raw = await async_api_request(
+            "POST",
+            f"{self._config.base_url}/sandboxes/{self.id}/{endpoint}",
+            headers={"X-API-Key": self._config.api_key},
+            client=self._http_client,
+        )
+        token = raw.get("access_token") if raw else None
+        if not token:
+            raise SandboxError(
+                f"Invalid API response from POST /sandboxes/{{id}}/{endpoint}: "
+                "missing access_token"
+            )
+        self._access_token = token
+        self.files = AsyncFiles(
+            self.id,
+            self._config.sandbox_host,
+            self._access_token,
+            client=self._http_client,
+        )
+        return token
+
+    async def _refresh_activate(self) -> str:
+        """Slow-path fallback for data-plane AuthenticationError."""
+        return await self._post_and_rotate_token("activate")
 
     @classmethod
     async def create(
@@ -105,17 +138,23 @@ class AsyncSandbox:
         api_key: str | None = None,
         base_url: str | None = None,
     ) -> AsyncSandbox:
-        """Connect to an existing sandbox by ID."""
+        """Connect to an existing sandbox by ID.
+
+        Calls ``POST /activate`` so the returned instance is guaranteed to
+        be active (paused sandboxes are auto-resumed) with a fresh access
+        token.
+        """
         config = resolve_config(api_key=api_key, base_url=base_url)
         raw = await async_api_request(
-            "GET",
-            f"{config.base_url}/sandboxes/{sandbox_id}",
+            "POST",
+            f"{config.base_url}/sandboxes/{sandbox_id}/activate",
             headers={"X-API-Key": config.api_key},
         )
         token = raw.get("access_token") if raw else None
         if not token:
             raise SandboxError(
-                "Invalid API response from GET /sandboxes/{id}: missing access_token"
+                "Invalid API response from POST /sandboxes/{id}/activate: "
+                "missing access_token"
             )
         return cls(to_sandbox_info(raw), token, config)
 
@@ -202,25 +241,7 @@ class AsyncSandbox:
         the fresh token transparently.
         """
         self._require_live()
-        raw = await async_api_request(
-            "POST",
-            f"{self._config.base_url}/sandboxes/{self.id}/resume",
-            headers={"X-API-Key": self._config.api_key},
-            client=self._http_client,
-        )
-        token = raw.get("access_token") if raw else None
-        if not token:
-            raise SandboxError(
-                "Invalid API response from POST /sandboxes/{id}/resume: "
-                "missing access_token"
-            )
-        self._access_token = token
-        self.files = AsyncFiles(
-            self.id,
-            self._config.sandbox_host,
-            self._access_token,
-            client=self._http_client,
-        )
+        await self._post_and_rotate_token("resume")
 
     async def kill(self) -> None:
         """Delete this sandbox and all its resources. Idempotent."""

--- a/packages/python-sdk/src/superserve/async_sandbox.py
+++ b/packages/python-sdk/src/superserve/async_sandbox.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import builtins
 from typing import TYPE_CHECKING, Any
 
@@ -36,6 +37,7 @@ class AsyncSandbox:
         self._config = config
         self._http_client: httpx.AsyncClient = httpx.AsyncClient(timeout=30.0)
         self._closed = False
+        self._refresh_lock = asyncio.Lock()
 
         self.commands = AsyncCommands(
             AsyncCommandsDeps(
@@ -61,7 +63,7 @@ class AsyncSandbox:
         token = raw.get("access_token") if raw else None
         if not token:
             raise SandboxError(
-                f"Invalid API response from POST /sandboxes/{{id}}/{endpoint}: "
+                f"Invalid API response from POST /sandboxes/{self.id}/{endpoint}: "
                 "missing access_token"
             )
         self._access_token = token
@@ -74,8 +76,9 @@ class AsyncSandbox:
         return token
 
     async def _refresh_activate(self) -> str:
-        """Slow-path fallback for data-plane AuthenticationError."""
-        return await self._post_and_rotate_token("activate")
+        """Async variant of Sandbox._refresh_activate."""
+        async with self._refresh_lock:
+            return await self._post_and_rotate_token("activate")
 
     @classmethod
     async def create(
@@ -153,7 +156,7 @@ class AsyncSandbox:
         token = raw.get("access_token") if raw else None
         if not token:
             raise SandboxError(
-                "Invalid API response from POST /sandboxes/{id}/activate: "
+                f"Invalid API response from POST /sandboxes/{sandbox_id}/activate: "
                 "missing access_token"
             )
         return cls(to_sandbox_info(raw), token, config)

--- a/packages/python-sdk/src/superserve/commands.py
+++ b/packages/python-sdk/src/superserve/commands.py
@@ -129,6 +129,8 @@ class Commands:
 
     # Safe for streaming: 401 is returned in the HTTP status code before
     # any SSE data is written, so the retry can't double-emit callbacks.
+    # The try/except wraps `send` only — if `refresh_activate` itself 401s
+    # (bad API key), it propagates uncaught, so no recursion is possible.
     def _with_token_retry(self, send: Callable[[str], T]) -> T:
         try:
             return send(self._deps.get_access_token())

--- a/packages/python-sdk/src/superserve/commands.py
+++ b/packages/python-sdk/src/superserve/commands.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, TypeVar
 
 import httpx
 
@@ -16,6 +16,8 @@ from ._config import data_plane_url
 from ._http import api_request, async_api_request, async_stream_sse, stream_sse
 from .errors import AuthenticationError, SandboxError
 from .types import CommandResult
+
+T = TypeVar("T")
 
 
 @dataclass(frozen=True)
@@ -87,7 +89,7 @@ class Commands:
         body: dict[str, Any],
         timeout_seconds: int | None,
     ) -> CommandResult:
-        def send(token: str) -> dict[str, Any]:
+        def send(token: str) -> Any:
             return api_request(
                 "POST",
                 f"{self._data_plane_base_url}/exec",
@@ -99,7 +101,7 @@ class Commands:
                 client=self._client,
             )
 
-        raw = self._with_token_retry(send)
+        raw: dict[str, Any] = self._with_token_retry(send)
         return CommandResult(
             stdout=raw.get("stdout", ""),
             stderr=raw.get("stderr", ""),
@@ -127,9 +129,7 @@ class Commands:
 
     # Safe for streaming: 401 is returned in the HTTP status code before
     # any SSE data is written, so the retry can't double-emit callbacks.
-    def _with_token_retry(
-        self, send: Callable[[str], Any]
-    ) -> Any:
+    def _with_token_retry(self, send: Callable[[str], T]) -> T:
         try:
             return send(self._deps.get_access_token())
         except AuthenticationError:
@@ -236,7 +236,7 @@ class AsyncCommands:
         body: dict[str, Any],
         timeout_seconds: int | None,
     ) -> CommandResult:
-        async def send(token: str) -> dict[str, Any]:
+        async def send(token: str) -> Any:
             return await async_api_request(
                 "POST",
                 f"{self._data_plane_base_url}/exec",
@@ -248,7 +248,7 @@ class AsyncCommands:
                 client=self._client,
             )
 
-        raw = await self._with_token_retry(send)
+        raw: dict[str, Any] = await self._with_token_retry(send)
         return CommandResult(
             stdout=raw.get("stdout", ""),
             stderr=raw.get("stderr", ""),
@@ -275,8 +275,8 @@ class AsyncCommands:
         return await self._with_token_retry(send)
 
     async def _with_token_retry(
-        self, send: Callable[[str], Awaitable[Any]]
-    ) -> Any:
+        self, send: Callable[[str], Awaitable[T]]
+    ) -> T:
         try:
             return await send(self._deps.get_access_token())
         except AuthenticationError:

--- a/packages/python-sdk/src/superserve/commands.py
+++ b/packages/python-sdk/src/superserve/commands.py
@@ -1,15 +1,41 @@
-"""`sandbox.commands` - run shell commands inside a sandbox."""
+"""``sandbox.commands`` - run shell commands inside a sandbox.
+
+Hits the per-sandbox data plane with the access token. On 401 the SDK
+auto-refreshes via ``POST /activate`` and retries once.
+"""
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from typing import Any
 
 import httpx
 
+from ._config import data_plane_url
 from ._http import api_request, async_api_request, async_stream_sse, stream_sse
-from .errors import SandboxError
+from .errors import AuthenticationError, SandboxError
 from .types import CommandResult
+
+
+@dataclass(frozen=True)
+class CommandsDeps:
+    """Internal deps from Sandbox. ``refresh_activate`` is invoked on 401."""
+
+    sandbox_id: str
+    sandbox_host: str
+    get_access_token: Callable[[], str]
+    refresh_activate: Callable[[], str]
+
+
+@dataclass(frozen=True)
+class AsyncCommandsDeps:
+    """Async variant of CommandsDeps."""
+
+    sandbox_id: str
+    sandbox_host: str
+    get_access_token: Callable[[], str]
+    refresh_activate: Callable[[], Awaitable[str]]
 
 
 class Commands:
@@ -17,15 +43,14 @@ class Commands:
 
     def __init__(
         self,
-        base_url: str,
-        sandbox_id: str,
-        api_key: str,
+        deps: CommandsDeps,
         client: httpx.Client | None = None,
     ) -> None:
-        self._base_url = base_url
-        self._sandbox_id = sandbox_id
-        self._api_key = api_key
+        self._deps = deps
         self._client = client
+        self._data_plane_base_url = data_plane_url(
+            deps.sandbox_id, deps.sandbox_host
+        )
 
     def run(
         self,
@@ -49,31 +74,32 @@ class Commands:
         if timeout_seconds is not None:
             body["timeout_s"] = timeout_seconds
 
-        headers = {"X-API-Key": self._api_key}
         is_streaming = on_stdout is not None or on_stderr is not None
 
         if is_streaming:
             return self._run_streaming(
-                body, headers, on_stdout, on_stderr, timeout_seconds
+                body, on_stdout, on_stderr, timeout_seconds
             )
-        return self._run_sync(body, headers, timeout_seconds)
+        return self._run_sync(body, timeout_seconds)
 
     def _run_sync(
         self,
         body: dict[str, Any],
-        headers: dict[str, str],
         timeout_seconds: int | None,
     ) -> CommandResult:
-        raw = api_request(
-            "POST",
-            f"{self._base_url}/sandboxes/{self._sandbox_id}/exec",
-            headers=headers,
-            json_body=body,
-            timeout=float(timeout_seconds) + 5.0
-            if timeout_seconds is not None
-            else 30.0,
-            client=self._client,
-        )
+        def send(token: str) -> dict[str, Any]:
+            return api_request(
+                "POST",
+                f"{self._data_plane_base_url}/exec",
+                headers={"X-Access-Token": token},
+                json_body=body,
+                timeout=float(timeout_seconds) + 5.0
+                if timeout_seconds is not None
+                else 30.0,
+                client=self._client,
+            )
+
+        raw = self._with_token_retry(send)
         return CommandResult(
             stdout=raw.get("stdout", ""),
             stderr=raw.get("stderr", ""),
@@ -83,7 +109,38 @@ class Commands:
     def _run_streaming(
         self,
         body: dict[str, Any],
+        on_stdout: Callable[[str], None] | None,
+        on_stderr: Callable[[str], None] | None,
+        timeout_seconds: int | None,
+    ) -> CommandResult:
+        def send(token: str) -> CommandResult:
+            return self._consume_stream(
+                f"{self._data_plane_base_url}/exec/stream",
+                {"X-Access-Token": token},
+                body,
+                on_stdout,
+                on_stderr,
+                timeout_seconds,
+            )
+
+        return self._with_token_retry(send)
+
+    # Safe for streaming: 401 is returned in the HTTP status code before
+    # any SSE data is written, so the retry can't double-emit callbacks.
+    def _with_token_retry(
+        self, send: Callable[[str], Any]
+    ) -> Any:
+        try:
+            return send(self._deps.get_access_token())
+        except AuthenticationError:
+            fresh = self._deps.refresh_activate()
+            return send(fresh)
+
+    def _consume_stream(
+        self,
+        url: str,
         headers: dict[str, str],
+        body: dict[str, Any],
         on_stdout: Callable[[str], None] | None,
         on_stderr: Callable[[str], None] | None,
         timeout_seconds: int | None,
@@ -110,7 +167,7 @@ class Commands:
                     stderr_parts.append(event["error"])
 
         stream_sse(
-            f"{self._base_url}/sandboxes/{self._sandbox_id}/exec/stream",
+            url,
             headers=headers,
             json_body=body,
             timeout=float(timeout_seconds) + 5.0
@@ -122,7 +179,8 @@ class Commands:
 
         if not saw_finished:
             raise SandboxError(
-                "Command stream ended without a finished event (possible network disconnect)"
+                "Command stream ended without a finished event "
+                "(possible network disconnect)"
             )
 
         return CommandResult(
@@ -137,15 +195,14 @@ class AsyncCommands:
 
     def __init__(
         self,
-        base_url: str,
-        sandbox_id: str,
-        api_key: str,
+        deps: AsyncCommandsDeps,
         client: httpx.AsyncClient | None = None,
     ) -> None:
-        self._base_url = base_url
-        self._sandbox_id = sandbox_id
-        self._api_key = api_key
+        self._deps = deps
         self._client = client
+        self._data_plane_base_url = data_plane_url(
+            deps.sandbox_id, deps.sandbox_host
+        )
 
     async def run(
         self,
@@ -157,10 +214,7 @@ class AsyncCommands:
         on_stdout: Callable[[str], None] | None = None,
         on_stderr: Callable[[str], None] | None = None,
     ) -> CommandResult:
-        """Async variant of Commands.run().
-
-        Paused sandboxes are transparently resumed before execution.
-        """
+        """Async variant of Commands.run()."""
         body: dict[str, Any] = {"command": command}
         if cwd is not None:
             body["working_dir"] = cwd
@@ -169,31 +223,32 @@ class AsyncCommands:
         if timeout_seconds is not None:
             body["timeout_s"] = timeout_seconds
 
-        headers = {"X-API-Key": self._api_key}
         is_streaming = on_stdout is not None or on_stderr is not None
 
         if is_streaming:
             return await self._run_streaming(
-                body, headers, on_stdout, on_stderr, timeout_seconds
+                body, on_stdout, on_stderr, timeout_seconds
             )
-        return await self._run_sync(body, headers, timeout_seconds)
+        return await self._run_sync(body, timeout_seconds)
 
     async def _run_sync(
         self,
         body: dict[str, Any],
-        headers: dict[str, str],
         timeout_seconds: int | None,
     ) -> CommandResult:
-        raw = await async_api_request(
-            "POST",
-            f"{self._base_url}/sandboxes/{self._sandbox_id}/exec",
-            headers=headers,
-            json_body=body,
-            timeout=float(timeout_seconds) + 5.0
-            if timeout_seconds is not None
-            else 30.0,
-            client=self._client,
-        )
+        async def send(token: str) -> dict[str, Any]:
+            return await async_api_request(
+                "POST",
+                f"{self._data_plane_base_url}/exec",
+                headers={"X-Access-Token": token},
+                json_body=body,
+                timeout=float(timeout_seconds) + 5.0
+                if timeout_seconds is not None
+                else 30.0,
+                client=self._client,
+            )
+
+        raw = await self._with_token_retry(send)
         return CommandResult(
             stdout=raw.get("stdout", ""),
             stderr=raw.get("stderr", ""),
@@ -203,7 +258,36 @@ class AsyncCommands:
     async def _run_streaming(
         self,
         body: dict[str, Any],
+        on_stdout: Callable[[str], None] | None,
+        on_stderr: Callable[[str], None] | None,
+        timeout_seconds: int | None,
+    ) -> CommandResult:
+        async def send(token: str) -> CommandResult:
+            return await self._consume_stream(
+                f"{self._data_plane_base_url}/exec/stream",
+                {"X-Access-Token": token},
+                body,
+                on_stdout,
+                on_stderr,
+                timeout_seconds,
+            )
+
+        return await self._with_token_retry(send)
+
+    async def _with_token_retry(
+        self, send: Callable[[str], Awaitable[Any]]
+    ) -> Any:
+        try:
+            return await send(self._deps.get_access_token())
+        except AuthenticationError:
+            fresh = await self._deps.refresh_activate()
+            return await send(fresh)
+
+    async def _consume_stream(
+        self,
+        url: str,
         headers: dict[str, str],
+        body: dict[str, Any],
         on_stdout: Callable[[str], None] | None,
         on_stderr: Callable[[str], None] | None,
         timeout_seconds: int | None,
@@ -230,7 +314,7 @@ class AsyncCommands:
                     stderr_parts.append(event["error"])
 
         await async_stream_sse(
-            f"{self._base_url}/sandboxes/{self._sandbox_id}/exec/stream",
+            url,
             headers=headers,
             json_body=body,
             timeout=float(timeout_seconds) + 5.0
@@ -242,7 +326,8 @@ class AsyncCommands:
 
         if not saw_finished:
             raise SandboxError(
-                "Command stream ended without a finished event (possible network disconnect)"
+                "Command stream ended without a finished event "
+                "(possible network disconnect)"
             )
 
         return CommandResult(

--- a/packages/python-sdk/src/superserve/sandbox.py
+++ b/packages/python-sdk/src/superserve/sandbox.py
@@ -64,7 +64,7 @@ class Sandbox:
             client=self._http_client,
         )
         token = raw.get("access_token") if raw else None
-        if not token:
+        if not isinstance(token, str) or not token:
             raise SandboxError(
                 f"Invalid API response from POST /sandboxes/{self.id}/{endpoint}: "
                 "missing access_token"

--- a/packages/python-sdk/src/superserve/sandbox.py
+++ b/packages/python-sdk/src/superserve/sandbox.py
@@ -9,7 +9,7 @@ import httpx
 
 from ._config import ResolvedConfig, resolve_config
 from ._http import api_request
-from .commands import Commands
+from .commands import Commands, CommandsDeps
 from .errors import NotFoundError, SandboxError
 from .files import Files
 from .types import NetworkConfig, SandboxInfo, SandboxStatus, to_sandbox_info
@@ -38,11 +38,47 @@ class Sandbox:
         self._closed = False
 
         self.commands = Commands(
-            config.base_url, self.id, config.api_key, client=self._http_client
+            CommandsDeps(
+                sandbox_id=self.id,
+                sandbox_host=config.sandbox_host,
+                get_access_token=lambda: self._access_token,
+                refresh_activate=self._refresh_activate,
+            ),
+            client=self._http_client,
         )
         self.files = Files(
             self.id, config.sandbox_host, self._access_token, client=self._http_client
         )
+
+    def _post_and_rotate_token(self, endpoint: str) -> str:
+        """POST a token-rotating endpoint (``resume`` or ``activate``), update
+        the cached token, rebuild ``self.files`` with the fresh token.
+        Returns the new token.
+        """
+        raw = api_request(
+            "POST",
+            f"{self._config.base_url}/sandboxes/{self.id}/{endpoint}",
+            headers={"X-API-Key": self._config.api_key},
+            client=self._http_client,
+        )
+        token = raw.get("access_token") if raw else None
+        if not token:
+            raise SandboxError(
+                f"Invalid API response from POST /sandboxes/{{id}}/{endpoint}: "
+                "missing access_token"
+            )
+        self._access_token = token
+        self.files = Files(
+            self.id,
+            self._config.sandbox_host,
+            self._access_token,
+            client=self._http_client,
+        )
+        return token
+
+    def _refresh_activate(self) -> str:
+        """Slow-path fallback for data-plane AuthenticationError."""
+        return self._post_and_rotate_token("activate")
 
     @classmethod
     def create(
@@ -105,17 +141,23 @@ class Sandbox:
         api_key: str | None = None,
         base_url: str | None = None,
     ) -> Sandbox:
-        """Connect to an existing sandbox by ID."""
+        """Connect to an existing sandbox by ID.
+
+        Calls ``POST /activate`` so the returned instance is guaranteed to
+        be active (paused sandboxes are auto-resumed) with a fresh access
+        token.
+        """
         config = resolve_config(api_key=api_key, base_url=base_url)
         raw = api_request(
-            "GET",
-            f"{config.base_url}/sandboxes/{sandbox_id}",
+            "POST",
+            f"{config.base_url}/sandboxes/{sandbox_id}/activate",
             headers={"X-API-Key": config.api_key},
         )
         token = raw.get("access_token") if raw else None
         if not token:
             raise SandboxError(
-                "Invalid API response from GET /sandboxes/{id}: missing access_token"
+                "Invalid API response from POST /sandboxes/{id}/activate: "
+                "missing access_token"
             )
         return cls(to_sandbox_info(raw), token, config)
 
@@ -202,25 +244,7 @@ class Sandbox:
         the fresh token transparently.
         """
         self._require_live()
-        raw = api_request(
-            "POST",
-            f"{self._config.base_url}/sandboxes/{self.id}/resume",
-            headers={"X-API-Key": self._config.api_key},
-            client=self._http_client,
-        )
-        token = raw.get("access_token") if raw else None
-        if not token:
-            raise SandboxError(
-                "Invalid API response from POST /sandboxes/{id}/resume: "
-                "missing access_token"
-            )
-        self._access_token = token
-        self.files = Files(
-            self.id,
-            self._config.sandbox_host,
-            self._access_token,
-            client=self._http_client,
-        )
+        self._post_and_rotate_token("resume")
 
     def kill(self) -> None:
         """Delete this sandbox and all its resources. Idempotent."""

--- a/packages/python-sdk/src/superserve/sandbox.py
+++ b/packages/python-sdk/src/superserve/sandbox.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import builtins
+import threading
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -36,6 +37,7 @@ class Sandbox:
         self._config = config
         self._http_client: httpx.Client = httpx.Client(timeout=30.0)
         self._closed = False
+        self._refresh_lock = threading.Lock()
 
         self.commands = Commands(
             CommandsDeps(
@@ -64,7 +66,7 @@ class Sandbox:
         token = raw.get("access_token") if raw else None
         if not token:
             raise SandboxError(
-                f"Invalid API response from POST /sandboxes/{{id}}/{endpoint}: "
+                f"Invalid API response from POST /sandboxes/{self.id}/{endpoint}: "
                 "missing access_token"
             )
         self._access_token = token
@@ -77,8 +79,12 @@ class Sandbox:
         return token
 
     def _refresh_activate(self) -> str:
-        """Slow-path fallback for data-plane AuthenticationError."""
-        return self._post_and_rotate_token("activate")
+        """Slow-path fallback for data-plane AuthenticationError. Lock
+        serializes refreshes so concurrent callers don't race the
+        server-side BeginResume claim (the loser gets 409).
+        """
+        with self._refresh_lock:
+            return self._post_and_rotate_token("activate")
 
     @classmethod
     def create(
@@ -156,7 +162,7 @@ class Sandbox:
         token = raw.get("access_token") if raw else None
         if not token:
             raise SandboxError(
-                "Invalid API response from POST /sandboxes/{id}/activate: "
+                f"Invalid API response from POST /sandboxes/{sandbox_id}/activate: "
                 "missing access_token"
             )
         return cls(to_sandbox_info(raw), token, config)

--- a/packages/python-sdk/tests/test_async.py
+++ b/packages/python-sdk/tests/test_async.py
@@ -64,7 +64,7 @@ class TestAsyncSandboxSmoke:
 
     async def test_kill_swallows_404(self) -> None:
         with respx.mock() as router:
-            router.get(f"{API}/sandboxes/sbx-1").mock(
+            router.post(f"{API}/sandboxes/sbx-1/activate").mock(
                 return_value=httpx.Response(200, json=_raw())
             )
             router.delete(f"{API}/sandboxes/sbx-1").mock(
@@ -75,7 +75,7 @@ class TestAsyncSandboxSmoke:
 
     async def test_pause_returns_none(self) -> None:
         with respx.mock() as router:
-            router.get(f"{API}/sandboxes/sbx-1").mock(
+            router.post(f"{API}/sandboxes/sbx-1/activate").mock(
                 return_value=httpx.Response(200, json=_raw())
             )
             pause_route = router.post(f"{API}/sandboxes/sbx-1/pause").mock(
@@ -91,7 +91,7 @@ class TestAsyncSandboxSmoke:
 
     async def test_resume_rotates_token_and_rebuilds_files(self) -> None:
         with respx.mock() as router:
-            router.get(f"{API}/sandboxes/sbx-1").mock(
+            router.post(f"{API}/sandboxes/sbx-1/activate").mock(
                 return_value=httpx.Response(200, json=_raw())
             )
             router.post(f"{API}/sandboxes/sbx-1/resume").mock(
@@ -116,7 +116,7 @@ class TestAsyncSandboxSmoke:
 
     async def test_resume_missing_access_token_raises(self) -> None:
         with respx.mock() as router:
-            router.get(f"{API}/sandboxes/sbx-1").mock(
+            router.post(f"{API}/sandboxes/sbx-1/activate").mock(
                 return_value=httpx.Response(200, json=_raw())
             )
             router.post(f"{API}/sandboxes/sbx-1/resume").mock(

--- a/packages/python-sdk/tests/test_async.py
+++ b/packages/python-sdk/tests/test_async.py
@@ -194,3 +194,72 @@ class TestAsyncCreateFromTemplate:
                 assert b"from_snapshot" in body
             finally:
                 await sbx._close_http_client()
+
+
+class TestAsyncConcurrentRefresh:
+    async def test_serialized_refresh_under_concurrent_401(self) -> None:
+        import asyncio
+
+        sbx_id = "sbx-aconc"
+        sandbox_host = "sandbox.example.com"
+        data_plane = f"https://boxd-{sbx_id}.{sandbox_host}"
+
+        exec_call_count = 0
+        activate_call_count = 0
+
+        def exec_response(_request: httpx.Request) -> httpx.Response:
+            nonlocal exec_call_count
+            exec_call_count += 1
+            if exec_call_count <= 2:
+                return httpx.Response(
+                    401, json={"error": {"code": "auth_failed"}}
+                )
+            return httpx.Response(
+                200, json={"stdout": "ok", "stderr": "", "exit_code": 0}
+            )
+
+        async def activate_response(_request: httpx.Request) -> httpx.Response:
+            nonlocal activate_call_count
+            activate_call_count += 1
+            # Yield to event loop — if the lock were missing, both refreshes
+            # would interleave here.
+            await asyncio.sleep(0.02)
+            return httpx.Response(
+                200,
+                json={
+                    "id": sbx_id,
+                    "name": "c",
+                    "status": "active",
+                    "created_at": "2026-01-01T00:00:00Z",
+                    "access_token": "tok-refreshed",
+                },
+            )
+
+        with respx.mock(base_url=API, assert_all_called=False) as router:
+            router.post(f"{API}/sandboxes/{sbx_id}/activate").mock(
+                side_effect=activate_response
+            )
+            router.post(f"{data_plane}/exec").mock(side_effect=exec_response)
+
+            sbx = await AsyncSandbox.connect(
+                sbx_id, api_key="ss_live_x", base_url=API
+            )
+            try:
+                sbx._config = sbx._config.__class__(
+                    api_key=sbx._config.api_key,
+                    base_url=sbx._config.base_url,
+                    sandbox_host=sandbox_host,
+                )
+                sbx.commands._data_plane_base_url = data_plane
+
+                a, b = await asyncio.gather(
+                    sbx.commands.run("echo a"),
+                    sbx.commands.run("echo b"),
+                )
+                assert a.stdout == "ok"
+                assert b.stdout == "ok"
+                # connect did 1 + 2 serialized refreshes = 3
+                assert activate_call_count == 3
+                assert exec_call_count == 4
+            finally:
+                await sbx._close_http_client()

--- a/packages/python-sdk/tests/test_commands.py
+++ b/packages/python-sdk/tests/test_commands.py
@@ -5,22 +5,45 @@ from __future__ import annotations
 import httpx
 import pytest
 import respx
-from superserve.commands import Commands
-from superserve.errors import SandboxError
+from superserve.commands import Commands, CommandsDeps
+from superserve.errors import AuthenticationError, SandboxError
+
+SANDBOX_HOST = "sandbox.example.com"
+SBX = "sbx-1"
+DATA_PLANE = f"https://boxd-{SBX}.{SANDBOX_HOST}"
+
+
+def _make_deps(
+    *,
+    initial_token: str = "tok-initial",
+    refreshed_token: str = "tok-refreshed",
+) -> tuple[CommandsDeps, dict]:
+    """Returns deps + a state dict so tests can inspect refresh count."""
+    state: dict = {"token": initial_token, "refreshes": 0}
+
+    def refresh() -> str:
+        state["refreshes"] += 1
+        state["token"] = refreshed_token
+        return refreshed_token
+
+    deps = CommandsDeps(
+        sandbox_id=SBX,
+        sandbox_host=SANDBOX_HOST,
+        get_access_token=lambda: state["token"],
+        refresh_activate=refresh,
+    )
+    return deps, state
 
 
 def _make_commands() -> Commands:
-    return Commands(
-        base_url="https://api.example.com",
-        sandbox_id="sbx-1",
-        api_key="ss_live_key",
-    )
+    deps, _ = _make_deps()
+    return Commands(deps)
 
 
 class TestCommandsRun:
-    def test_sync_returns_command_result(self) -> None:
+    def test_hits_data_plane_with_access_token(self) -> None:
         with respx.mock() as router:
-            router.post("https://api.example.com/sandboxes/sbx-1/exec").mock(
+            route = router.post(f"{DATA_PLANE}/exec").mock(
                 return_value=httpx.Response(
                     200,
                     json={"stdout": "hi\n", "stderr": "", "exit_code": 0},
@@ -28,37 +51,74 @@ class TestCommandsRun:
             )
             result = _make_commands().run("echo hi")
             assert result.stdout == "hi\n"
-            assert result.stderr == ""
-            assert result.exit_code == 0
+
+            req = route.calls.last.request
+            assert req.headers.get("x-access-token") == "tok-initial"
+            assert "x-api-key" not in {k.lower() for k in req.headers}
 
     def test_sync_with_env_and_cwd(self) -> None:
         with respx.mock() as router:
-            route = router.post("https://api.example.com/sandboxes/sbx-1/exec").mock(
+            route = router.post(f"{DATA_PLANE}/exec").mock(
                 return_value=httpx.Response(
-                    200,
-                    json={"stdout": "ok", "stderr": "", "exit_code": 0},
+                    200, json={"stdout": "ok", "stderr": "", "exit_code": 0}
                 )
             )
-            result = _make_commands().run(
+            _make_commands().run(
                 "ls", cwd="/tmp", env={"FOO": "bar"}, timeout_seconds=10
             )
-            assert result.stdout == "ok"
-            # verify body was sent
             request_body = route.calls.last.request.content
             assert b"/tmp" in request_body
             assert b"FOO" in request_body
 
     def test_nonzero_exit_code(self) -> None:
         with respx.mock() as router:
-            router.post("https://api.example.com/sandboxes/sbx-1/exec").mock(
+            router.post(f"{DATA_PLANE}/exec").mock(
                 return_value=httpx.Response(
-                    200,
-                    json={"stdout": "", "stderr": "boom", "exit_code": 1},
+                    200, json={"stdout": "", "stderr": "boom", "exit_code": 1}
                 )
             )
             result = _make_commands().run("false")
             assert result.exit_code == 1
             assert result.stderr == "boom"
+
+    def test_refreshes_token_and_retries_on_401(self) -> None:
+        deps, state = _make_deps()
+        with respx.mock() as router:
+            router.post(f"{DATA_PLANE}/exec").mock(
+                side_effect=[
+                    httpx.Response(401, json={"error": {"code": "auth_failed"}}),
+                    httpx.Response(
+                        200,
+                        json={"stdout": "ok\n", "stderr": "", "exit_code": 0},
+                    ),
+                ]
+            )
+            result = Commands(deps).run("echo")
+            assert result.stdout == "ok\n"
+            assert state["refreshes"] == 1
+
+    def test_does_not_retry_on_non_auth_errors(self) -> None:
+        deps, state = _make_deps()
+        with respx.mock() as router:
+            router.post(f"{DATA_PLANE}/exec").mock(
+                return_value=httpx.Response(
+                    500, json={"error": {"code": "server_error"}}
+                )
+            )
+            with pytest.raises(SandboxError):
+                Commands(deps).run("echo")
+        assert state["refreshes"] == 0
+
+    def test_propagates_auth_error_when_refresh_also_fails(self) -> None:
+        deps, _ = _make_deps()
+        with respx.mock() as router:
+            router.post(f"{DATA_PLANE}/exec").mock(
+                return_value=httpx.Response(
+                    401, json={"error": {"code": "auth_failed"}}
+                )
+            )
+            with pytest.raises(AuthenticationError):
+                Commands(deps).run("echo")
 
 
 class TestCommandsStreaming:
@@ -73,7 +133,7 @@ class TestCommandsStreaming:
         stderr_chunks: list[str] = []
 
         with respx.mock() as router:
-            router.post("https://api.example.com/sandboxes/sbx-1/exec/stream").mock(
+            router.post(f"{DATA_PLANE}/exec/stream").mock(
                 return_value=httpx.Response(
                     200,
                     content=sse_body.encode(),
@@ -96,7 +156,7 @@ class TestCommandsStreaming:
         sse_body = 'data: {"stdout": "partial"}\n\n'
 
         with respx.mock() as router:
-            router.post("https://api.example.com/sandboxes/sbx-1/exec/stream").mock(
+            router.post(f"{DATA_PLANE}/exec/stream").mock(
                 return_value=httpx.Response(
                     200,
                     content=sse_body.encode(),
@@ -105,8 +165,7 @@ class TestCommandsStreaming:
             )
             with pytest.raises(SandboxError, match="finished"):
                 _make_commands().run(
-                    "echo partial",
-                    on_stdout=lambda _c: None,
+                    "echo partial", on_stdout=lambda _c: None
                 )
 
     def test_streaming_with_nonzero_exit_code(self) -> None:
@@ -116,7 +175,7 @@ class TestCommandsStreaming:
         )
 
         with respx.mock() as router:
-            router.post("https://api.example.com/sandboxes/sbx-1/exec/stream").mock(
+            router.post(f"{DATA_PLANE}/exec/stream").mock(
                 return_value=httpx.Response(
                     200,
                     content=sse_body.encode(),

--- a/packages/python-sdk/tests/test_commands.py
+++ b/packages/python-sdk/tests/test_commands.py
@@ -186,3 +186,32 @@ class TestCommandsStreaming:
 
         assert result.exit_code == 42
         assert result.stderr == "err\n"
+
+    def test_streaming_retry_on_401_does_not_double_emit_callbacks(
+        self,
+    ) -> None:
+        deps, state = _make_deps()
+        sse_body = (
+            'data: {"stdout": "one"}\n\n'
+            'data: {"finished": true, "exit_code": 0}\n\n'
+        )
+        with respx.mock() as router:
+            router.post(f"{DATA_PLANE}/exec/stream").mock(
+                side_effect=[
+                    httpx.Response(401, json={"error": {"code": "auth_failed"}}),
+                    httpx.Response(
+                        200,
+                        content=sse_body.encode(),
+                        headers={"Content-Type": "text/event-stream"},
+                    ),
+                ]
+            )
+
+            received: list[str] = []
+            result = Commands(deps).run("echo", on_stdout=received.append)
+
+        # Callbacks fire exactly once — the 401 attempt never invoked on_stdout
+        assert received == ["one"]
+        assert result.stdout == "one"
+        assert result.exit_code == 0
+        assert state["refreshes"] == 1

--- a/packages/python-sdk/tests/test_sandbox.py
+++ b/packages/python-sdk/tests/test_sandbox.py
@@ -309,3 +309,100 @@ class TestCreateFromTemplate:
                 assert b"from_snapshot" in body
             finally:
                 sbx._close_http_client()
+
+
+class TestConcurrentRefresh:
+    def test_serialized_refresh_under_concurrent_401(self) -> None:
+        import threading
+
+        sbx_id = "sbx-conc"
+        sandbox_host = "sandbox.example.com"
+        data_plane = f"https://boxd-{sbx_id}.{sandbox_host}"
+
+        exec_call_count = 0
+        activate_call_count = 0
+        activate_lock = threading.Lock()
+        exec_lock = threading.Lock()
+
+        def exec_response(_request: httpx.Request) -> httpx.Response:
+            nonlocal exec_call_count
+            with exec_lock:
+                exec_call_count += 1
+                this_call = exec_call_count
+            # First two calls (one per thread) 401; subsequent succeed
+            if this_call <= 2:
+                return httpx.Response(
+                    401, json={"error": {"code": "auth_failed"}}
+                )
+            return httpx.Response(
+                200, json={"stdout": "ok", "stderr": "", "exit_code": 0}
+            )
+
+        def activate_response(_request: httpx.Request) -> httpx.Response:
+            nonlocal activate_call_count
+            with activate_lock:
+                activate_call_count += 1
+            # Slow enough to maximize chance of overlap if the lock were missing
+            import time as _t
+
+            _t.sleep(0.02)
+            return httpx.Response(
+                200,
+                json={
+                    "id": sbx_id,
+                    "name": "c",
+                    "status": "active",
+                    "created_at": "2026-01-01T00:00:00Z",
+                    "access_token": "tok-refreshed",
+                },
+            )
+
+        with respx.mock(
+            base_url=API, assert_all_called=False
+        ) as router:
+            router.post(f"{API}/sandboxes/{sbx_id}/activate").mock(
+                side_effect=activate_response
+            )
+            router.post(f"{data_plane}/exec").mock(side_effect=exec_response)
+
+            sbx = Sandbox.connect(
+                sbx_id, api_key="ss_live_x", base_url=API
+            )
+            try:
+                # Override sandbox_host so the data-plane URL matches our mock
+                sbx._config = sbx._config.__class__(
+                    api_key=sbx._config.api_key,
+                    base_url=sbx._config.base_url,
+                    sandbox_host=sandbox_host,
+                )
+                sbx.commands._data_plane_base_url = data_plane
+
+                results: list[Exception | str] = [None, None]  # type: ignore
+
+                def worker(idx: int) -> None:
+                    try:
+                        r = sbx.commands.run(f"echo {idx}")
+                        results[idx] = r.stdout
+                    except Exception as e:
+                        results[idx] = e
+
+                t1 = threading.Thread(target=worker, args=(0,))
+                t2 = threading.Thread(target=worker, args=(1,))
+                t1.start()
+                t2.start()
+                t1.join()
+                t2.join()
+
+                # Both must succeed (no 409 from lost-race second refresh)
+                for r in results:
+                    assert not isinstance(
+                        r, Exception
+                    ), f"expected success, got {r!r}"
+                assert results[0] == "ok"
+                assert results[1] == "ok"
+
+                # connect() did 1 activate + serialized refreshes added 2
+                assert activate_call_count == 3
+                assert exec_call_count == 4  # 2 initial 401s + 2 retries
+            finally:
+                sbx._close_http_client()

--- a/packages/python-sdk/tests/test_sandbox.py
+++ b/packages/python-sdk/tests/test_sandbox.py
@@ -63,7 +63,7 @@ class TestCreate:
 class TestConnect:
     def test_gets_and_returns_instance(self) -> None:
         with respx.mock() as router:
-            route = router.get(f"{API}/sandboxes/sbx-1").mock(
+            route = router.post(f"{API}/sandboxes/sbx-1/activate").mock(
                 return_value=httpx.Response(200, json=_raw())
             )
             sandbox = Sandbox.connect("sbx-1")
@@ -76,7 +76,7 @@ class TestConnect:
 
     def test_missing_access_token_raises(self) -> None:
         with respx.mock() as router:
-            router.get(f"{API}/sandboxes/sbx-1").mock(
+            router.post(f"{API}/sandboxes/sbx-1/activate").mock(
                 return_value=httpx.Response(200, json=_raw(access_token=None))
             )
             with pytest.raises(SandboxError, match="access_token"):
@@ -129,7 +129,7 @@ class TestKillById:
 class TestInstanceMethods:
     def test_kill_swallows_404(self) -> None:
         with respx.mock() as router:
-            router.get(f"{API}/sandboxes/sbx-1").mock(
+            router.post(f"{API}/sandboxes/sbx-1/activate").mock(
                 return_value=httpx.Response(200, json=_raw())
             )
             router.delete(f"{API}/sandboxes/sbx-1").mock(
@@ -141,7 +141,7 @@ class TestInstanceMethods:
 
     def test_repr_includes_id_and_status(self) -> None:
         with respx.mock() as router:
-            router.get(f"{API}/sandboxes/sbx-1").mock(
+            router.post(f"{API}/sandboxes/sbx-1/activate").mock(
                 return_value=httpx.Response(200, json=_raw())
             )
             sandbox = Sandbox.connect("sbx-1")
@@ -173,7 +173,7 @@ class TestInstanceMethods:
 
     def test_pause_returns_none(self) -> None:
         with respx.mock() as router:
-            router.get(f"{API}/sandboxes/sbx-1").mock(
+            router.post(f"{API}/sandboxes/sbx-1/activate").mock(
                 return_value=httpx.Response(200, json=_raw())
             )
             pause_route = router.post(f"{API}/sandboxes/sbx-1/pause").mock(
@@ -189,7 +189,7 @@ class TestInstanceMethods:
 
     def test_resume_rotates_token_and_rebuilds_files(self) -> None:
         with respx.mock() as router:
-            router.get(f"{API}/sandboxes/sbx-1").mock(
+            router.post(f"{API}/sandboxes/sbx-1/activate").mock(
                 return_value=httpx.Response(200, json=_raw())
             )
             router.post(f"{API}/sandboxes/sbx-1/resume").mock(
@@ -215,7 +215,7 @@ class TestInstanceMethods:
 
     def test_resume_missing_access_token_raises(self) -> None:
         with respx.mock() as router:
-            router.get(f"{API}/sandboxes/sbx-1").mock(
+            router.post(f"{API}/sandboxes/sbx-1/activate").mock(
                 return_value=httpx.Response(200, json=_raw())
             )
             router.post(f"{API}/sandboxes/sbx-1/resume").mock(
@@ -232,7 +232,7 @@ class TestInstanceMethods:
 
     def test_update_metadata(self) -> None:
         with respx.mock() as router:
-            router.get(f"{API}/sandboxes/sbx-1").mock(
+            router.post(f"{API}/sandboxes/sbx-1/activate").mock(
                 return_value=httpx.Response(200, json=_raw())
             )
             route = router.patch(f"{API}/sandboxes/sbx-1").mock(

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superserve/sdk",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "TypeScript SDK for the Superserve sandbox API",
   "keywords": [
     "firecracker",

--- a/packages/sdk/src/Sandbox.ts
+++ b/packages/sdk/src/Sandbox.ts
@@ -20,7 +20,6 @@ import { NotFoundError, SandboxError } from "./errors.js"
 import { Files } from "./files.js"
 import { request, requestVoid } from "./http.js"
 import type {
-  ApiResumeResponse,
   ApiSandboxResponse,
   ConnectionOptions,
   SandboxCreateOptions,
@@ -70,8 +69,44 @@ export class Sandbox {
     this._accessToken = accessToken
     this._config = config
 
-    this.commands = new Commands(config.baseUrl, this.id, config.apiKey)
+    this.commands = new Commands({
+      sandboxId: this.id,
+      sandboxHost: config.sandboxHost,
+      getAccessToken: () => this._accessToken,
+      refreshActivate: () => this._refreshActivate(),
+    })
     this.files = new Files(this.id, config.sandboxHost, this._accessToken)
+  }
+
+  /**
+   * POST a token-rotating endpoint (`/resume` or `/activate`), update the
+   * cached token, and rebuild `this.files` with the fresh token. Returns
+   * the new token. @internal
+   */
+  private async _postAndRotateToken(
+    endpoint: "resume" | "activate",
+  ): Promise<string> {
+    const raw = await request<ApiSandboxResponse>({
+      method: "POST",
+      url: `${this._config.baseUrl}/sandboxes/${this.id}/${endpoint}`,
+      headers: { "X-API-Key": this._config.apiKey },
+    })
+    if (!raw.access_token) {
+      throw new SandboxError(
+        `Invalid API response from POST /sandboxes/{id}/${endpoint}: missing access_token`,
+      )
+    }
+    this._accessToken = raw.access_token
+    this.files = new Files(this.id, this._config.sandboxHost, this._accessToken)
+    return this._accessToken
+  }
+
+  /**
+   * Call `POST /activate` to ensure the sandbox is active and refresh the
+   * access token. Slow-path fallback for data-plane AuthenticationError. @internal
+   */
+  private _refreshActivate(): Promise<string> {
+    return this._postAndRotateToken("activate")
   }
 
   // -------------------------------------------------------------------------
@@ -133,7 +168,8 @@ export class Sandbox {
   /**
    * Connect to an existing sandbox by ID.
    *
-   * Fetches the sandbox info and access token, returns a ready-to-use instance.
+   * Calls `POST /activate` so the returned instance is guaranteed to be
+   * active (paused sandboxes are auto-resumed) with a fresh access token.
    *
    * @example
    * ```typescript
@@ -147,15 +183,15 @@ export class Sandbox {
     const config = resolveConfig(options)
 
     const raw = await request<ApiSandboxResponse>({
-      method: "GET",
-      url: `${config.baseUrl}/sandboxes/${sandboxId}`,
+      method: "POST",
+      url: `${config.baseUrl}/sandboxes/${sandboxId}/activate`,
       headers: { "X-API-Key": config.apiKey },
       signal: options.signal,
     })
 
     if (!raw.access_token) {
       throw new SandboxError(
-        "Invalid API response from GET /sandboxes/{id}: missing access_token",
+        "Invalid API response from POST /sandboxes/{id}/activate: missing access_token",
       )
     }
     return new Sandbox(toSandboxInfo(raw), raw.access_token, config)
@@ -254,19 +290,7 @@ export class Sandbox {
    * fresh token transparently.
    */
   async resume(): Promise<void> {
-    const raw = await request<ApiResumeResponse>({
-      method: "POST",
-      url: `${this._config.baseUrl}/sandboxes/${this.id}/resume`,
-      headers: { "X-API-Key": this._config.apiKey },
-    })
-    if (!raw.access_token) {
-      throw new SandboxError(
-        "Invalid API response from POST /sandboxes/{id}/resume: missing access_token",
-      )
-    }
-    this._accessToken = raw.access_token
-    // Rebuild sandbox.files with the fresh token
-    this.files = new Files(this.id, this._config.sandboxHost, this._accessToken)
+    await this._postAndRotateToken("resume")
   }
 
   /**

--- a/packages/sdk/src/Sandbox.ts
+++ b/packages/sdk/src/Sandbox.ts
@@ -54,6 +54,7 @@ export class Sandbox {
   files: Files
 
   private _accessToken: string
+  private _refreshInFlight: Promise<string> | null = null
   private readonly _config: ResolvedConfig
 
   /** @internal — Use Sandbox.create() or Sandbox.connect() instead. */
@@ -93,7 +94,7 @@ export class Sandbox {
     })
     if (!raw.access_token) {
       throw new SandboxError(
-        `Invalid API response from POST /sandboxes/{id}/${endpoint}: missing access_token`,
+        `Invalid API response from POST /sandboxes/${this.id}/${endpoint}: missing access_token`,
       )
     }
     this._accessToken = raw.access_token
@@ -102,11 +103,16 @@ export class Sandbox {
   }
 
   /**
-   * Call `POST /activate` to ensure the sandbox is active and refresh the
-   * access token. Slow-path fallback for data-plane AuthenticationError. @internal
+   * Slow-path fallback for data-plane AuthenticationError. Coalesces
+   * concurrent callers onto a single in-flight POST /activate so a
+   * paused-sandbox resume isn't claimed twice (the loser gets 409). @internal
    */
   private _refreshActivate(): Promise<string> {
-    return this._postAndRotateToken("activate")
+    if (this._refreshInFlight) return this._refreshInFlight
+    this._refreshInFlight = this._postAndRotateToken("activate").finally(() => {
+      this._refreshInFlight = null
+    })
+    return this._refreshInFlight
   }
 
   // -------------------------------------------------------------------------
@@ -191,7 +197,7 @@ export class Sandbox {
 
     if (!raw.access_token) {
       throw new SandboxError(
-        "Invalid API response from POST /sandboxes/{id}/activate: missing access_token",
+        `Invalid API response from POST /sandboxes/${sandboxId}/activate: missing access_token`,
       )
     }
     return new Sandbox(toSandboxInfo(raw), raw.access_token, config)

--- a/packages/sdk/src/commands.ts
+++ b/packages/sdk/src/commands.ts
@@ -1,14 +1,14 @@
 /**
  * `sandbox.commands` - run shell commands inside a sandbox.
  *
- * Supports two modes:
- * - Synchronous: waits for command to finish, returns stdout/stderr/exitCode
- * - Streaming: fires onStdout/onStderr callbacks via SSE, then returns result
+ * Hits the per-sandbox data plane with the access token. On 401 the
+ * SDK auto-refreshes via `POST /activate` and retries once.
  *
  * Accessed as `sandbox.commands.run(...)`.
  */
 
-import { SandboxError } from "./errors.js"
+import { dataPlaneUrl } from "./config.js"
+import { AuthenticationError, SandboxError } from "./errors.js"
 import { request, streamSSE } from "./http.js"
 import type {
   ApiExecResult,
@@ -17,13 +17,21 @@ import type {
   CommandResult,
 } from "./types.js"
 
+/** @internal */
+export interface CommandsDeps {
+  sandboxId: string
+  sandboxHost: string
+  getAccessToken: () => string
+  refreshActivate: () => Promise<string>
+}
+
 export class Commands {
+  private readonly _dataPlaneBaseUrl: string
+
   /** @internal */
-  constructor(
-    private readonly _baseUrl: string,
-    private readonly _sandboxId: string,
-    private readonly _apiKey: string,
-  ) {}
+  constructor(private readonly _deps: CommandsDeps) {
+    this._dataPlaneBaseUrl = dataPlaneUrl(_deps.sandboxId, _deps.sandboxHost)
+  }
 
   /**
    * Execute a command inside the sandbox.
@@ -60,30 +68,32 @@ export class Commands {
     // API expects seconds; convert from ms
     if (timeoutMs !== undefined) body.timeout_s = Math.ceil(timeoutMs / 1000)
 
-    const authHeaders = { "X-API-Key": this._apiKey }
-
     if (isStreaming) {
-      return this._runStreaming(body, authHeaders, options)
+      return this._runStreaming(body, options)
     }
-    return this._runSync(body, authHeaders, options)
+    return this._runSync(body, options)
   }
 
   private async _runSync(
     body: Record<string, unknown>,
-    headers: Record<string, string>,
     options: CommandOptions,
   ): Promise<CommandResult> {
-    const raw = await request<ApiExecResult>({
-      method: "POST",
-      url: `${this._baseUrl}/sandboxes/${this._sandboxId}/exec`,
-      headers,
-      body,
-      // Add a 5s buffer so the server-side command timeout fires first
-      // and returns its proper response before the client aborts.
-      timeoutMs:
-        options.timeoutMs !== undefined ? options.timeoutMs + 5_000 : undefined,
-      signal: options.signal,
-    })
+    const send = (token: string) =>
+      request<ApiExecResult>({
+        method: "POST",
+        url: `${this._dataPlaneBaseUrl}/exec`,
+        headers: { "X-Access-Token": token },
+        body,
+        // Add a 5s buffer so the server-side command timeout fires first
+        // and returns its proper response before the client aborts.
+        timeoutMs:
+          options.timeoutMs !== undefined
+            ? options.timeoutMs + 5_000
+            : undefined,
+        signal: options.signal,
+      })
+
+    const raw = await this._withTokenRetry(send)
     return {
       stdout: raw.stdout ?? "",
       stderr: raw.stderr ?? "",
@@ -93,7 +103,36 @@ export class Commands {
 
   private async _runStreaming(
     body: Record<string, unknown>,
+    options: CommandOptions,
+  ): Promise<CommandResult> {
+    const send = async (token: string) =>
+      this._consumeStream(
+        `${this._dataPlaneBaseUrl}/exec/stream`,
+        { "X-Access-Token": token },
+        body,
+        options,
+      )
+    return this._withTokenRetry(send)
+  }
+
+  // Safe for streaming: 401 is returned in the HTTP status code before
+  // any SSE data is written, so the retry can't double-emit callbacks.
+  private async _withTokenRetry<T>(
+    send: (token: string) => Promise<T>,
+  ): Promise<T> {
+    try {
+      return await send(this._deps.getAccessToken())
+    } catch (err) {
+      if (!(err instanceof AuthenticationError)) throw err
+      const fresh = await this._deps.refreshActivate()
+      return send(fresh)
+    }
+  }
+
+  private async _consumeStream(
+    url: string,
     headers: Record<string, string>,
+    body: Record<string, unknown>,
     options: CommandOptions,
   ): Promise<CommandResult> {
     let stdout = ""
@@ -103,10 +142,9 @@ export class Commands {
     let sawFinished = false
 
     await streamSSE({
-      url: `${this._baseUrl}/sandboxes/${this._sandboxId}/exec/stream`,
+      url,
       headers,
       body,
-      // Idle timeout (resets per chunk); +5s matches Python SDK parity.
       timeoutMs:
         options.timeoutMs !== undefined ? options.timeoutMs + 5_000 : undefined,
       signal: options.signal,

--- a/packages/sdk/src/commands.ts
+++ b/packages/sdk/src/commands.ts
@@ -117,6 +117,8 @@ export class Commands {
 
   // Safe for streaming: 401 is returned in the HTTP status code before
   // any SSE data is written, so the retry can't double-emit callbacks.
+  // The try/catch wraps `send` only — if `refreshActivate` itself 401s
+  // (bad API key), it propagates uncaught, so no recursion is possible.
   private async _withTokenRetry<T>(
     send: (token: string) => Promise<T>,
   ): Promise<T> {

--- a/packages/sdk/tests/commands.test.ts
+++ b/packages/sdk/tests/commands.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import { Commands } from "../src/commands.js"
-import { SandboxError } from "../src/errors.js"
+import { Commands, type CommandsDeps } from "../src/commands.js"
+import { AuthenticationError, SandboxError } from "../src/errors.js"
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -26,34 +26,52 @@ function sseResponse(chunks: string[]): Response {
   })
 }
 
-const baseUrl = "https://api.superserve.ai"
-const apiKey = "ss_live_test"
 const sandboxId = "sbx-1"
+const sandboxHost = "sandbox.superserve.ai"
+const dataPlaneUrl = `https://boxd-${sandboxId}.${sandboxHost}`
+
+function makeDeps(overrides: Partial<CommandsDeps> = {}): CommandsDeps {
+  let token = "tok-initial"
+  return {
+    sandboxId,
+    sandboxHost,
+    getAccessToken: () => token,
+    refreshActivate: async () => {
+      token = "tok-refreshed"
+      return token
+    },
+    ...overrides,
+  }
+}
 
 describe("Commands.run (sync)", () => {
   afterEach(() => {
     vi.unstubAllGlobals()
   })
 
-  it("returns stdout/stderr/exitCode from API", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () =>
-        jsonResponse({
-          stdout: "hello\n",
-          stderr: "warn\n",
-          exit_code: 0,
-        }),
-      ),
+  it("hits the data-plane /exec with X-Access-Token", async () => {
+    const mock = vi.fn(async () =>
+      jsonResponse({ stdout: "hello\n", stderr: "warn\n", exit_code: 0 }),
     )
+    vi.stubGlobal("fetch", mock)
 
-    const commands = new Commands(baseUrl, sandboxId, apiKey)
+    const commands = new Commands(makeDeps())
     const result = await commands.run("echo hello")
+
     expect(result).toEqual({
       stdout: "hello\n",
       stderr: "warn\n",
       exitCode: 0,
     })
+    const [url, init] = mock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe(`${dataPlaneUrl}/exec`)
+    expect(init.method).toBe("POST")
+    expect((init.headers as Record<string, string>)["X-Access-Token"]).toBe(
+      "tok-initial",
+    )
+    expect(
+      (init.headers as Record<string, string>)["X-API-Key"],
+    ).toBeUndefined()
   })
 
   it("converts timeoutMs to timeout_s (ceiled)", async () => {
@@ -62,12 +80,69 @@ describe("Commands.run (sync)", () => {
     )
     vi.stubGlobal("fetch", mock)
 
-    const commands = new Commands(baseUrl, sandboxId, apiKey)
+    const commands = new Commands(makeDeps())
     await commands.run("sleep 1", { timeoutMs: 2500 })
 
     const init = mock.mock.calls[0]?.[1] as RequestInit
     const body = JSON.parse(init.body as string)
     expect(body.timeout_s).toBe(3)
+  })
+
+  it("refreshes token + retries on AuthenticationError, then succeeds", async () => {
+    let refreshCalled = 0
+    const deps = makeDeps({
+      refreshActivate: async () => {
+        refreshCalled += 1
+        return "tok-refreshed"
+      },
+    })
+
+    const mock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        jsonResponse({ error: { code: "auth_failed" } }, 401),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ stdout: "ok\n", stderr: "", exit_code: 0 }),
+      )
+    vi.stubGlobal("fetch", mock)
+
+    const commands = new Commands(deps)
+    const result = await commands.run("echo")
+
+    expect(result.stdout).toBe("ok\n")
+    expect(refreshCalled).toBe(1)
+    expect(mock).toHaveBeenCalledTimes(2)
+    const [, secondInit] = mock.mock.calls[1] as [string, RequestInit]
+    expect(
+      (secondInit.headers as Record<string, string>)["X-Access-Token"],
+    ).toBe("tok-refreshed")
+  })
+
+  it("does NOT retry on non-auth errors (e.g. 500)", async () => {
+    const deps = makeDeps()
+    const mock = vi.fn(async () =>
+      jsonResponse({ error: { code: "server_error" } }, 500),
+    )
+    vi.stubGlobal("fetch", mock)
+
+    const commands = new Commands(deps)
+    await expect(commands.run("echo")).rejects.toBeInstanceOf(SandboxError)
+  })
+
+  it("propagates AuthenticationError if refresh also fails", async () => {
+    const deps = makeDeps({
+      refreshActivate: async () => "tok-refreshed",
+    })
+    const mock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(jsonResponse({ error: { code: "auth_failed" } }, 401))
+    vi.stubGlobal("fetch", mock)
+
+    const commands = new Commands(deps)
+    await expect(commands.run("echo")).rejects.toBeInstanceOf(
+      AuthenticationError,
+    )
   })
 })
 
@@ -76,26 +151,27 @@ describe("Commands.run (streaming)", () => {
     vi.unstubAllGlobals()
   })
 
-  it("calls onStdout for each chunk and returns aggregated result", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () =>
-        sseResponse([
-          `data: ${JSON.stringify({ stdout: "hi " })}\n`,
-          `data: ${JSON.stringify({ stdout: "there" })}\n`,
-          `data: ${JSON.stringify({ finished: true, exit_code: 0 })}\n`,
-        ]),
-      ),
+  it("hits data-plane /exec/stream and aggregates stdout chunks", async () => {
+    const mock = vi.fn(async () =>
+      sseResponse([
+        `data: ${JSON.stringify({ stdout: "hi " })}\n`,
+        `data: ${JSON.stringify({ stdout: "there" })}\n`,
+        `data: ${JSON.stringify({ finished: true, exit_code: 0 })}\n`,
+      ]),
     )
+    vi.stubGlobal("fetch", mock)
 
     const received: string[] = []
-    const commands = new Commands(baseUrl, sandboxId, apiKey)
+    const commands = new Commands(makeDeps())
     const result = await commands.run("echo", {
       onStdout: (d) => received.push(d),
     })
+
     expect(received).toEqual(["hi ", "there"])
     expect(result.stdout).toBe("hi there")
     expect(result.exitCode).toBe(0)
+    const [url] = mock.mock.calls[0] as [string]
+    expect(url).toBe(`${dataPlaneUrl}/exec/stream`)
   })
 
   it("throws if stream ends without finished event", async () => {
@@ -106,7 +182,7 @@ describe("Commands.run (streaming)", () => {
       ),
     )
 
-    const commands = new Commands(baseUrl, sandboxId, apiKey)
+    const commands = new Commands(makeDeps())
     await expect(
       commands.run("echo", { onStdout: () => {} }),
     ).rejects.toSatisfy(
@@ -126,10 +202,8 @@ describe("Commands.run (streaming)", () => {
       ),
     )
 
-    const commands = new Commands(baseUrl, sandboxId, apiKey)
-    const result = await commands.run("bad", {
-      onStderr: () => {},
-    })
+    const commands = new Commands(makeDeps())
+    const result = await commands.run("bad", { onStderr: () => {} })
     expect(result.stderr).toBe("warn\ncrashed")
     expect(result.exitCode).toBe(1)
   })

--- a/packages/sdk/tests/commands.test.ts
+++ b/packages/sdk/tests/commands.test.ts
@@ -207,4 +207,38 @@ describe("Commands.run (streaming)", () => {
     expect(result.stderr).toBe("warn\ncrashed")
     expect(result.exitCode).toBe(1)
   })
+
+  it("streaming retry on 401 doesn't double-emit callbacks", async () => {
+    let refreshCalls = 0
+    const deps = makeDeps({
+      refreshActivate: async () => {
+        refreshCalls += 1
+        return "tok-refreshed"
+      },
+    })
+    const mock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        jsonResponse({ error: { code: "auth_failed" } }, 401),
+      )
+      .mockResolvedValueOnce(
+        sseResponse([
+          `data: ${JSON.stringify({ stdout: "one" })}\n`,
+          `data: ${JSON.stringify({ finished: true, exit_code: 0 })}\n`,
+        ]),
+      )
+    vi.stubGlobal("fetch", mock)
+
+    const received: string[] = []
+    const commands = new Commands(deps)
+    const result = await commands.run("echo", {
+      onStdout: (d) => received.push(d),
+    })
+
+    // Callbacks fire exactly once — the 401 attempt never invoked onStdout
+    expect(received).toEqual(["one"])
+    expect(result.stdout).toBe("one")
+    expect(result.exitCode).toBe(0)
+    expect(refreshCalls).toBe(1)
+  })
 })

--- a/packages/sdk/tests/sandbox.test.ts
+++ b/packages/sdk/tests/sandbox.test.ts
@@ -290,3 +290,45 @@ describe("Sandbox.create fromTemplate / fromSnapshot", () => {
     expect(body.from_snapshot).toBe("snap-abc")
   })
 })
+
+describe("Sandbox concurrent token refresh coalesce", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("two concurrent 401-retries fire only one /activate", async () => {
+    let activateCalls = 0
+    let execCalls = 0
+    const mock = vi.fn<typeof fetch>(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString()
+      if (url.includes("/activate")) {
+        activateCalls += 1
+        // Slow enough that both concurrent callers race onto the same
+        // in-flight promise.
+        await new Promise((r) => setTimeout(r, 20))
+        return jsonResponse({ ...baseSandbox, access_token: "tok-refreshed" })
+      }
+      if (url.endsWith("/exec")) {
+        execCalls += 1
+        if (execCalls <= 2) return errorResponse(401, "auth_failed")
+        return jsonResponse({ stdout: "ok", stderr: "", exit_code: 0 })
+      }
+      return jsonResponse(baseSandbox)
+    })
+    vi.stubGlobal("fetch", mock)
+
+    const sandbox = await Sandbox.connect("sbx-1", commonOpts)
+    expect(activateCalls).toBe(1) // baseline: connect() did one
+
+    const [a, b] = await Promise.all([
+      sandbox.commands.run("echo a"),
+      sandbox.commands.run("echo b"),
+    ])
+
+    expect(a.exitCode).toBe(0)
+    expect(b.exitCode).toBe(0)
+    // Two concurrent 401s → ONE additional /activate (coalesced)
+    expect(activateCalls).toBe(2)
+    expect(execCalls).toBe(4) // 2 initial 401s + 2 successful retries
+  })
+})

--- a/packages/sdk/tests/sandbox.test.ts
+++ b/packages/sdk/tests/sandbox.test.ts
@@ -78,7 +78,7 @@ describe("Sandbox statics", () => {
     ).rejects.toThrow(/missing access_token/)
   })
 
-  it("Sandbox.connect fetches and returns instance", async () => {
+  it("Sandbox.connect POSTs /activate and returns instance", async () => {
     const mock = vi.fn(async () => jsonResponse(baseSandbox))
     vi.stubGlobal("fetch", mock)
 
@@ -86,8 +86,8 @@ describe("Sandbox statics", () => {
     expect(sandbox.id).toBe("sbx-1")
 
     const [url, init] = mock.mock.calls[0] as [string, RequestInit]
-    expect(url).toBe("https://api.superserve.ai/sandboxes/sbx-1")
-    expect(init.method).toBe("GET")
+    expect(url).toBe("https://api.superserve.ai/sandboxes/sbx-1/activate")
+    expect(init.method).toBe("POST")
   })
 
   it("Sandbox.connect throws when access_token missing", async () => {


### PR DESCRIPTION
Switches `Sandbox.commands.run()` to the per-sandbox data-plane `/exec` and `Sandbox.connect()` to `POST /activate`. On 401 the SDK auto-refreshes via /activate and retries once.

Same shape in TS and Python (sync + async). Pairs with sandbox PR #77 which shipped the server-side endpoints.

**Breaking**: `Sandbox.connect()` now POSTs `/activate` instead of `GET /sandboxes/:id`. Paused sandboxes are auto-resumed and the token is rotated on every call. The previous read-only "fetch existing sandbox info without resuming" behavior is no longer available through `connect()` — use `Sandbox.list()` + filter or the REST API for inspection-only flows.