### PR TITLE
sdk: route data plane via shared host on supported domains (0.7.3)

### DIFF
--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "superserve"
-version = "0.7.2"
+version = "0.7.3"
 description = "Python SDK for the Superserve sandbox API"
 license = "Apache-2.0"
 readme = "README.md"

--- a/packages/python-sdk/src/superserve/__init__.py
+++ b/packages/python-sdk/src/superserve/__init__.py
@@ -35,7 +35,7 @@ from .types import (
     WorkdirStep,
 )
 
-__version__ = "0.7.2"
+__version__ = "0.7.3"
 
 __all__ = [
     "AsyncSandbox",

--- a/packages/python-sdk/src/superserve/_config.py
+++ b/packages/python-sdk/src/superserve/_config.py
@@ -65,13 +65,14 @@ def data_plane_target(sandbox_id: str, sandbox_host: str) -> DataPlaneTarget:
     X-Superserve-Sandbox-Id. Unsupported hosts fall back to the
     per-sandbox subdomain.
     """
-    if sandbox_host in _SUPPORTED_SHARED_HOSTS:
+    host = sandbox_host.lower()
+    if host in _SUPPORTED_SHARED_HOSTS:
         return DataPlaneTarget(
-            url=f"https://{sandbox_host}",
+            url=f"https://{host}",
             headers={_SANDBOX_ID_HEADER: sandbox_id},
         )
     return DataPlaneTarget(
-        url=f"https://boxd-{sandbox_id}.{sandbox_host}",
+        url=f"https://boxd-{sandbox_id}.{host}",
         headers={},
     )
 

--- a/packages/python-sdk/src/superserve/_config.py
+++ b/packages/python-sdk/src/superserve/_config.py
@@ -47,7 +47,7 @@ _SUPPORTED_SHARED_HOSTS: frozenset[str] = frozenset(
     }
 )
 
-SANDBOX_ID_HEADER = "X-Superserve-Sandbox-Id"
+_SANDBOX_ID_HEADER = "X-Superserve-Sandbox-Id"
 
 
 @dataclass(frozen=True)
@@ -68,7 +68,7 @@ def data_plane_target(sandbox_id: str, sandbox_host: str) -> DataPlaneTarget:
     if sandbox_host in _SUPPORTED_SHARED_HOSTS:
         return DataPlaneTarget(
             url=f"https://{sandbox_host}",
-            headers={SANDBOX_ID_HEADER: sandbox_id},
+            headers={_SANDBOX_ID_HEADER: sandbox_id},
         )
     return DataPlaneTarget(
         url=f"https://boxd-{sandbox_id}.{sandbox_host}",

--- a/packages/python-sdk/src/superserve/_config.py
+++ b/packages/python-sdk/src/superserve/_config.py
@@ -39,9 +39,41 @@ def resolve_config(
     )
 
 
-def data_plane_url(sandbox_id: str, sandbox_host: str) -> str:
-    """Build the data-plane base URL for a specific sandbox."""
-    return f"https://boxd-{sandbox_id}.{sandbox_host}"
+# Sandbox hosts where the proxy supports shared-host routing.
+_SUPPORTED_SHARED_HOSTS: frozenset[str] = frozenset(
+    {
+        "sandbox.superserve.ai",
+        "staging-sandbox.superserve.ai",
+    }
+)
+
+SANDBOX_ID_HEADER = "X-Superserve-Sandbox-Id"
+
+
+@dataclass(frozen=True)
+class DataPlaneTarget:
+    """Base URL + routing headers for one data-plane request."""
+
+    url: str
+    headers: dict[str, str]
+
+
+def data_plane_target(sandbox_id: str, sandbox_host: str) -> DataPlaneTarget:
+    """Resolve the data-plane base URL + routing headers for a sandbox.
+
+    On a supported host, routes via the shared origin with
+    X-Superserve-Sandbox-Id. Unsupported hosts fall back to the
+    per-sandbox subdomain.
+    """
+    if sandbox_host in _SUPPORTED_SHARED_HOSTS:
+        return DataPlaneTarget(
+            url=f"https://{sandbox_host}",
+            headers={SANDBOX_ID_HEADER: sandbox_id},
+        )
+    return DataPlaneTarget(
+        url=f"https://boxd-{sandbox_id}.{sandbox_host}",
+        headers={},
+    )
 
 
 def _derive_sandbox_host(base_url: str) -> str:

--- a/packages/python-sdk/src/superserve/commands.py
+++ b/packages/python-sdk/src/superserve/commands.py
@@ -12,7 +12,7 @@ from typing import Any, TypeVar
 
 import httpx
 
-from ._config import data_plane_url
+from ._config import data_plane_target
 from ._http import api_request, async_api_request, async_stream_sse, stream_sse
 from .errors import AuthenticationError, SandboxError
 from .types import CommandResult
@@ -50,9 +50,9 @@ class Commands:
     ) -> None:
         self._deps = deps
         self._client = client
-        self._data_plane_base_url = data_plane_url(
-            deps.sandbox_id, deps.sandbox_host
-        )
+        target = data_plane_target(deps.sandbox_id, deps.sandbox_host)
+        self._data_plane_base_url = target.url
+        self._routing_headers = target.headers
 
     def run(
         self,
@@ -93,7 +93,7 @@ class Commands:
             return api_request(
                 "POST",
                 f"{self._data_plane_base_url}/exec",
-                headers={"X-Access-Token": token},
+                headers={**self._routing_headers, "X-Access-Token": token},
                 json_body=body,
                 timeout=float(timeout_seconds) + 5.0
                 if timeout_seconds is not None
@@ -118,7 +118,7 @@ class Commands:
         def send(token: str) -> CommandResult:
             return self._consume_stream(
                 f"{self._data_plane_base_url}/exec/stream",
-                {"X-Access-Token": token},
+                {**self._routing_headers, "X-Access-Token": token},
                 body,
                 on_stdout,
                 on_stderr,
@@ -202,9 +202,9 @@ class AsyncCommands:
     ) -> None:
         self._deps = deps
         self._client = client
-        self._data_plane_base_url = data_plane_url(
-            deps.sandbox_id, deps.sandbox_host
-        )
+        target = data_plane_target(deps.sandbox_id, deps.sandbox_host)
+        self._data_plane_base_url = target.url
+        self._routing_headers = target.headers
 
     async def run(
         self,
@@ -242,7 +242,7 @@ class AsyncCommands:
             return await async_api_request(
                 "POST",
                 f"{self._data_plane_base_url}/exec",
-                headers={"X-Access-Token": token},
+                headers={**self._routing_headers, "X-Access-Token": token},
                 json_body=body,
                 timeout=float(timeout_seconds) + 5.0
                 if timeout_seconds is not None
@@ -267,7 +267,7 @@ class AsyncCommands:
         async def send(token: str) -> CommandResult:
             return await self._consume_stream(
                 f"{self._data_plane_base_url}/exec/stream",
-                {"X-Access-Token": token},
+                {**self._routing_headers, "X-Access-Token": token},
                 body,
                 on_stdout,
                 on_stderr,

--- a/packages/python-sdk/src/superserve/files.py
+++ b/packages/python-sdk/src/superserve/files.py
@@ -7,7 +7,7 @@ from urllib.parse import quote
 
 import httpx
 
-from ._config import data_plane_url
+from ._config import data_plane_target
 from ._http import (
     async_download_bytes,
     async_upload_bytes,
@@ -34,7 +34,9 @@ class Files:
         access_token: str,
         client: httpx.Client | None = None,
     ) -> None:
-        self._base_url = data_plane_url(sandbox_id, sandbox_host)
+        target = data_plane_target(sandbox_id, sandbox_host)
+        self._base_url = target.url
+        self._routing_headers = target.headers
         self._access_token = access_token
         self._client = client
 
@@ -48,7 +50,7 @@ class Files:
         url = f"{self._base_url}/files?path={quote(path, safe='')}"
         kwargs: dict[str, Any] = {
             "url": url,
-            "headers": {"X-Access-Token": self._access_token},
+            "headers": {**self._routing_headers, "X-Access-Token": self._access_token},
             "content": content,
             "client": self._client,
         }
@@ -62,7 +64,7 @@ class Files:
         url = f"{self._base_url}/files?path={quote(path, safe='')}"
         kwargs: dict[str, Any] = {
             "url": url,
-            "headers": {"X-Access-Token": self._access_token},
+            "headers": {**self._routing_headers, "X-Access-Token": self._access_token},
             "client": self._client,
         }
         if timeout is not None:
@@ -85,7 +87,9 @@ class AsyncFiles:
         access_token: str,
         client: httpx.AsyncClient | None = None,
     ) -> None:
-        self._base_url = data_plane_url(sandbox_id, sandbox_host)
+        target = data_plane_target(sandbox_id, sandbox_host)
+        self._base_url = target.url
+        self._routing_headers = target.headers
         self._access_token = access_token
         self._client = client
 
@@ -99,7 +103,7 @@ class AsyncFiles:
         url = f"{self._base_url}/files?path={quote(path, safe='')}"
         kwargs: dict[str, Any] = {
             "url": url,
-            "headers": {"X-Access-Token": self._access_token},
+            "headers": {**self._routing_headers, "X-Access-Token": self._access_token},
             "content": content,
             "client": self._client,
         }
@@ -113,7 +117,7 @@ class AsyncFiles:
         url = f"{self._base_url}/files?path={quote(path, safe='')}"
         kwargs: dict[str, Any] = {
             "url": url,
-            "headers": {"X-Access-Token": self._access_token},
+            "headers": {**self._routing_headers, "X-Access-Token": self._access_token},
             "client": self._client,
         }
         if timeout is not None:

--- a/packages/python-sdk/tests/test_commands.py
+++ b/packages/python-sdk/tests/test_commands.py
@@ -215,3 +215,42 @@ class TestCommandsStreaming:
         assert result.stdout == "one"
         assert result.exit_code == 0
         assert state["refreshes"] == 1
+
+
+class TestCommandsSharedHostRouting:
+    def test_uses_shared_host_when_supported(self) -> None:
+        deps = CommandsDeps(
+            sandbox_id=SBX,
+            sandbox_host="sandbox.superserve.ai",
+            get_access_token=lambda: "tok",
+            refresh_activate=lambda: "tok",
+        )
+        with respx.mock() as router:
+            route = router.post("https://sandbox.superserve.ai/exec").mock(
+                return_value=httpx.Response(
+                    200, json={"stdout": "ok", "stderr": "", "exit_code": 0}
+                )
+            )
+            Commands(deps).run("echo")
+            req = route.calls.last.request
+            assert req.headers.get("x-superserve-sandbox-id") == SBX
+            assert req.headers.get("x-access-token") == "tok"
+
+    def test_falls_back_to_subdomain_on_unsupported_host(self) -> None:
+        deps = CommandsDeps(
+            sandbox_id=SBX,
+            sandbox_host="self-hosted.example.org",
+            get_access_token=lambda: "tok",
+            refresh_activate=lambda: "tok",
+        )
+        with respx.mock() as router:
+            route = router.post(
+                f"https://boxd-{SBX}.self-hosted.example.org/exec"
+            ).mock(
+                return_value=httpx.Response(
+                    200, json={"stdout": "ok", "stderr": "", "exit_code": 0}
+                )
+            )
+            Commands(deps).run("echo")
+            req = route.calls.last.request
+            assert "x-superserve-sandbox-id" not in {k.lower() for k in req.headers}

--- a/packages/python-sdk/tests/test_commands.py
+++ b/packages/python-sdk/tests/test_commands.py
@@ -254,3 +254,48 @@ class TestCommandsSharedHostRouting:
             Commands(deps).run("echo")
             req = route.calls.last.request
             assert "x-superserve-sandbox-id" not in {k.lower() for k in req.headers}
+
+    def test_streaming_carries_sandbox_id_header_on_shared_host(self) -> None:
+        deps = CommandsDeps(
+            sandbox_id=SBX,
+            sandbox_host="sandbox.superserve.ai",
+            get_access_token=lambda: "tok",
+            refresh_activate=lambda: "tok",
+        )
+        sse_body = (
+            'data: {"stdout": "x"}\n\n'
+            'data: {"finished": true, "exit_code": 0}\n\n'
+        )
+        with respx.mock() as router:
+            route = router.post("https://sandbox.superserve.ai/exec/stream").mock(
+                return_value=httpx.Response(
+                    200,
+                    content=sse_body.encode(),
+                    headers={"Content-Type": "text/event-stream"},
+                )
+            )
+            Commands(deps).run("echo", on_stdout=lambda _c: None)
+            req = route.calls.last.request
+            assert req.headers.get("x-superserve-sandbox-id") == SBX
+
+    def test_preserves_sandbox_id_header_after_401_retry_on_shared_host(self) -> None:
+        deps = CommandsDeps(
+            sandbox_id=SBX,
+            sandbox_host="sandbox.superserve.ai",
+            get_access_token=lambda: "tok",
+            refresh_activate=lambda: "tok-refreshed",
+        )
+        with respx.mock() as router:
+            route = router.post("https://sandbox.superserve.ai/exec").mock(
+                side_effect=[
+                    httpx.Response(401, json={"error": {"code": "auth_failed"}}),
+                    httpx.Response(
+                        200,
+                        json={"stdout": "ok\n", "stderr": "", "exit_code": 0},
+                    ),
+                ]
+            )
+            Commands(deps).run("echo")
+            second = route.calls[1].request
+            assert second.headers.get("x-superserve-sandbox-id") == SBX
+            assert second.headers.get("x-access-token") == "tok-refreshed"

--- a/packages/python-sdk/tests/test_config.py
+++ b/packages/python-sdk/tests/test_config.py
@@ -7,7 +7,7 @@ from superserve._config import (
     DEFAULT_BASE_URL,
     DEFAULT_SANDBOX_HOST,
     _derive_sandbox_host,
-    data_plane_url,
+    data_plane_target,
     resolve_config,
 )
 from superserve.errors import AuthenticationError
@@ -72,9 +72,18 @@ class TestDeriveSandboxHost:
         assert _derive_sandbox_host("not a url") == DEFAULT_SANDBOX_HOST
 
 
-class TestDataPlaneUrl:
-    def test_builds_url(self) -> None:
-        assert (
-            data_plane_url("abc-123", "sandbox.superserve.ai")
-            == "https://boxd-abc-123.sandbox.superserve.ai"
-        )
+class TestDataPlaneTarget:
+    def test_shared_host_on_prod(self) -> None:
+        target = data_plane_target("abc-123", "sandbox.superserve.ai")
+        assert target.url == "https://sandbox.superserve.ai"
+        assert target.headers["X-Superserve-Sandbox-Id"] == "abc-123"
+
+    def test_shared_host_on_staging(self) -> None:
+        target = data_plane_target("xyz", "staging-sandbox.superserve.ai")
+        assert target.url == "https://staging-sandbox.superserve.ai"
+        assert target.headers["X-Superserve-Sandbox-Id"] == "xyz"
+
+    def test_falls_back_to_subdomain_on_unsupported_host(self) -> None:
+        target = data_plane_target("abc", "self-hosted.example.org")
+        assert target.url == "https://boxd-abc.self-hosted.example.org"
+        assert target.headers == {}

--- a/packages/python-sdk/tests/test_config.py
+++ b/packages/python-sdk/tests/test_config.py
@@ -87,3 +87,8 @@ class TestDataPlaneTarget:
         target = data_plane_target("abc", "self-hosted.example.org")
         assert target.url == "https://boxd-abc.self-hosted.example.org"
         assert target.headers == {}
+
+    def test_matches_supported_hosts_case_insensitively(self) -> None:
+        target = data_plane_target("abc", "Sandbox.SuperServe.AI")
+        assert target.url == "https://sandbox.superserve.ai"
+        assert target.headers["X-Superserve-Sandbox-Id"] == "abc"

--- a/packages/python-sdk/tests/test_files.py
+++ b/packages/python-sdk/tests/test_files.py
@@ -119,3 +119,17 @@ class TestFilesSharedHostRouting:
             req = route.calls.last.request
             assert req.headers.get("x-superserve-sandbox-id") == "abc-123"
             assert req.headers.get("x-access-token") == "tok-xyz"
+
+    def test_read_also_carries_sandbox_id_header_on_shared_host(self) -> None:
+        files = Files(
+            sandbox_id="abc-123",
+            sandbox_host="sandbox.superserve.ai",
+            access_token="tok-xyz",
+        )
+        with respx.mock() as router:
+            route = router.get("https://sandbox.superserve.ai/files").mock(
+                return_value=httpx.Response(200, content=b"hello")
+            )
+            files.read("/tmp/f.bin")
+            req = route.calls.last.request
+            assert req.headers.get("x-superserve-sandbox-id") == "abc-123"

--- a/packages/python-sdk/tests/test_files.py
+++ b/packages/python-sdk/tests/test_files.py
@@ -102,3 +102,20 @@ class TestFilesReadText:
                 return_value=httpx.Response(200, content="héllo".encode())
             )
             assert _make_files().read_text("/home/x.txt") == "héllo"
+
+
+class TestFilesSharedHostRouting:
+    def test_uses_shared_host_when_supported(self) -> None:
+        files = Files(
+            sandbox_id="abc-123",
+            sandbox_host="sandbox.superserve.ai",
+            access_token="tok-xyz",
+        )
+        with respx.mock() as router:
+            route = router.post("https://sandbox.superserve.ai/files").mock(
+                return_value=httpx.Response(200)
+            )
+            files.write("/tmp/f.txt", "data")
+            req = route.calls.last.request
+            assert req.headers.get("x-superserve-sandbox-id") == "abc-123"
+            assert req.headers.get("x-access-token") == "tok-xyz"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superserve/sdk",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "TypeScript SDK for the Superserve sandbox API",
   "keywords": [
     "firecracker",

--- a/packages/sdk/src/commands.ts
+++ b/packages/sdk/src/commands.ts
@@ -7,7 +7,7 @@
  * Accessed as `sandbox.commands.run(...)`.
  */
 
-import { dataPlaneUrl } from "./config.js"
+import { dataPlaneTarget } from "./config.js"
 import { AuthenticationError, SandboxError } from "./errors.js"
 import { request, streamSSE } from "./http.js"
 import type {
@@ -27,10 +27,13 @@ export interface CommandsDeps {
 
 export class Commands {
   private readonly _dataPlaneBaseUrl: string
+  private readonly _routingHeaders: Record<string, string>
 
   /** @internal */
   constructor(private readonly _deps: CommandsDeps) {
-    this._dataPlaneBaseUrl = dataPlaneUrl(_deps.sandboxId, _deps.sandboxHost)
+    const target = dataPlaneTarget(_deps.sandboxId, _deps.sandboxHost)
+    this._dataPlaneBaseUrl = target.url
+    this._routingHeaders = target.headers
   }
 
   /**
@@ -82,7 +85,7 @@ export class Commands {
       request<ApiExecResult>({
         method: "POST",
         url: `${this._dataPlaneBaseUrl}/exec`,
-        headers: { "X-Access-Token": token },
+        headers: { ...this._routingHeaders, "X-Access-Token": token },
         body,
         // Add a 5s buffer so the server-side command timeout fires first
         // and returns its proper response before the client aborts.
@@ -108,7 +111,7 @@ export class Commands {
     const send = async (token: string) =>
       this._consumeStream(
         `${this._dataPlaneBaseUrl}/exec/stream`,
-        { "X-Access-Token": token },
+        { ...this._routingHeaders, "X-Access-Token": token },
         body,
         options,
       )

--- a/packages/sdk/src/config.ts
+++ b/packages/sdk/src/config.ts
@@ -64,14 +64,15 @@ export function dataPlaneTarget(
   sandboxHost: string,
 ): DataPlaneTarget {
   const isBrowser = typeof window !== "undefined"
-  if (!isBrowser && SUPPORTED_SHARED_HOSTS.has(sandboxHost)) {
+  const host = sandboxHost.toLowerCase()
+  if (!isBrowser && SUPPORTED_SHARED_HOSTS.has(host)) {
     return {
-      url: `https://${sandboxHost}`,
+      url: `https://${host}`,
       headers: { [SANDBOX_ID_HEADER]: sandboxId },
     }
   }
   return {
-    url: `https://boxd-${sandboxId}.${sandboxHost}`,
+    url: `https://boxd-${sandboxId}.${host}`,
     headers: {},
   }
 }

--- a/packages/sdk/src/config.ts
+++ b/packages/sdk/src/config.ts
@@ -38,13 +38,42 @@ export function resolveConfig(opts?: {
   return { apiKey, baseUrl, sandboxHost }
 }
 
+// Sandbox hosts where the proxy supports shared-host routing.
+const SUPPORTED_SHARED_HOSTS: ReadonlySet<string> = new Set([
+  "sandbox.superserve.ai",
+  "staging-sandbox.superserve.ai",
+])
+
+const SANDBOX_ID_HEADER = "X-Superserve-Sandbox-Id"
+
+/** Base URL + routing headers for one data-plane request. */
+export interface DataPlaneTarget {
+  url: string
+  headers: Record<string, string>
+}
+
 /**
- * Build the data-plane base URL for a specific sandbox.
+ * Resolve the data-plane base URL + routing headers for a sandbox.
  *
- * Example: `https://boxd-{sandboxId}.sandbox.superserve.ai`
+ * On a supported host (server-side), routes via the shared origin with
+ * `X-Superserve-Sandbox-Id`. Browsers and unsupported hosts use the
+ * per-sandbox subdomain.
  */
-export function dataPlaneUrl(sandboxId: string, sandboxHost: string): string {
-  return `https://boxd-${sandboxId}.${sandboxHost}`
+export function dataPlaneTarget(
+  sandboxId: string,
+  sandboxHost: string,
+): DataPlaneTarget {
+  const isBrowser = typeof window !== "undefined"
+  if (!isBrowser && SUPPORTED_SHARED_HOSTS.has(sandboxHost)) {
+    return {
+      url: `https://${sandboxHost}`,
+      headers: { [SANDBOX_ID_HEADER]: sandboxId },
+    }
+  }
+  return {
+    url: `https://boxd-${sandboxId}.${sandboxHost}`,
+    headers: {},
+  }
 }
 
 /**

--- a/packages/sdk/src/files.ts
+++ b/packages/sdk/src/files.ts
@@ -1,14 +1,13 @@
 /**
  * `sandbox.files` - read and write files inside a sandbox.
  *
- * Hits the data-plane directly at `boxd-{id}.sandbox.superserve.ai`
- * using the per-sandbox access token. The control-plane API key is
- * not used for file operations.
+ * Hits the data plane with the per-sandbox access token. The
+ * control-plane API key is not used for file operations.
  *
  * Accessed as `sandbox.files.write(...)` / `sandbox.files.read(...)`.
  */
 
-import { dataPlaneUrl } from "./config.js"
+import { dataPlaneTarget } from "./config.js"
 import { ValidationError } from "./errors.js"
 import { downloadBytes, uploadBytes } from "./http.js"
 import type { FileInput } from "./types.js"
@@ -24,6 +23,7 @@ function validatePath(path: string): void {
 
 export class Files {
   private readonly _dataPlaneBaseUrl: string
+  private readonly _routingHeaders: Record<string, string>
 
   /** @internal */
   constructor(
@@ -31,7 +31,9 @@ export class Files {
     sandboxHost: string,
     private readonly _accessToken: string,
   ) {
-    this._dataPlaneBaseUrl = dataPlaneUrl(sandboxId, sandboxHost)
+    const target = dataPlaneTarget(sandboxId, sandboxHost)
+    this._dataPlaneBaseUrl = target.url
+    this._routingHeaders = target.headers
   }
 
   /**
@@ -56,7 +58,7 @@ export class Files {
     const url = `${this._dataPlaneBaseUrl}/files?path=${encodeURIComponent(path)}`
     await uploadBytes({
       url,
-      headers: { "X-Access-Token": this._accessToken },
+      headers: { ...this._routingHeaders, "X-Access-Token": this._accessToken },
       body,
       timeoutMs: options.timeoutMs,
       signal: options.signal,
@@ -79,7 +81,7 @@ export class Files {
     const url = `${this._dataPlaneBaseUrl}/files?path=${encodeURIComponent(path)}`
     return downloadBytes({
       url,
-      headers: { "X-Access-Token": this._accessToken },
+      headers: { ...this._routingHeaders, "X-Access-Token": this._accessToken },
       timeoutMs: options.timeoutMs,
       signal: options.signal,
     })

--- a/packages/sdk/tests/commands.test.ts
+++ b/packages/sdk/tests/commands.test.ts
@@ -27,7 +27,7 @@ function sseResponse(chunks: string[]): Response {
 }
 
 const sandboxId = "sbx-1"
-const sandboxHost = "sandbox.superserve.ai"
+const sandboxHost = "sandbox.example.com"
 const dataPlaneUrl = `https://boxd-${sandboxId}.${sandboxHost}`
 
 function makeDeps(overrides: Partial<CommandsDeps> = {}): CommandsDeps {
@@ -240,5 +240,50 @@ describe("Commands.run (streaming)", () => {
     expect(result.stdout).toBe("one")
     expect(result.exitCode).toBe(0)
     expect(refreshCalls).toBe(1)
+  })
+})
+
+describe("Commands.run (shared-host routing)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("uses shared host + X-Superserve-Sandbox-Id when sandboxHost is supported", async () => {
+    const mock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        jsonResponse({ stdout: "hi\n", stderr: "", exit_code: 0 }),
+      )
+    vi.stubGlobal("fetch", mock)
+
+    const commands = new Commands(
+      makeDeps({ sandboxHost: "sandbox.superserve.ai" }),
+    )
+    await commands.run("echo hi")
+
+    const [url, init] = mock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe("https://sandbox.superserve.ai/exec")
+    const headers = init.headers as Record<string, string>
+    expect(headers["X-Superserve-Sandbox-Id"]).toBe(sandboxId)
+    expect(headers["X-Access-Token"]).toBe("tok-initial")
+  })
+
+  it("falls back to per-sandbox subdomain on unsupported host", async () => {
+    const mock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        jsonResponse({ stdout: "", stderr: "", exit_code: 0 }),
+      )
+    vi.stubGlobal("fetch", mock)
+
+    const commands = new Commands(
+      makeDeps({ sandboxHost: "self-hosted.example.org" }),
+    )
+    await commands.run("echo")
+
+    const [url, init] = mock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe(`https://boxd-${sandboxId}.self-hosted.example.org/exec`)
+    const headers = init.headers as Record<string, string>
+    expect(headers["X-Superserve-Sandbox-Id"]).toBeUndefined()
   })
 })

--- a/packages/sdk/tests/commands.test.ts
+++ b/packages/sdk/tests/commands.test.ts
@@ -286,4 +286,49 @@ describe("Commands.run (shared-host routing)", () => {
     const headers = init.headers as Record<string, string>
     expect(headers["X-Superserve-Sandbox-Id"]).toBeUndefined()
   })
+
+  it("streaming carries X-Superserve-Sandbox-Id on shared host", async () => {
+    const mock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        sseResponse([
+          `data: ${JSON.stringify({ stdout: "x" })}\n`,
+          `data: ${JSON.stringify({ finished: true, exit_code: 0 })}\n`,
+        ]),
+      )
+    vi.stubGlobal("fetch", mock)
+
+    const commands = new Commands(
+      makeDeps({ sandboxHost: "sandbox.superserve.ai" }),
+    )
+    await commands.run("echo", { onStdout: () => {} })
+
+    const [url, init] = mock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe("https://sandbox.superserve.ai/exec/stream")
+    const headers = init.headers as Record<string, string>
+    expect(headers["X-Superserve-Sandbox-Id"]).toBe(sandboxId)
+  })
+
+  it("preserves X-Superserve-Sandbox-Id after 401 retry on shared host", async () => {
+    const deps = makeDeps({
+      sandboxHost: "sandbox.superserve.ai",
+      refreshActivate: async () => "tok-refreshed",
+    })
+    const mock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        jsonResponse({ error: { code: "auth_failed" } }, 401),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ stdout: "ok\n", stderr: "", exit_code: 0 }),
+      )
+    vi.stubGlobal("fetch", mock)
+
+    await new Commands(deps).run("echo")
+
+    const [, secondInit] = mock.mock.calls[1] as [string, RequestInit]
+    const headers = secondInit.headers as Record<string, string>
+    expect(headers["X-Superserve-Sandbox-Id"]).toBe(sandboxId)
+    expect(headers["X-Access-Token"]).toBe("tok-refreshed")
+  })
 })

--- a/packages/sdk/tests/config.test.ts
+++ b/packages/sdk/tests/config.test.ts
@@ -102,4 +102,10 @@ describe("dataPlaneTarget", () => {
     expect(target.url).toBe("https://boxd-abc.self-hosted.example.org")
     expect(target.headers).toEqual({})
   })
+
+  it("matches supported hosts case-insensitively (RFC 4343)", () => {
+    const target = dataPlaneTarget("abc", "Sandbox.SuperServe.AI")
+    expect(target.url).toBe("https://sandbox.superserve.ai")
+    expect(target.headers["X-Superserve-Sandbox-Id"]).toBe("abc")
+  })
 })

--- a/packages/sdk/tests/config.test.ts
+++ b/packages/sdk/tests/config.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
-import { dataPlaneUrl, resolveConfig } from "../src/config.js"
+import { dataPlaneTarget, resolveConfig } from "../src/config.js"
 import { AuthenticationError } from "../src/errors.js"
 
 describe("resolveConfig", () => {
@@ -84,16 +84,22 @@ describe("resolveConfig", () => {
   })
 })
 
-describe("dataPlaneUrl", () => {
-  it("builds data plane URL from sandbox id and host", () => {
-    expect(dataPlaneUrl("abc-123", "sandbox.superserve.ai")).toBe(
-      "https://boxd-abc-123.sandbox.superserve.ai",
-    )
+describe("dataPlaneTarget", () => {
+  it("uses shared host + routing header on supported prod host", () => {
+    const target = dataPlaneTarget("abc-123", "sandbox.superserve.ai")
+    expect(target.url).toBe("https://sandbox.superserve.ai")
+    expect(target.headers["X-Superserve-Sandbox-Id"]).toBe("abc-123")
   })
 
-  it("builds staging data plane URL", () => {
-    expect(dataPlaneUrl("xyz", "staging-sandbox.superserve.ai")).toBe(
-      "https://boxd-xyz.staging-sandbox.superserve.ai",
-    )
+  it("uses shared host + routing header on supported staging host", () => {
+    const target = dataPlaneTarget("xyz", "staging-sandbox.superserve.ai")
+    expect(target.url).toBe("https://staging-sandbox.superserve.ai")
+    expect(target.headers["X-Superserve-Sandbox-Id"]).toBe("xyz")
+  })
+
+  it("falls back to per-sandbox subdomain on unsupported host", () => {
+    const target = dataPlaneTarget("abc", "self-hosted.example.org")
+    expect(target.url).toBe("https://boxd-abc.self-hosted.example.org")
+    expect(target.headers).toEqual({})
   })
 })

--- a/packages/sdk/tests/files.test.ts
+++ b/packages/sdk/tests/files.test.ts
@@ -176,4 +176,23 @@ describe("Files shared-host routing", () => {
     expect(headers["X-Superserve-Sandbox-Id"]).toBe(sandboxId)
     expect(headers["X-Access-Token"]).toBe(accessToken)
   })
+
+  it("read also carries X-Superserve-Sandbox-Id on shared host", async () => {
+    const mock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(new Uint8Array([1, 2, 3]), { status: 200 }),
+      )
+    vi.stubGlobal("fetch", mock)
+
+    const files = new Files(sandboxId, "sandbox.superserve.ai", accessToken)
+    await files.read("/tmp/f.bin")
+
+    const [url, init] = mock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe(
+      `https://sandbox.superserve.ai/files?path=${encodeURIComponent("/tmp/f.bin")}`,
+    )
+    const headers = init.headers as Record<string, string>
+    expect(headers["X-Superserve-Sandbox-Id"]).toBe(sandboxId)
+  })
 })

--- a/packages/sdk/tests/files.test.ts
+++ b/packages/sdk/tests/files.test.ts
@@ -4,7 +4,7 @@ import { ValidationError } from "../src/errors.js"
 import { Files } from "../src/files.js"
 
 const sandboxId = "sbx-1"
-const sandboxHost = "sandbox.superserve.ai"
+const sandboxHost = "sandbox.example.com"
 const accessToken = "tok-abc"
 
 async function readBodyAsBytes(
@@ -151,5 +151,29 @@ describe("Files.readText", () => {
     const files = new Files(sandboxId, sandboxHost, accessToken)
     const out = await files.readText("/app/file.txt")
     expect(out).toBe("héllo world")
+  })
+})
+
+describe("Files shared-host routing", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("uses shared host + X-Superserve-Sandbox-Id when sandboxHost is supported", async () => {
+    const mock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }))
+    vi.stubGlobal("fetch", mock)
+
+    const files = new Files(sandboxId, "sandbox.superserve.ai", accessToken)
+    await files.write("/tmp/f.txt", "data")
+
+    const [url, init] = mock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe(
+      `https://sandbox.superserve.ai/files?path=${encodeURIComponent("/tmp/f.txt")}`,
+    )
+    const headers = init.headers as Record<string, string>
+    expect(headers["X-Superserve-Sandbox-Id"]).toBe(sandboxId)
+    expect(headers["X-Access-Token"]).toBe(accessToken)
   })
 })

--- a/uv.lock
+++ b/uv.lock
@@ -492,7 +492,7 @@ wheels = [
 
 [[package]]
 name = "superserve"
-version = "0.7.1"
+version = "0.7.3"
 source = { editable = "packages/python-sdk" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
On supported sandbox hosts (prod + staging), the SDK now routes `commands.run` / `commands.run` (streaming) / `files.read|write` through a single shared host (`sandbox.superserve.ai` or `staging-sandbox.superserve.ai`) with `X-Superserve-Sandbox-Id` carrying the sandbox ID, instead of opening a per-sandbox subdomain origin. Unsupported hosts and browsers keep using `boxd-{id}.<host>` — backward compatible.

Why: HTTP clients (undici, httpx) key connection pools by origin. One subdomain per sandbox = one cold TLS handshake per sandbox under burst. Collapsing to one origin reuses the pool. Should restore the burst regression introduced in 0.7.2.

Requires the proxy-side change in [sandbox#80](https://github.com/superserve-ai/sandbox/pull/80) — already merged + deployed to staging.

Bumps both SDKs to 0.7.3.