### PR TITLE
Console: audit logs, expand for details

### DIFF
--- a/apps/console/src/app/(dashboard)/audit-logs/page.tsx
+++ b/apps/console/src/app/(dashboard)/audit-logs/page.tsx
@@ -1,21 +1,13 @@
 "use client"
 
 import { ClipboardTextIcon } from "@phosphor-icons/react"
-import {
-  Badge,
-  type BadgeVariant,
-  Table,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-  Tooltip,
-  TooltipPopup,
-  TooltipTrigger,
-} from "@superserve/ui"
+import { Table, TableHead, TableHeader, TableRow } from "@superserve/ui"
 import { useMemo, useState } from "react"
 
-import { AnimatedTableRow } from "@/components/animated-table-row"
+import {
+  ActivityDetailRow,
+  ActivitySummaryRow,
+} from "@/components/audit/activity-row"
 import { DateRangeFilter } from "@/components/date-range-filter"
 import { EmptyState } from "@/components/empty-state"
 import { ErrorState } from "@/components/error-state"
@@ -24,12 +16,6 @@ import { StickyHoverTableBody } from "@/components/sticky-hover-table"
 import { TableSkeleton } from "@/components/table-skeleton"
 import { TableToolbar } from "@/components/table-toolbar"
 import { useActivity } from "@/hooks/use-activity"
-import { formatTime } from "@/lib/format"
-
-const STATUS_VARIANT: Record<string, BadgeVariant> = {
-  success: "success",
-  error: "destructive",
-}
 
 const CATEGORY_TABS = [
   { label: "All", value: "all" },
@@ -39,22 +25,6 @@ const CATEGORY_TABS = [
   { label: "Errors", value: "_errors" },
 ]
 
-function formatDuration(ms: number | null): string {
-  if (ms === null) return "-"
-  if (ms < 1000) return `${ms}ms`
-  return `${(ms / 1000).toFixed(1)}s`
-}
-
-function TimeCell({ date }: { date: Date }) {
-  const { relative, absolute } = formatTime(date)
-  return (
-    <div className="tabular-nums">
-      <span className="text-foreground/80">{relative}</span>
-      <span className="ml-2 text-xs text-muted">{absolute}</span>
-    </div>
-  )
-}
-
 export default function AuditLogsPage() {
   const [categoryFilter, setCategoryFilter] = useState("all")
   const [search, setSearch] = useState("")
@@ -62,6 +32,7 @@ export default function AuditLogsPage() {
     start: Date
     end: Date
   } | null>(null)
+  const [expandedId, setExpandedId] = useState<string | null>(null)
 
   const { data: activity, isPending, error, refetch } = useActivity()
 
@@ -159,58 +130,27 @@ export default function AuditLogsPage() {
                 </TableRow>
               </TableHeader>
               <StickyHoverTableBody>
-                {filtered.map((log) => (
-                  <AnimatedTableRow key={log.id}>
-                    <TableCell className="whitespace-nowrap">
-                      <TimeCell date={new Date(log.created_at)} />
-                    </TableCell>
-                    <TableCell className="font-mono text-foreground/80">
-                      {log.sandbox_name ?? "-"}
-                    </TableCell>
-                    <TableCell className="text-muted capitalize">
-                      {log.category}
-                    </TableCell>
-                    <TableCell className="text-foreground/80">
-                      {log.action}
-                    </TableCell>
-                    <TableCell className="font-mono text-xs text-muted tabular-nums">
-                      {formatDuration(log.duration_ms)}
-                    </TableCell>
-                    <TableCell>
-                      {log.status ? (
-                        log.error ? (
-                          <Tooltip>
-                            <TooltipTrigger
-                              render={
-                                <Badge
-                                  variant={
-                                    STATUS_VARIANT[log.status] ?? "muted"
-                                  }
-                                  dot
-                                  className="cursor-default"
-                                />
-                              }
-                            >
-                              {log.status}
-                            </TooltipTrigger>
-                            <TooltipPopup className="max-w-xs text-xs">
-                              {log.error}
-                            </TooltipPopup>
-                          </Tooltip>
-                        ) : (
-                          <Badge
-                            variant={STATUS_VARIANT[log.status] ?? "muted"}
-                            dot
-                          >
-                            {log.status}
-                          </Badge>
+                {filtered.flatMap((log) => {
+                  const isOpen = expandedId === log.id
+                  const rows = [
+                    <ActivitySummaryRow
+                      key={log.id}
+                      log={log}
+                      isOpen={isOpen}
+                      onToggle={() =>
+                        setExpandedId((prev) =>
+                          prev === log.id ? null : log.id,
                         )
-                      ) : (
-                        <span className="text-muted">-</span>
-                      )}
-                    </TableCell>
-                  </AnimatedTableRow>
-                ))}
+                      }
+                    />,
+                  ]
+                  if (isOpen) {
+                    rows.push(
+                      <ActivityDetailRow key={`${log.id}-detail`} log={log} />,
+                    )
+                  }
+                  return rows
+                })}
               </StickyHoverTableBody>
             </Table>
           </div>

--- a/apps/console/src/components/audit/activity-detail.tsx
+++ b/apps/console/src/components/audit/activity-detail.tsx
@@ -1,0 +1,181 @@
+import {
+  ClipboardTextIcon,
+  CubeIcon,
+  StackIcon,
+  TerminalIcon,
+  WarningIcon,
+} from "@phosphor-icons/react"
+import { Badge, HighlightedCode, Separator } from "@superserve/ui"
+
+import { CodeBlock } from "@/components/code-block"
+import type { ActivityResponse } from "@/lib/api/types"
+import { formatTime } from "@/lib/format"
+import {
+  ACTIVITY_STATUS_VARIANT,
+  formatBytes,
+  formatDuration,
+} from "@/lib/sandbox-utils"
+
+const CATEGORY_META: Record<
+  string,
+  { icon: React.ElementType; label: string }
+> = {
+  sandbox: { icon: CubeIcon, label: "Sandbox" },
+  template: { icon: StackIcon, label: "Template" },
+  exec: { icon: TerminalIcon, label: "Exec" },
+}
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/
+
+export function prettifyKey(key: string): string {
+  return key
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+    .trim()
+}
+
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2)
+  } catch {
+    return String(value)
+  }
+}
+
+// Renders a metadata value based on its shape rather than an assumed
+// per-action schema, so each action naturally surfaces its own fields.
+export function formatMetadataValue(
+  key: string,
+  value: unknown,
+): React.ReactNode {
+  if (key === "command" && typeof value === "string") {
+    return <CodeBlock command={value} />
+  }
+  if (value !== null && typeof value === "object") {
+    return (
+      <div className="border border-dashed border-border bg-background px-3 py-2">
+        <HighlightedCode lang="typescript" code={safeJson(value)} />
+      </div>
+    )
+  }
+  if (typeof value === "boolean") {
+    return (
+      <Badge variant={value ? "success" : "muted"} dot>
+        {String(value)}
+      </Badge>
+    )
+  }
+  if (typeof value === "number" && /(_ms$|duration)/i.test(key)) {
+    return (
+      <span className="font-mono tabular-nums">{formatDuration(value)}</span>
+    )
+  }
+  if (typeof value === "number" && /(bytes|size)/i.test(key)) {
+    return <span className="font-mono tabular-nums">{formatBytes(value)}</span>
+  }
+  if (typeof value === "string" && ISO_DATE_RE.test(value)) {
+    return (
+      <span className="tabular-nums">
+        {formatTime(new Date(value)).absolute}
+      </span>
+    )
+  }
+  if (value === null || value === undefined) {
+    return <span className="text-muted">—</span>
+  }
+  return <span className="font-mono break-all">{String(value)}</span>
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string
+  children: React.ReactNode
+}) {
+  return (
+    <>
+      <dt className="pt-0.5 text-xs text-muted">{label}</dt>
+      <dd className="min-w-0 text-sm text-foreground/80">{children}</dd>
+    </>
+  )
+}
+
+export function ActivityDetail({ log }: { log: ActivityResponse }) {
+  const meta = CATEGORY_META[log.category]
+  const Icon = meta?.icon ?? ClipboardTextIcon
+  const metadataEntries = Object.entries(log.metadata ?? {})
+  const hasMetadata = metadataEntries.length > 0
+
+  return (
+    <div className="border-b border-border bg-surface/30 px-4 py-4">
+      <div className="mb-4 flex items-center gap-2">
+        <Icon className="size-3.5 text-muted" weight="light" />
+        <span className="font-mono text-xs text-muted uppercase">
+          {meta?.label ?? log.category} &middot; {log.action}
+        </span>
+      </div>
+
+      <dl className="grid grid-cols-[160px_1fr] gap-x-4 gap-y-3">
+        <Field label="Time">
+          <span className="tabular-nums">
+            {formatTime(new Date(log.created_at)).absolute}
+          </span>
+        </Field>
+        <Field label="Sandbox">
+          <span className="font-mono">{log.sandbox_name ?? "—"}</span>
+        </Field>
+        <Field label="Sandbox ID">
+          <span className="font-mono break-all text-foreground/70">
+            {log.sandbox_id}
+          </span>
+        </Field>
+        <Field label="Action">
+          <span className="font-mono">{log.action}</span>
+        </Field>
+        <Field label="Duration">
+          <span className="font-mono tabular-nums">
+            {formatDuration(log.duration_ms)}
+          </span>
+        </Field>
+        <Field label="Status">
+          {log.status ? (
+            <Badge variant={ACTIVITY_STATUS_VARIANT[log.status] ?? "muted"} dot>
+              {log.status}
+            </Badge>
+          ) : (
+            <span className="text-muted">—</span>
+          )}
+        </Field>
+      </dl>
+
+      {log.error && (
+        <div className="mt-4 flex items-start gap-2 border border-dashed border-destructive/40 bg-destructive/5 px-3 py-2">
+          <WarningIcon
+            className="mt-0.5 size-3.5 shrink-0 text-destructive"
+            weight="light"
+          />
+          <p className="font-mono text-xs leading-relaxed break-all text-destructive">
+            {log.error}
+          </p>
+        </div>
+      )}
+
+      {hasMetadata && (
+        <>
+          <Separator className="my-4" />
+          <p className="mb-3 font-mono text-xs text-muted uppercase">
+            Metadata
+          </p>
+          <dl className="grid grid-cols-[160px_1fr] gap-x-4 gap-y-3">
+            {metadataEntries.map(([key, value]) => (
+              <Field key={key} label={prettifyKey(key)}>
+                {formatMetadataValue(key, value)}
+              </Field>
+            ))}
+          </dl>
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/console/src/components/audit/activity-row.tsx
+++ b/apps/console/src/components/audit/activity-row.tsx
@@ -1,0 +1,122 @@
+"use client"
+
+import { CaretDownIcon } from "@phosphor-icons/react"
+import {
+  Badge,
+  cn,
+  TableCell,
+  Tooltip,
+  TooltipPopup,
+  TooltipTrigger,
+} from "@superserve/ui"
+import { motion } from "motion/react"
+
+import { AnimatedTableRow } from "@/components/animated-table-row"
+import type { ActivityResponse } from "@/lib/api/types"
+import { formatTime } from "@/lib/format"
+import { ACTIVITY_STATUS_VARIANT, formatDuration } from "@/lib/sandbox-utils"
+
+import { ActivityDetail } from "./activity-detail"
+
+interface ActivitySummaryRowProps {
+  log: ActivityResponse
+  isOpen: boolean
+  onToggle: () => void
+}
+
+export function ActivitySummaryRow({
+  log,
+  isOpen,
+  onToggle,
+}: ActivitySummaryRowProps) {
+  const { relative, absolute } = formatTime(new Date(log.created_at))
+
+  return (
+    <AnimatedTableRow onClick={onToggle} className="cursor-pointer">
+      <TableCell className="whitespace-nowrap">
+        <div className="flex items-center gap-2 tabular-nums">
+          <button
+            type="button"
+            aria-expanded={isOpen}
+            aria-label={isOpen ? "Collapse details" : "Expand details"}
+            onClick={(e) => {
+              e.stopPropagation()
+              onToggle()
+            }}
+            className="-m-1 cursor-pointer p-1 text-muted transition-colors hover:text-foreground"
+          >
+            <CaretDownIcon
+              className={cn(
+                "size-3.5 shrink-0 transition-transform",
+                isOpen ? "" : "-rotate-90",
+              )}
+              weight="light"
+            />
+          </button>
+          <span className="text-foreground/80">{relative}</span>
+          <span className="text-xs text-muted">{absolute}</span>
+        </div>
+      </TableCell>
+      <TableCell className="font-mono text-foreground/80">
+        {log.sandbox_name ?? "-"}
+      </TableCell>
+      <TableCell className="text-muted capitalize">{log.category}</TableCell>
+      <TableCell className="text-foreground/80">{log.action}</TableCell>
+      <TableCell className="font-mono text-xs text-muted tabular-nums">
+        {formatDuration(log.duration_ms)}
+      </TableCell>
+      <TableCell>
+        {log.status ? (
+          log.error ? (
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Badge
+                    variant={ACTIVITY_STATUS_VARIANT[log.status] ?? "muted"}
+                    dot
+                    className="cursor-default"
+                  />
+                }
+              >
+                {log.status}
+              </TooltipTrigger>
+              <TooltipPopup className="max-w-xs text-xs">
+                {log.error}
+              </TooltipPopup>
+            </Tooltip>
+          ) : (
+            <Badge variant={ACTIVITY_STATUS_VARIANT[log.status] ?? "muted"} dot>
+              {log.status}
+            </Badge>
+          )
+        ) : (
+          <span className="text-muted">-</span>
+        )}
+      </TableCell>
+    </AnimatedTableRow>
+  )
+}
+
+// Plain motion.tr (NO `layout`) so the inner height animation never fights a
+// layout projection. `data-detail-row` tells StickyHoverTableBody to keep the
+// hover indicator on summary rows only.
+export function ActivityDetailRow({ log }: { log: ActivityResponse }) {
+  return (
+    <motion.tr data-detail-row="true">
+      <TableCell colSpan={6} className="p-0">
+        <motion.div
+          className="overflow-hidden"
+          initial={{ height: 0, opacity: 0 }}
+          animate={{ height: "auto", opacity: 1 }}
+          exit={{ height: 0, opacity: 0 }}
+          transition={{
+            height: { type: "spring", bounce: 0.15, duration: 0.4 },
+            opacity: { duration: 0.15, ease: "easeInOut" },
+          }}
+        >
+          <ActivityDetail log={log} />
+        </motion.div>
+      </TableCell>
+    </motion.tr>
+  )
+}

--- a/apps/console/src/components/sticky-hover-table.tsx
+++ b/apps/console/src/components/sticky-hover-table.tsx
@@ -24,6 +24,8 @@ export function StickyHoverTableBody({
     if (!row || !tbodyRef.current?.contains(row)) return
     // Skip the absolute-positioned hover indicator row
     if (row.getAttribute("aria-hidden") === "true") return
+    // Keep the indicator on summary rows only, not expanded detail rows
+    if (row.getAttribute("data-detail-row") === "true") return
     const tbodyRect = tbodyRef.current.getBoundingClientRect()
     const rowRect = row.getBoundingClientRect()
     setHoverStyle({


### PR DESCRIPTION
## Description
Audit Logs: Click on row to expand and get details

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [x] All tests passing

## Screenshots/Demo
<img width="1470" height="956" alt="Screenshot 2026-05-29 at 6 41 12 PM" src="https://github.com/user-attachments/assets/b0ff8a9f-6060-47da-9afe-3d73ccad6962" />
