### PR TITLE
docs: add activate and files endpoints to API reference nav

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -122,9 +122,7 @@
           },
           {
             "group": "Managed Agents",
-            "pages": [
-              "integrations/managed-agents/claude-managed-agents"
-            ]
+            "pages": ["integrations/managed-agents/claude-managed-agents"]
           },
           {
             "group": "Agent Harnesses",
@@ -152,7 +150,8 @@
               "PATCH /sandboxes/{sandbox_id}",
               "DELETE /sandboxes/{sandbox_id}",
               "POST /sandboxes/{sandbox_id}/pause",
-              "POST /sandboxes/{sandbox_id}/resume"
+              "POST /sandboxes/{sandbox_id}/resume",
+              "POST /sandboxes/{sandbox_id}/activate"
             ]
           },
           {
@@ -161,6 +160,10 @@
               "POST /sandboxes/{sandbox_id}/exec",
               "POST /sandboxes/{sandbox_id}/exec/stream"
             ]
+          },
+          {
+            "group": "Files",
+            "pages": ["GET /files", "POST /files"]
           },
           {
             "group": "Templates",


### PR DESCRIPTION
Surfaces three endpoints that exist in the OpenAPI spec but were missing from the API reference nav, so they now render in the docs.

## Changes
- Add `POST /sandboxes/{sandbox_id}/activate` to the Sandboxes group
- Add a new Files group with `GET /files` and `POST /files`

The spec itself is pulled live from the sandbox repo's `main`; all three paths are already present there, so the Mintlify build resolves them.