### PR TITLE
ci: check docs nav stays in sync with the OpenAPI spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,17 +6,23 @@ on:
     paths:
       - "apps/**"
       - "packages/**"
+      - "docs/**"
+      - "scripts/**"
       - "package.json"
       - "bun.lock"
       - "turbo.json"
+      - ".github/workflows/ci.yml"
   pull_request:
     branches: [main]
     paths:
       - "apps/**"
       - "packages/**"
+      - "docs/**"
+      - "scripts/**"
       - "package.json"
       - "bun.lock"
       - "turbo.json"
+      - ".github/workflows/ci.yml"
 
 jobs:
   ci:
@@ -42,6 +48,9 @@ jobs:
 
       - name: Typecheck
         run: bun run typecheck
+
+      - name: Check docs nav matches OpenAPI spec
+        run: bun run docs:check-nav
 
       - name: Test
         run: bun run test

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:e2e": "turbo run e2e",
     "docs:dev": "mintlify dev --dir docs",
     "docs:build": "mintlify build --dir docs",
+    "docs:check-nav": "bun run scripts/check-docs-nav.ts",
     "prepare": "husky"
   },
   "dependencies": {

--- a/scripts/check-docs-nav.ts
+++ b/scripts/check-docs-nav.ts
@@ -1,0 +1,103 @@
+#!/usr/bin/env bun
+/**
+ * Verifies the API Reference nav in docs/docs.json stays in sync with the
+ * OpenAPI spec it points at. Fails if the spec documents an operation that
+ * isn't listed in the nav (so it never renders), or if the nav lists an
+ * operation the spec doesn't define (a stale or mistyped entry).
+ *
+ * The spec is fetched from the URL in docs.json, so this also enforces that a
+ * nav entry can only land once the backing spec change is live.
+ */
+
+const HTTP_METHODS = [
+  "GET",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+  "HEAD",
+  "OPTIONS",
+]
+
+// Paths defined in the spec but intentionally absent from the public nav.
+const EXEMPT_PATHS = new Set(["/health"])
+
+const OP_RE = new RegExp(`^(${HTTP_METHODS.join("|")}) /`)
+
+type DocsConfig = {
+  navigation: {
+    tabs: Array<{
+      tab: string
+      openapi?: string
+      groups?: Array<{ pages: unknown[] }>
+    }>
+  }
+}
+
+function navOpsFromDocs(docs: DocsConfig): {
+  ops: Set<string>
+  specUrl: string
+} {
+  const apiTab = docs.navigation.tabs.find((t) => typeof t.openapi === "string")
+  if (!apiTab?.openapi) {
+    throw new Error("no tab with an `openapi` field found in docs.json")
+  }
+  const ops = new Set<string>()
+  for (const group of apiTab.groups ?? []) {
+    for (const page of group.pages ?? []) {
+      if (typeof page === "string" && OP_RE.test(page)) {
+        ops.add(page.replace(/\s+/g, " ").trim())
+      }
+    }
+  }
+  return { ops, specUrl: apiTab.openapi }
+}
+
+function specOps(spec: {
+  paths?: Record<string, Record<string, unknown>>
+}): Set<string> {
+  const ops = new Set<string>()
+  for (const [path, item] of Object.entries(spec.paths ?? {})) {
+    for (const key of Object.keys(item)) {
+      const method = key.toUpperCase()
+      if (HTTP_METHODS.includes(method)) ops.add(`${method} ${path}`)
+    }
+  }
+  return ops
+}
+
+const docsPath = new URL("../docs/docs.json", import.meta.url)
+const docs = (await Bun.file(docsPath).json()) as DocsConfig
+const { ops: nav, specUrl } = navOpsFromDocs(docs)
+
+const res = await fetch(specUrl)
+if (!res.ok) {
+  console.error(`failed to fetch OpenAPI spec (${res.status}): ${specUrl}`)
+  process.exit(1)
+}
+const spec = Bun.YAML.parse(await res.text()) as Parameters<typeof specOps>[0]
+const api = specOps(spec)
+
+const missingFromNav = [...api].filter((op) => {
+  const path = op.split(" ", 2)[1]
+  return !EXEMPT_PATHS.has(path) && !nav.has(op)
+})
+const missingFromSpec = [...nav].filter((op) => !api.has(op))
+
+if (missingFromNav.length || missingFromSpec.length) {
+  if (missingFromNav.length) {
+    console.error(
+      "Documented in the OpenAPI spec but missing from the docs nav:",
+    )
+    for (const op of missingFromNav.toSorted()) console.error(`  - ${op}`)
+    console.error("Add these to the API Reference group in docs/docs.json.\n")
+  }
+  if (missingFromSpec.length) {
+    console.error("Listed in the docs nav but not defined in the OpenAPI spec:")
+    for (const op of missingFromSpec.toSorted()) console.error(`  - ${op}`)
+    console.error("Remove these from docs/docs.json or fix the path/method.\n")
+  }
+  process.exit(1)
+}
+
+console.log(`docs nav in sync with OpenAPI spec (${api.size} operations).`)

--- a/scripts/check-docs-nav.ts
+++ b/scripts/check-docs-nav.ts
@@ -22,7 +22,7 @@ const HTTP_METHODS = [
 // Paths defined in the spec but intentionally absent from the public nav.
 const EXEMPT_PATHS = new Set(["/health"])
 
-const OP_RE = new RegExp(`^(${HTTP_METHODS.join("|")}) /`)
+const OP_RE = new RegExp(`^(${HTTP_METHODS.join("|")})\\s+/`)
 
 type DocsConfig = {
   navigation: {
@@ -38,7 +38,9 @@ function navOpsFromDocs(docs: DocsConfig): {
   ops: Set<string>
   specUrl: string
 } {
-  const apiTab = docs.navigation.tabs.find((t) => typeof t.openapi === "string")
+  const apiTab = docs.navigation?.tabs?.find(
+    (t) => typeof t.openapi === "string",
+  )
   if (!apiTab?.openapi) {
     throw new Error("no tab with an `openapi` field found in docs.json")
   }
@@ -53,11 +55,15 @@ function navOpsFromDocs(docs: DocsConfig): {
   return { ops, specUrl: apiTab.openapi }
 }
 
-function specOps(spec: {
-  paths?: Record<string, Record<string, unknown>>
-}): Set<string> {
+function specOps(spec: unknown): Set<string> {
   const ops = new Set<string>()
-  for (const [path, item] of Object.entries(spec.paths ?? {})) {
+  const paths =
+    spec && typeof spec === "object"
+      ? (spec as { paths?: unknown }).paths
+      : null
+  if (!paths || typeof paths !== "object") return ops
+  for (const [path, item] of Object.entries(paths)) {
+    if (!item || typeof item !== "object") continue
     for (const key of Object.keys(item)) {
       const method = key.toUpperCase()
       if (HTTP_METHODS.includes(method)) ops.add(`${method} ${path}`)
@@ -75,8 +81,13 @@ if (!res.ok) {
   console.error(`failed to fetch OpenAPI spec (${res.status}): ${specUrl}`)
   process.exit(1)
 }
-const spec = Bun.YAML.parse(await res.text()) as Parameters<typeof specOps>[0]
-const api = specOps(spec)
+const api = specOps(Bun.YAML.parse(await res.text()))
+if (api.size === 0) {
+  console.error(
+    `OpenAPI spec produced no operations (fetch or parse problem): ${specUrl}`,
+  )
+  process.exit(1)
+}
 
 const missingFromNav = [...api].filter((op) => {
   const path = op.split(" ", 2)[1]


### PR DESCRIPTION
Adds an automated check so the API Reference nav in `docs/docs.json` can't drift from the OpenAPI spec it renders — the gap that let a documented endpoint go missing from the published docs.

## What it does
`scripts/check-docs-nav.ts` fetches the spec referenced in `docs.json` and compares it against the API Reference nav, both directions:
- A spec operation missing from the nav fails the check (it would never render).
- A nav entry with no matching spec operation fails the check (stale or mistyped).

Because the spec is fetched from its source URL, this also enforces that a nav entry only lands once the backing spec change is live.

## Wiring
- New `docs:check-nav` script, run as a CI step.
- CI `paths:` filter now includes `docs/**`, `scripts/**`, and the workflow itself — previously docs-only changes didn't trigger CI at all.
- `/health` is exempt (intentionally not in the public nav). Uses the built-in `Bun.YAML` parser, no new dependencies.