### PR TITLE
console: clearer directory download error and fix a11y control labels

### DIFF
--- a/apps/console/src/components/date-range-filter.tsx
+++ b/apps/console/src/components/date-range-filter.tsx
@@ -155,6 +155,7 @@ export function DateRangeFilter({ value, onChange }: DateRangeFilterProps) {
           render={
             <button
               type="button"
+              aria-label="Select a custom date range"
               className={cn(
                 "inline-flex cursor-pointer items-center gap-1.5 px-2 py-1 font-mono text-xs uppercase transition-colors",
                 isCustom

--- a/apps/console/src/components/date-range-filter.tsx
+++ b/apps/console/src/components/date-range-filter.tsx
@@ -155,7 +155,11 @@ export function DateRangeFilter({ value, onChange }: DateRangeFilterProps) {
           render={
             <button
               type="button"
-              aria-label="Select a custom date range"
+              aria-label={
+                isCustom
+                  ? `Custom date range: ${formatShortDate(value.start)} to ${formatShortDate(value.end)}`
+                  : "Select a custom date range"
+              }
               className={cn(
                 "inline-flex cursor-pointer items-center gap-1.5 px-2 py-1 font-mono text-xs uppercase transition-colors",
                 isCustom

--- a/apps/console/src/components/sandboxes/files-section.test.tsx
+++ b/apps/console/src/components/sandboxes/files-section.test.tsx
@@ -229,7 +229,7 @@ describe("FilesSection — download", () => {
     await user.click(downloadBtn)
     expect(fetchSpy).not.toHaveBeenCalled()
     expect(mockAddToast).toHaveBeenCalledWith(
-      expect.stringContaining("absolute"),
+      expect.stringContaining("directory"),
       "error",
     )
   })
@@ -271,8 +271,65 @@ describe("FilesSection — download", () => {
     )
   })
 
-  it("surfaces upstream errors as a toast + fires DOWNLOAD_FAILED", async () => {
-    fetchSpy.mockResolvedValue(new Response("not found", { status: 404 }))
+  it("surfaces a parsed upstream error as a toast + fires DOWNLOAD_FAILED", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ error: "disk on fire" }), { status: 500 }),
+    )
+    render(<FilesSection sandbox={activeSandbox} />)
+
+    const downloadPathInput = screen.getAllByPlaceholderText(
+      "/home/user/file.txt",
+    )[1]
+    await user.clear(downloadPathInput)
+    await user.type(downloadPathInput, "/home/user/file.txt")
+
+    await user.click(screen.getByRole("button", { name: /Download/ }))
+
+    expect(mockAddToast).toHaveBeenCalledWith(
+      expect.stringContaining("disk on fire"),
+      "error",
+    )
+    expect(mockCapture).toHaveBeenCalledWith(
+      "file_download_failed",
+      expect.objectContaining({ sandbox_id: "sbx-1" }),
+    )
+  })
+
+  it("shows a friendly message for a directory path, not the raw backend error", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: "use FilesystemService.ListDir for directories",
+        }),
+        { status: 400 },
+      ),
+    )
+    render(<FilesSection sandbox={activeSandbox} />)
+
+    const downloadPathInput = screen.getAllByPlaceholderText(
+      "/home/user/file.txt",
+    )[1]
+    await user.clear(downloadPathInput)
+    await user.type(downloadPathInput, "/home/user/research")
+
+    await user.click(screen.getByRole("button", { name: /Download/ }))
+
+    expect(mockAddToast).toHaveBeenCalledWith(
+      expect.stringContaining("directory"),
+      "error",
+    )
+    expect(mockAddToast).not.toHaveBeenCalledWith(
+      expect.stringContaining("FilesystemService"),
+      "error",
+    )
+  })
+
+  it("shows a friendly message when the file is missing (404)", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ error: "file not found" }), {
+        status: 404,
+      }),
+    )
     render(<FilesSection sandbox={activeSandbox} />)
 
     const downloadPathInput = screen.getAllByPlaceholderText(
@@ -284,12 +341,8 @@ describe("FilesSection — download", () => {
     await user.click(screen.getByRole("button", { name: /Download/ }))
 
     expect(mockAddToast).toHaveBeenCalledWith(
-      expect.stringContaining("not found"),
+      expect.stringContaining("No file found"),
       "error",
-    )
-    expect(mockCapture).toHaveBeenCalledWith(
-      "file_download_failed",
-      expect.objectContaining({ sandbox_id: "sbx-1" }),
     )
   })
 })

--- a/apps/console/src/components/sandboxes/files-section.test.tsx
+++ b/apps/console/src/components/sandboxes/files-section.test.tsx
@@ -295,6 +295,30 @@ describe("FilesSection — download", () => {
     )
   })
 
+  it("does not leak an unexpected JSON error body into the toast", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ unexpected: "shape" }), { status: 500 }),
+    )
+    render(<FilesSection sandbox={activeSandbox} />)
+
+    const downloadPathInput = screen.getAllByPlaceholderText(
+      "/home/user/file.txt",
+    )[1]
+    await user.clear(downloadPathInput)
+    await user.type(downloadPathInput, "/home/user/file.txt")
+
+    await user.click(screen.getByRole("button", { name: /Download/ }))
+
+    expect(mockAddToast).toHaveBeenCalledWith(
+      expect.stringContaining("Download failed"),
+      "error",
+    )
+    expect(mockAddToast).not.toHaveBeenCalledWith(
+      expect.stringContaining("unexpected"),
+      "error",
+    )
+  })
+
   it("shows a friendly message for a directory path, not the raw backend error", async () => {
     fetchSpy.mockResolvedValue(
       new Response(

--- a/apps/console/src/components/sandboxes/files-section.tsx
+++ b/apps/console/src/components/sandboxes/files-section.tsx
@@ -374,7 +374,7 @@ function DownloadPanel({ sandbox, disabled, reason }: PanelProps) {
         // backend error.
         if (res.status === 400 && /director/i.test(detail)) {
           throw new Error(
-            `"${target}" is a directory — enter a path to a specific file inside it. Folder downloads aren't supported.`,
+            `"${target}" is a directory — enter a path to a specific file inside it.`,
           )
         }
         if (res.status === 404) {

--- a/apps/console/src/components/sandboxes/files-section.tsx
+++ b/apps/console/src/components/sandboxes/files-section.tsx
@@ -43,6 +43,26 @@ function isValidAbsolutePath(path: string): boolean {
   return true
 }
 
+/**
+ * Pull a human-readable message out of a data-plane error response. Bodies are
+ * JSON like {"error":"..."} or {"error":{"code","message"}}; fall back to the
+ * raw text, then a generic message. Keeps internal error strings out of toasts.
+ */
+async function errorMessage(res: Response, fallback: string): Promise<string> {
+  const text = await res.text().catch(() => "")
+  try {
+    const err = (JSON.parse(text) as { error?: unknown }).error
+    if (typeof err === "string") return err
+    if (err && typeof err === "object" && "message" in err) {
+      const message = (err as { message?: unknown }).message
+      if (typeof message === "string") return message
+    }
+  } catch {
+    // Body wasn't JSON; fall through to the raw text.
+  }
+  return text || fallback
+}
+
 function disabledReason(status: SandboxResponse["status"]): string | null {
   switch (status) {
     case "active":
@@ -206,8 +226,9 @@ function UploadPanel({ sandbox, disabled, reason }: PanelProps) {
         body: file,
       })
       if (!res.ok) {
-        const text = await res.text().catch(() => "")
-        throw new Error(text || `Upload failed (${res.status})`)
+        throw new Error(
+          await errorMessage(res, `Upload failed (${res.status})`),
+        )
       }
       posthog.capture(FILE_EVENTS.UPLOAD_SUCCEEDED, {
         sandbox_id: sandbox.id,
@@ -271,6 +292,7 @@ function UploadPanel({ sandbox, disabled, reason }: PanelProps) {
         <input
           ref={inputRef}
           type="file"
+          aria-label="File to upload"
           className="hidden"
           disabled={disabled}
           onChange={handleFileChange}
@@ -280,6 +302,7 @@ function UploadPanel({ sandbox, disabled, reason }: PanelProps) {
         value={path}
         onChange={(e) => setPath(e.target.value)}
         placeholder="/home/user/file.txt"
+        aria-label="Upload destination path"
         disabled={disabled}
         className="font-mono text-xs"
       />
@@ -314,7 +337,14 @@ function DownloadPanel({ sandbox, disabled, reason }: PanelProps) {
 
   const handleDownload = async () => {
     const target = path.trim()
-    if (!isValidAbsolutePath(target) || target.endsWith("/")) {
+    if (target.endsWith("/")) {
+      addToast(
+        "That's a directory — enter a path to a specific file inside it.",
+        "error",
+      )
+      return
+    }
+    if (!isValidAbsolutePath(target)) {
       addToast(
         "Path must be an absolute file path without '..' segments",
         "error",
@@ -330,8 +360,22 @@ function DownloadPanel({ sandbox, disabled, reason }: PanelProps) {
         headers: { "X-Access-Token": sandbox.access_token },
       })
       if (!res.ok) {
-        const text = await res.text().catch(() => "")
-        throw new Error(text || `Download failed (${res.status})`)
+        const detail = await errorMessage(
+          res,
+          `Download failed (${res.status})`,
+        )
+        // Downloads are single-file only; a directory path is rejected by the
+        // data plane. Surface something the user can act on instead of the raw
+        // backend error.
+        if (res.status === 400 && /director/i.test(detail)) {
+          throw new Error(
+            `"${target}" is a directory — enter a path to a specific file inside it. Folder downloads aren't supported.`,
+          )
+        }
+        if (res.status === 404) {
+          throw new Error(`No file found at "${target}"`)
+        }
+        throw new Error(detail)
       }
 
       const lengthHeader = res.headers.get("content-length")
@@ -407,6 +451,7 @@ function DownloadPanel({ sandbox, disabled, reason }: PanelProps) {
         value={path}
         onChange={(e) => setPath(e.target.value)}
         placeholder="/home/user/file.txt"
+        aria-label="Download file path"
         disabled={disabled}
         className="font-mono text-xs"
       />

--- a/apps/console/src/components/sandboxes/files-section.tsx
+++ b/apps/console/src/components/sandboxes/files-section.tsx
@@ -51,12 +51,17 @@ function isValidAbsolutePath(path: string): boolean {
 async function errorMessage(res: Response, fallback: string): Promise<string> {
   const text = await res.text().catch(() => "")
   try {
-    const err = (JSON.parse(text) as { error?: unknown }).error
+    const parsed = JSON.parse(text) as Record<string, unknown>
+    const err = parsed.error
     if (typeof err === "string") return err
     if (err && typeof err === "object" && "message" in err) {
       const message = (err as { message?: unknown }).message
       if (typeof message === "string") return message
     }
+    if (typeof parsed.message === "string") return parsed.message
+    // Parsed as JSON but no readable message — use the fallback rather than
+    // dumping the raw structure into a toast.
+    return fallback
   } catch {
     // Body wasn't JSON; fall through to the raw text.
   }

--- a/apps/console/src/components/sticky-hover-table.tsx
+++ b/apps/console/src/components/sticky-hover-table.tsx
@@ -56,7 +56,7 @@ export function StickyHoverTableBody({
           }}
           aria-hidden="true"
         >
-          <td style={{ padding: 0, border: 0 }}>
+          <td aria-hidden="true" style={{ padding: 0, border: 0 }}>
             <motion.div
               className="absolute right-0 left-0 bg-brand/5"
               animate={{


### PR DESCRIPTION
Downloading a directory path in the sandbox Files panel surfaced a raw internal backend error. Downloads are single-file only, so the console now handles the directory case cleanly.

## Changes
- Parse the data-plane error body instead of showing raw JSON.
- Directory path and missing-file (404) now get clear, actionable messages.
- Same handling applied to upload errors.
- Fixed the pre-existing jsx-a11y control-label errors in the touched and adjacent files (lint now green).