### PR TITLE
docs: add GET /exec/connect to API reference nav

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -157,6 +157,7 @@
           {
             "group": "Exec",
             "pages": [
+              "GET /exec/connect",
               "POST /sandboxes/{sandbox_id}/exec",
               "POST /sandboxes/{sandbox_id}/exec/stream"
             ]


### PR DESCRIPTION
Fixes the `check-docs-nav` CI check, which has been failing because `GET /exec/connect` was added to the OpenAPI spec but not the docs nav.

One-line addition to the Exec group in `docs/docs.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)