### PR TITLE
docs: fix factual inaccuracies in reference and integration guides

### DIFF
--- a/docs/integrations/agent-harnesses/claude-agent-sdk.mdx
+++ b/docs/integrations/agent-harnesses/claude-agent-sdk.mdx
@@ -71,13 +71,13 @@ await sandbox.kill()
 ```python Python {7-14}
 import anyio
 from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient, create_sdk_mcp_server, tool
-from superserve import Sandbox
+from superserve import AsyncSandbox
 
-sandbox = Sandbox.create(name="agent-runtime")
+sandbox = None
 
 @tool("bash", "Run a shell command in the sandbox.", {"command": str})
 async def bash(args):
-    result = sandbox.commands.run(args["command"], timeout_seconds=60)
+    result = await sandbox.commands.run(args["command"], timeout_seconds=60)
     return {
         "content": [
             {"type": "text", "text": f"{result.stdout}\n{result.stderr}"},
@@ -92,11 +92,13 @@ options = ClaudeAgentOptions(
 )
 
 async def main():
+    global sandbox
+    sandbox = await AsyncSandbox.create(name="agent-runtime")
     async with ClaudeSDKClient(options=options) as client:
         await client.query("List the files in /tmp and tell me how many there are.")
         async for msg in client.receive_response():
             print(msg)
-    sandbox.kill()
+    await sandbox.kill()
 
 anyio.run(main)
 ```

--- a/docs/integrations/agent-harnesses/claude-agent-sdk.mdx
+++ b/docs/integrations/agent-harnesses/claude-agent-sdk.mdx
@@ -73,7 +73,7 @@ import anyio
 from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient, create_sdk_mcp_server, tool
 from superserve import AsyncSandbox
 
-sandbox = None
+sandbox: AsyncSandbox | None = None
 
 @tool("bash", "Run a shell command in the sandbox.", {"command": str})
 async def bash(args):

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Introduction
 description: Superserve provides sandbox infrastructure to run code in isolated cloud environments powered by Firecracker MicroVMs.
 ---
 
-Each sandbox boots from a [template](/templates/overview) — a reusable base image with your dependencies baked in. The default `superserve/base` runs Ubuntu 24.04 with Python 3.12, Node.js 22, and common dev tools.
+Each sandbox boots from a [template](/templates/overview) — a reusable base image with your dependencies baked in.
 
 ## What you can do
 

--- a/docs/sandbox/lifecycle.mdx
+++ b/docs/sandbox/lifecycle.mdx
@@ -65,7 +65,7 @@ sandbox.commands.run("ls /tmp")
 A paused sandbox is auto-resumed by both `Sandbox.connect()` and `commands.run()`.
 </Tip>
 
-Resume rotates the sandbox's per-sandbox access token on the backend. The SDK re-injects the new token into `sandbox.files` transparently - nothing changes in your code.
+After a resume, keep using the same `sandbox` — your `commands` and `files` calls keep working with no changes on your side.
 
 ## Kill
 

--- a/docs/sandbox/networking.mdx
+++ b/docs/sandbox/networking.mdx
@@ -38,10 +38,10 @@ sandbox = Sandbox.create(
 
 | Field | Accepts | Notes |
 |---|---|---|
-| `allowOut` / `allow_out` | CIDRs + domains | Domains support wildcards (`*.example.com`). |
+| `allowOut` / `allow_out` | CIDRs + domains | Domains support wildcards (`*.example.com`). A wildcard matches subdomains at any depth but not the bare domain — `*.example.com` does not match `example.com`; list both if you need the apex. |
 | `denyOut` / `deny_out` | CIDRs only | Use `0.0.0.0/0` to deny the entire internet and rely on `allowOut` for exceptions. |
 
-Deny rules take precedence over allow rules when they overlap.
+Allow rules take precedence over deny rules when they overlap.
 
 ## Update rules on a running sandbox
 

--- a/docs/sdk-reference/files.mdx
+++ b/docs/sdk-reference/files.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Files
 description: sandbox.files - read and write files inside a sandbox's filesystem.
 ---
 
-Read and write files inside a sandbox via `sandbox.files`. Operations route directly to the data plane (`boxd-{id}.sandbox.superserve.ai`) using a per-sandbox access token. The SDK manages the token transparently, including rotation after `resume()`.
+Read and write files in a sandbox's filesystem with `sandbox.files`.
 
 ## `write`
 

--- a/docs/templates/build-spec.mdx
+++ b/docs/templates/build-spec.mdx
@@ -104,6 +104,7 @@ When a build lands on `failed`, `BuildError.code` carries one of these stable id
 | `snapshot_failed`      | Snapshot couldn't be captured.                                                               |
 | `start_cmd_failed`     | `startCmd` didn't launch successfully.                                                       |
 | `ready_cmd_failed`     | `readyCmd` didn't exit `0` within 10 minutes.                                                |
+| `dispatch_failed`      | The build host was unreachable when the build was dispatched.                                |
 | `build_failed`         | Catch-all when no specific code applies.                                                     |
 
 `Template.create` / `rebuild` can also be rejected **before a build starts** with a `RateLimitError` — `too_many_builds` (team's concurrent-build limit) or `too_many_templates` (team's template-count limit). These are not `BuildError` codes; see [Errors](/errors#ratelimiterror).


### PR DESCRIPTION
Fixes 6 doc inaccuracies, each verified against the platform source / SDK / tests:

- **introduction**: `superserve/base` is bare Ubuntu (no Python/Node) — removed the false claim
- **networking**: precedence is allow-wins (was stated as deny-wins); noted `*.x.com` doesn't match bare `x.com`
- **lifecycle**: resume doesn't rotate the access token — reworded
- **sdk-reference/files**: removed wrong data-plane host + token jargon
- **templates/build-spec**: added missing `dispatch_failed` error code
- **claude-agent-sdk**: async tool handler now uses `AsyncSandbox` + `await` (was a blocking sync call)