### PR TITLE
console: use slim Python base images in the template builder

### DIFF
--- a/apps/console/src/components/templates/create-template-dialog.tsx
+++ b/apps/console/src/components/templates/create-template-dialog.tsx
@@ -19,8 +19,8 @@ import { useCreateTemplate } from "@/hooks/use-templates"
 import { ApiError } from "@/lib/api/client"
 
 const CURATED_IMAGES = [
-  "python:3.11",
-  "python:3.12",
+  "python:3.11-slim",
+  "python:3.12-slim",
   "node:20-slim",
   "node:22-slim",
   "ubuntu:24.04",
@@ -307,6 +307,11 @@ export function CreateTemplateDialog({
               </div>
             </Field>
           </div>
+
+          <p className="text-xs text-muted">
+            Make sure the disk is large enough for your base image and build
+            steps.
+          </p>
 
           {errors.form && (
             <p className="border border-dashed border-destructive p-3 text-xs text-destructive">

--- a/apps/console/src/components/templates/create-template-dialog.tsx
+++ b/apps/console/src/components/templates/create-template-dialog.tsx
@@ -265,53 +265,55 @@ export function CreateTemplateDialog({
             </div>
           </Field>
 
-          <div className="grid grid-cols-2 gap-3">
-            <Field label="vCPU">
-              <div className="flex border border-dashed border-border">
-                {VCPU_OPTIONS.map((n) => (
-                  <button
-                    key={n}
-                    type="button"
-                    onClick={() => setVcpu(n)}
-                    className={cn(
-                      "flex-1 cursor-pointer py-2 font-mono text-xs uppercase transition-colors",
-                      vcpu === n
-                        ? "bg-foreground text-background"
-                        : "text-muted hover:text-foreground",
-                    )}
-                  >
-                    {n}
-                  </button>
-                ))}
-              </div>
-            </Field>
+          <div className="space-y-1.5">
+            <div className="grid grid-cols-2 gap-3">
+              <Field label="vCPU">
+                <div className="flex border border-dashed border-border">
+                  {VCPU_OPTIONS.map((n) => (
+                    <button
+                      key={n}
+                      type="button"
+                      onClick={() => setVcpu(n)}
+                      className={cn(
+                        "flex-1 cursor-pointer py-2 font-mono text-xs uppercase transition-colors",
+                        vcpu === n
+                          ? "bg-foreground text-background"
+                          : "text-muted hover:text-foreground",
+                      )}
+                    >
+                      {n}
+                    </button>
+                  ))}
+                </div>
+              </Field>
 
-            <Field label="Disk">
-              <div className="flex border border-dashed border-border">
-                {DISK_OPTIONS.map((d) => (
-                  <button
-                    key={d}
-                    type="button"
-                    onClick={() => setDisk(d)}
-                    className={cn(
-                      "flex-1 cursor-pointer py-2 font-mono text-xs uppercase transition-colors",
-                      disk === d
-                        ? "bg-foreground text-background"
-                        : "text-muted hover:text-foreground",
-                    )}
-                    title={`${d / 1024} GB`}
-                  >
-                    {d / 1024} GB
-                  </button>
-                ))}
-              </div>
-            </Field>
+              <Field label="Disk">
+                <div className="flex border border-dashed border-border">
+                  {DISK_OPTIONS.map((d) => (
+                    <button
+                      key={d}
+                      type="button"
+                      onClick={() => setDisk(d)}
+                      className={cn(
+                        "flex-1 cursor-pointer py-2 font-mono text-xs uppercase transition-colors",
+                        disk === d
+                          ? "bg-foreground text-background"
+                          : "text-muted hover:text-foreground",
+                      )}
+                      title={`${d / 1024} GB`}
+                    >
+                      {d / 1024} GB
+                    </button>
+                  ))}
+                </div>
+              </Field>
+            </div>
+
+            <p className="text-xs text-muted">
+              Make sure the disk is large enough for your base image and build
+              steps.
+            </p>
           </div>
-
-          <p className="text-xs text-muted">
-            Make sure the disk is large enough for your base image and build
-            steps.
-          </p>
 
           {errors.form && (
             <p className="border border-dashed border-destructive p-3 text-xs text-destructive">


### PR DESCRIPTION
The template builder's curated image list offered the **full** `python:3.11` / `python:3.12` images (~1.6 GB), while node/debian used `-slim`. The full Python images overflow the smaller disk options, so picking e.g. Python 3.12 + 1 GB disk always fails with `image_too_large`.

- Switch curated Python entries to `-slim` (`python:3.12-slim` is 179 MB vs 1.62 GB).
- Add an inline hint to size the disk to the base image (covers the custom-image path).

After this, every curated image fits a 1 GB disk (largest is `node:22-slim` at 329 MB).