### PR TITLE
guides: fix broken links in the managed-agents recipe READMEs

### DIFF
--- a/guides/managed-agents/claude-managed-agents/recipes/dev-environment/README.md
+++ b/guides/managed-agents/claude-managed-agents/recipes/dev-environment/README.md
@@ -134,7 +134,7 @@ To drop the restriction entirely and allow **all** public hosts (simplest, least
 
 ## See also
 
-- [Full guide](https://docs.superserve.ai/integrations/managed-agents/dev-environment)
-- [Base recipe](../claude-managed-agents/) — simpler starting point without the session-notes pattern
+- [Full guide](https://docs.superserve.ai/integrations/managed-agents/claude-managed-agents)
+- [Base recipe](../../) — simpler starting point without the session-notes pattern
 - [Claude Code guide](https://docs.superserve.ai/integrations/coding-agents/claude) — fully autonomous coding agent (no turn-by-turn guidance)
 - [Claude Managed Agents docs](https://platform.claude.com/docs/en/managed-agents/overview)

--- a/guides/managed-agents/claude-managed-agents/recipes/dev-environment/README.md
+++ b/guides/managed-agents/claude-managed-agents/recipes/dev-environment/README.md
@@ -33,7 +33,7 @@ The agent maintains a `/workspace/.session-notes` file that documents what is in
 
 - Repo: /workspace/acme-api (main branch, clean)
 - Node: 20.x, npm 10.x
-- node_modules: installed (last updated 2025-05-28)
+- node_modules: installed (last updated 2026-05-28)
 - Tests: all passing (jest, 47 tests)
 
 ## Last session

--- a/guides/managed-agents/claude-managed-agents/recipes/parallel-benchmark-agent/README.md
+++ b/guides/managed-agents/claude-managed-agents/recipes/parallel-benchmark-agent/README.md
@@ -118,6 +118,6 @@ Sub-sandboxes accrue charges while running. The agent-written harness always kil
 
 ## See also
 
-- [Full guide](https://docs.superserve.ai/integrations/managed-agents/parallel-benchmark-agent)
-- [Base recipe](../claude-managed-agents/) — simpler starting point without sub-sandbox creation
+- [Full guide](https://docs.superserve.ai/integrations/managed-agents/claude-managed-agents)
+- [Base recipe](../../) — simpler starting point without sub-sandbox creation
 - [Claude Managed Agents docs](https://platform.claude.com/docs/en/managed-agents/overview)

--- a/guides/managed-agents/claude-managed-agents/recipes/research-agent/README.md
+++ b/guides/managed-agents/claude-managed-agents/recipes/research-agent/README.md
@@ -92,6 +92,6 @@ node orchestrator.mjs           # long-running
 
 ## See also
 
-- [Full guide](https://docs.superserve.ai/integrations/managed-agents/research-agent)
-- [Base recipe](../claude-managed-agents/) — simpler starting point if you don't need web tools
+- [Full guide](https://docs.superserve.ai/integrations/managed-agents/claude-managed-agents)
+- [Base recipe](../../) — simpler starting point if you don't need web tools
 - [Claude Managed Agents docs](https://platform.claude.com/docs/en/managed-agents/overview)


### PR DESCRIPTION
Both See-also links in all three recipe READMEs were broken: `Full guide` 404'd (no per-recipe doc pages) and is repointed to the `claude-managed-agents` guide; `Base recipe` pointed at a nonexistent path and is fixed to `../../`.