### PR TITLE
docs: add Get Started button to navbar

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://mintlify.com/docs.json",
-  "theme": "maple",
+  "theme": "willow",
   "name": "Superserve",
   "colors": {
     "primary": "#B2FAB4",
@@ -36,9 +36,17 @@
     "strict": true
   },
   "navbar": {
+    "links": [
+      {
+        "type": "github",
+        "label": "GitHub",
+        "href": "https://github.com/superserve-ai/superserve"
+      }
+    ],
     "primary": {
-      "type": "github",
-      "href": "https://github.com/superserve-ai/superserve"
+      "type": "button",
+      "label": "Get Started",
+      "href": "https://console.superserve.ai?utm_source=docs&utm_medium=navbar"
     }
   },
   "contextual": {

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,4 +1,4 @@
-a[href*="console.superserve.ai"] {
+a[href*="utm_medium=navbar"] {
   background-color: #b2fab4 !important;
   color: #0a2b0c !important;
   font-family: "Geist Mono", monospace !important;
@@ -12,16 +12,16 @@ a[href*="console.superserve.ai"] {
   height: 2.25rem !important;
 }
 
-a[href*="console.superserve.ai"] * {
+a[href*="utm_medium=navbar"] * {
   color: #0a2b0c !important;
 }
 
-a[href*="console.superserve.ai"] svg,
-a[href*="console.superserve.ai"]::after {
+a[href*="utm_medium=navbar"] svg,
+a[href*="utm_medium=navbar"]::after {
   display: none !important;
 }
 
-a[href*="console.superserve.ai"]:hover {
+a[href*="utm_medium=navbar"]:hover {
   background-color: #9de89f !important;
   color: #0a2b0c !important;
 }

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,27 @@
+a[href*="console.superserve.ai"] {
+  background-color: #b2fab4 !important;
+  color: #0a2b0c !important;
+  font-family: "Geist Mono", monospace !important;
+  font-size: 0.75rem !important;
+  font-weight: 500 !important;
+  text-transform: uppercase !important;
+  letter-spacing: 0.05em !important;
+  border-radius: 0 !important;
+  border: none !important;
+  padding: 0 1.5rem !important;
+  height: 2.25rem !important;
+}
+
+a[href*="console.superserve.ai"] * {
+  color: #0a2b0c !important;
+}
+
+a[href*="console.superserve.ai"] svg,
+a[href*="console.superserve.ai"]::after {
+  display: none !important;
+}
+
+a[href*="console.superserve.ai"]:hover {
+  background-color: #9de89f !important;
+  color: #0a2b0c !important;
+}


### PR DESCRIPTION
## Summary

- Adds a **Get Started** button to the docs navbar (top-right header) linking to `https://console.superserve.ai` with UTM tracking
- Adds GitHub link alongside it in the navbar
- Switches theme from `maple` to `willow` — maple renders navbar items at the bottom of the sidebar; willow puts them in the header top-right
- Adds `style.css` to style the button to match the Superserve design system (mint fill, dark ink text, Geist Mono uppercase, sharp corners)

## Test plan

- [ ] Visit docs and confirm Get Started button appears in top-right header
- [ ] Confirm GitHub link appears next to it
- [ ] Confirm button styling matches the design system (mint green, dark text, no border radius)
- [ ] Confirm hover state works
- [ ] Confirm no visual regressions on other pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)