### PR TITLE
console: show auth-code-error page when signup is blocked

### DIFF
--- a/apps/console/src/app/(auth)/auth/signup/page.test.tsx
+++ b/apps/console/src/app/(auth)/auth/signup/page.test.tsx
@@ -67,8 +67,10 @@ vi.mock("./action", () => ({
 }))
 
 const mockSearchParams = new URLSearchParams()
+const mockRouterPush = vi.fn()
 vi.mock("next/navigation", () => ({
   useSearchParams: () => mockSearchParams,
+  useRouter: () => ({ push: mockRouterPush }),
 }))
 
 vi.mock("next/link", () => ({
@@ -95,6 +97,7 @@ describe("SignUpPage", () => {
     mockSignUpWithEmail.mockReset()
     mockSignInWithOAuth.mockReset()
     mockCapture.mockReset()
+    mockRouterPush.mockReset()
   })
 
   it("renders the signup form", async () => {
@@ -209,6 +212,30 @@ describe("SignUpPage", () => {
     expect(
       await screen.findByText("An account with this email already exists."),
     ).toBeInTheDocument()
+  })
+
+  it("redirects to auth-code-error when signup is blocked by the trigger", async () => {
+    mockSignUpWithEmail.mockResolvedValue({
+      success: false,
+      error: "Database error saving new user",
+    })
+    render(<SignUpPage />)
+
+    await user.type(
+      await screen.findByPlaceholderText("Full Name"),
+      "Test User",
+    )
+    await user.type(screen.getByPlaceholderText("Email"), "test@test.com")
+    await user.type(screen.getByPlaceholderText("Password"), "password123")
+    await user.type(
+      screen.getByPlaceholderText("Confirm Password"),
+      "password123",
+    )
+    await user.click(screen.getByRole("button", { name: "Sign Up" }))
+
+    await waitFor(() => {
+      expect(mockRouterPush).toHaveBeenCalledWith("/auth/auth-code-error")
+    })
   })
 
   it("shows generic error when signUpWithEmail throws", async () => {

--- a/apps/console/src/app/(auth)/auth/signup/page.tsx
+++ b/apps/console/src/app/(auth)/auth/signup/page.tsx
@@ -62,7 +62,9 @@ function SignUpContent() {
           method: "email",
           reason: result.error,
         })
-        if (result.error === "Database error saving new user") {
+        if (
+          result.error?.toLowerCase().includes("database error saving new user")
+        ) {
           router.push("/auth/auth-code-error")
           return
         }

--- a/apps/console/src/app/(auth)/auth/signup/page.tsx
+++ b/apps/console/src/app/(auth)/auth/signup/page.tsx
@@ -4,7 +4,7 @@ import { EyeIcon, EyeSlashIcon } from "@phosphor-icons/react"
 import { Button, Input } from "@superserve/ui"
 import Image from "next/image"
 import Link from "next/link"
-import { useSearchParams } from "next/navigation"
+import { useRouter, useSearchParams } from "next/navigation"
 import { usePostHog } from "posthog-js/react"
 import { Suspense, useEffect, useState } from "react"
 
@@ -28,6 +28,7 @@ function SignUpContent() {
   const [emailSent, setEmailSent] = useState(false)
   const [errors, setErrors] = useState<Record<string, string>>({})
   const posthog = usePostHog()
+  const router = useRouter()
   const searchParams = useSearchParams()
   const rawNext = searchParams.get("next") || "/"
   const nextUrl = rawNext.startsWith("/") ? rawNext : "/"
@@ -61,6 +62,10 @@ function SignUpContent() {
           method: "email",
           reason: result.error,
         })
+        if (result.error === "Database error saving new user") {
+          router.push("/auth/auth-code-error")
+          return
+        }
         setErrors({ form: result.error || "Error creating account." })
         return
       }


### PR DESCRIPTION
When a blocked email or domain attempts signup, the Supabase trigger raises and the action returns the wrapped 'Database error saving new user' message. Previously this rendered as inline error text on the signup form; now it routes to the same /auth/auth-code-error page that OAuth failures already use, matching the existing Authentication Error UX.