### PR TITLE
console: typed errorCode for blocked-email + signup-tailored error page

### DIFF
--- a/apps/console/src/app/(auth)/auth/auth-code-error/page.tsx
+++ b/apps/console/src/app/(auth)/auth/auth-code-error/page.tsx
@@ -1,12 +1,29 @@
-import { WarningIcon } from "@phosphor-icons/react/dist/ssr"
+"use client"
+
+import { WarningIcon } from "@phosphor-icons/react"
 import { Button } from "@superserve/ui"
 import Image from "next/image"
 import Link from "next/link"
+import { useSearchParams } from "next/navigation"
+import { Suspense } from "react"
 
 import { CornerBrackets } from "@/components/corner-brackets"
 import { DitherBackground } from "@/components/dither-background"
 
-export default function AuthCodeErrorPage() {
+function AuthCodeErrorContent() {
+  const searchParams = useSearchParams()
+  const reason = searchParams.get("reason")
+  const isSignupBlocked = reason === "signup_blocked"
+
+  const heading = isSignupBlocked
+    ? "Signup Not Available"
+    : "Authentication Error"
+  const message = isSignupBlocked
+    ? "Signup is not available for this email address. Contact support@superserve.ai if you believe this is in error."
+    : "Something went wrong during sign in. Please try again."
+  const retryHref = isSignupBlocked ? "/auth/signup" : "/auth/signin"
+  const retryLabel = isSignupBlocked ? "Back to Signup" : "Try Again"
+
   return (
     <div className="flex min-h-screen flex-col items-center justify-center p-6">
       <DitherBackground />
@@ -28,20 +45,28 @@ export default function AuthCodeErrorPage() {
         <div className="flex flex-col items-center">
           <WarningIcon className="mb-3 size-8 text-muted" weight="light" />
           <h1 className="text-center text-sm font-medium text-foreground">
-            Authentication Error
+            {heading}
           </h1>
-          <p className="mt-2 text-center text-xs text-muted">
-            Something went wrong during sign in. Please try again.
-          </p>
-          <Button
-            render={<Link href="/auth/signin" />}
-            size="sm"
-            className="mt-5"
-          >
-            Try Again
+          <p className="mt-2 text-center text-xs text-muted">{message}</p>
+          <Button render={<Link href={retryHref} />} size="sm" className="mt-5">
+            {retryLabel}
           </Button>
         </div>
       </div>
     </div>
+  )
+}
+
+export default function AuthCodeErrorPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center">
+          <div className="h-5 w-5 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+        </div>
+      }
+    >
+      <AuthCodeErrorContent />
+    </Suspense>
   )
 }

--- a/apps/console/src/app/(auth)/auth/auth-code-error/page.tsx
+++ b/apps/console/src/app/(auth)/auth/auth-code-error/page.tsx
@@ -12,17 +12,8 @@ import { DitherBackground } from "@/components/dither-background"
 
 function AuthCodeErrorContent() {
   const searchParams = useSearchParams()
-  const reason = searchParams.get("reason")
-  const isSignupBlocked = reason === "signup_blocked"
-
-  const heading = isSignupBlocked
-    ? "Signup Not Available"
-    : "Authentication Error"
-  const message = isSignupBlocked
-    ? "Signup is not available for this email address. Contact support@superserve.ai if you believe this is in error."
-    : "Something went wrong during sign in. Please try again."
-  const retryHref = isSignupBlocked ? "/auth/signup" : "/auth/signin"
-  const retryLabel = isSignupBlocked ? "Back to Signup" : "Try Again"
+  const isSignupContext = searchParams.get("reason") === "signup_blocked"
+  const retryHref = isSignupContext ? "/auth/signup" : "/auth/signin"
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center p-6">
@@ -45,11 +36,13 @@ function AuthCodeErrorContent() {
         <div className="flex flex-col items-center">
           <WarningIcon className="mb-3 size-8 text-muted" weight="light" />
           <h1 className="text-center text-sm font-medium text-foreground">
-            {heading}
+            Authentication Error
           </h1>
-          <p className="mt-2 text-center text-xs text-muted">{message}</p>
+          <p className="mt-2 text-center text-xs text-muted">
+            Something went wrong. Please try again.
+          </p>
           <Button render={<Link href={retryHref} />} size="sm" className="mt-5">
-            {retryLabel}
+            Try Again
           </Button>
         </div>
       </div>
@@ -62,7 +55,7 @@ export default function AuthCodeErrorPage() {
     <Suspense
       fallback={
         <div className="flex min-h-screen items-center justify-center">
-          <div className="h-5 w-5 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+          <div className="h-5 w-5 animate-spin border-2 border-primary border-t-transparent" />
         </div>
       }
     >

--- a/apps/console/src/app/(auth)/auth/callback/route.ts
+++ b/apps/console/src/app/(auth)/auth/callback/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server"
 
 import { notifySlackOfNewUser } from "@/app/(auth)/auth/signin/action"
 import { sendWelcomeEmail } from "@/app/(auth)/auth/signup/action"
+import { BLOCKED_TRIGGER_MESSAGE } from "@/lib/auth/errors"
 import { trackEvent } from "@/lib/posthog/actions"
 import { AUTH_EVENTS } from "@/lib/posthog/events"
 import { createServerClient } from "@/lib/supabase/server"
@@ -52,7 +53,7 @@ export async function GET(request: Request) {
     if (error) {
       const blocked = error.message
         .toLowerCase()
-        .includes("database error saving new user")
+        .includes(BLOCKED_TRIGGER_MESSAGE)
       if (blocked) {
         console.warn("OAuth signup blocked by trigger")
         return NextResponse.redirect(

--- a/apps/console/src/app/(auth)/auth/callback/route.ts
+++ b/apps/console/src/app/(auth)/auth/callback/route.ts
@@ -56,7 +56,10 @@ export async function GET(request: Request) {
       if (blocked) {
         console.warn("OAuth signup blocked by trigger")
         return NextResponse.redirect(
-          `${origin}/auth/auth-code-error?reason=signup_blocked`,
+          buildRedirectUrl(
+            origin,
+            "/auth/auth-code-error?reason=signup_blocked",
+          ),
         )
       }
       console.error("Auth callback error:", error.message, {

--- a/apps/console/src/app/(auth)/auth/callback/route.ts
+++ b/apps/console/src/app/(auth)/auth/callback/route.ts
@@ -50,6 +50,15 @@ export async function GET(request: Request) {
     }
 
     if (error) {
+      const blocked = error.message
+        .toLowerCase()
+        .includes("database error saving new user")
+      if (blocked) {
+        console.warn("OAuth signup blocked by trigger")
+        return NextResponse.redirect(
+          `${origin}/auth/auth-code-error?reason=signup_blocked`,
+        )
+      }
       console.error("Auth callback error:", error.message, {
         code: !!code,
         tokenHash: !!tokenHash,

--- a/apps/console/src/app/(auth)/auth/signup/action.ts
+++ b/apps/console/src/app/(auth)/auth/signup/action.ts
@@ -54,7 +54,7 @@ export const signUpWithEmail = async (
         console.warn("Signup blocked by trigger", { email: parsed.data.email })
         return {
           success: false,
-          error: error.message,
+          error: "Signup is not available for this email address.",
           errorCode: "blocked_email" as const,
         }
       }

--- a/apps/console/src/app/(auth)/auth/signup/action.ts
+++ b/apps/console/src/app/(auth)/auth/signup/action.ts
@@ -3,6 +3,7 @@
 import { z } from "zod"
 
 import { notifySlackOfNewUser } from "@/app/(auth)/auth/signin/action"
+import { BLOCKED_TRIGGER_MESSAGE } from "@/lib/auth/errors"
 import { sendEmail } from "@/lib/email/send"
 import { ConfirmationEmail } from "@/lib/email/templates/confirmation"
 import { WelcomeEmail } from "@/lib/email/templates/welcome"
@@ -48,9 +49,7 @@ export const signUpWithEmail = async (
           error: "An account with this email already exists.",
         }
       }
-      if (
-        error.message.toLowerCase().includes("database error saving new user")
-      ) {
+      if (error.message.toLowerCase().includes(BLOCKED_TRIGGER_MESSAGE)) {
         console.warn("Signup blocked by trigger", { email: parsed.data.email })
         return {
           success: false,

--- a/apps/console/src/app/(auth)/auth/signup/action.ts
+++ b/apps/console/src/app/(auth)/auth/signup/action.ts
@@ -48,6 +48,16 @@ export const signUpWithEmail = async (
           error: "An account with this email already exists.",
         }
       }
+      if (
+        error.message.toLowerCase().includes("database error saving new user")
+      ) {
+        console.warn("Signup blocked by trigger", { email: parsed.data.email })
+        return {
+          success: false,
+          error: error.message,
+          errorCode: "blocked_email" as const,
+        }
+      }
       return { success: false, error: error.message }
     }
 

--- a/apps/console/src/app/(auth)/auth/signup/page.test.tsx
+++ b/apps/console/src/app/(auth)/auth/signup/page.test.tsx
@@ -218,6 +218,7 @@ describe("SignUpPage", () => {
     mockSignUpWithEmail.mockResolvedValue({
       success: false,
       error: "Database error saving new user",
+      errorCode: "blocked_email",
     })
     render(<SignUpPage />)
 
@@ -234,7 +235,9 @@ describe("SignUpPage", () => {
     await user.click(screen.getByRole("button", { name: "Sign Up" }))
 
     await waitFor(() => {
-      expect(mockRouterPush).toHaveBeenCalledWith("/auth/auth-code-error")
+      expect(mockRouterPush).toHaveBeenCalledWith(
+        "/auth/auth-code-error?reason=signup_blocked",
+      )
     })
   })
 

--- a/apps/console/src/app/(auth)/auth/signup/page.tsx
+++ b/apps/console/src/app/(auth)/auth/signup/page.tsx
@@ -62,7 +62,7 @@ function SignUpContent() {
           method: "email",
           reason: result.error,
         })
-        if (result.errorCode === "blocked_email") {
+        if ("errorCode" in result && result.errorCode === "blocked_email") {
           router.push("/auth/auth-code-error?reason=signup_blocked")
           return
         }

--- a/apps/console/src/app/(auth)/auth/signup/page.tsx
+++ b/apps/console/src/app/(auth)/auth/signup/page.tsx
@@ -62,10 +62,8 @@ function SignUpContent() {
           method: "email",
           reason: result.error,
         })
-        if (
-          result.error?.toLowerCase().includes("database error saving new user")
-        ) {
-          router.push("/auth/auth-code-error")
+        if (result.errorCode === "blocked_email") {
+          router.push("/auth/auth-code-error?reason=signup_blocked")
           return
         }
         setErrors({ form: result.error || "Error creating account." })

--- a/apps/console/src/lib/auth/errors.ts
+++ b/apps/console/src/lib/auth/errors.ts
@@ -1,0 +1,4 @@
+// Supabase wraps Postgres trigger exceptions raised during auth.users INSERT
+// as this generic message. Used to detect signups blocked by the
+// `reject_blocked_emails` trigger on auth.users.
+export const BLOCKED_TRIGGER_MESSAGE = "database error saving new user"


### PR DESCRIPTION
Follow-up to PR #218. Two improvements based on review feedback:

- Replace fragile string-match in the page with a typed `errorCode: "blocked_email"` returned from the signup action. Action also logs the blocked attempt (with email) for visibility.
- Pass `?reason=signup_blocked` to the auth-code-error page so the copy and "Try Again" destination match the signup context instead of saying "sign in". OAuth callback also redirects with the same query param when the trigger fires.