### PR TITLE
docs: MCP contextual options, copy improvements

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -50,7 +50,7 @@
     }
   },
   "contextual": {
-    "options": ["copy", "view", "chatgpt", "claude"]
+    "options": ["copy", "view", "claude", "mcp", "add-mcp", "cursor", "vscode"]
   },
   "navigation": {
     "tabs": [

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -4,7 +4,13 @@ sidebarTitle: Introduction
 description: Superserve provides sandbox infrastructure to run code in isolated cloud environments powered by Firecracker MicroVMs.
 ---
 
-Each sandbox boots from a [template](/templates/overview) — a reusable base image with your dependencies baked in.
+Each sandbox starts from a [template](/templates/overview) — a reusable base image with your dependencies baked in.
+
+<Tip>
+  Use the menu at the top right of any page to add our docs as an MCP server
+  in Claude Code, Cursor, or VS Code — giving your agent direct access to
+  search and read Superserve documentation.
+</Tip>
 
 ## What you can do
 
@@ -19,7 +25,7 @@ Each sandbox boots from a [template](/templates/overview) — a reusable base im
 
 <CardGroup cols={2}>
   <Card title="Quickstart" icon="rocket" href="/quickstart">
-    Create your first sandbox in under five minutes.
+    Create your first sandbox and run your first command.
   </Card>
   <Card title="Get an API key" icon="key" href="/api-key">
     Authenticate the SDK with your Superserve account.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Quickstart"
 sidebarTitle: Quickstart
-description: Create your first sandbox, run a command, and read a file - in under five minutes.
+description: Create your first sandbox, run a command, and read a file.
 ---
 
 Install the SDK, set your API key, and create a sandbox.


### PR DESCRIPTION
## Summary
- Added MCP contextual menu options (`mcp`, `add-mcp`, `cursor`, `vscode`) and dropped `chatgpt` — makes it easy for Claude Code, Cursor, and VS Code users to add our docs as an MCP server
- Added MCP tip callout to introduction page
- Changed "boots" → "starts" (less jargon-y)
- Removed "in under five minutes" time claim from quickstart description and intro card