### PR TITLE
Bump SDK versions to 0.7.5

### DIFF
--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "superserve"
-version = "0.7.4"
+version = "0.7.5"
 description = "Python SDK for the Superserve sandbox API"
 license = "Apache-2.0"
 readme = "README.md"

--- a/packages/python-sdk/src/superserve/__init__.py
+++ b/packages/python-sdk/src/superserve/__init__.py
@@ -48,7 +48,7 @@ from .types import (
     WorkdirStep,
 )
 
-__version__ = "0.7.4"
+__version__ = "0.7.5"
 
 __all__ = [
     "AsyncCommandSession",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superserve/sdk",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "TypeScript SDK for the Superserve sandbox API",
   "keywords": [
     "firecracker",


### PR DESCRIPTION
Release the current SDK (adds the secrets surface) to npm + PyPI before the runtime-binding work.