### PR TITLE
Bump SDK versions to 0.7.6

### DIFF
--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "superserve"
-version = "0.7.5"
+version = "0.7.6"
 description = "Python SDK for the Superserve sandbox API"
 license = "Apache-2.0"
 readme = "README.md"

--- a/packages/python-sdk/src/superserve/__init__.py
+++ b/packages/python-sdk/src/superserve/__init__.py
@@ -48,7 +48,7 @@ from .types import (
     WorkdirStep,
 )
 
-__version__ = "0.7.5"
+__version__ = "0.7.6"
 
 __all__ = [
     "AsyncCommandSession",

--- a/packages/python-sdk/src/superserve/_http.py
+++ b/packages/python-sdk/src/superserve/_http.py
@@ -21,7 +21,7 @@ from .errors import SandboxError, SandboxTimeoutError, map_api_error
 
 DEFAULT_TIMEOUT = 30.0
 
-SDK_VERSION = "0.7.4"
+SDK_VERSION = "0.7.6"
 USER_AGENT = (
     f"superserve-python/{SDK_VERSION} "
     f"(python/{sys.version_info.major}.{sys.version_info.minor})"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superserve/sdk",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "TypeScript SDK for the Superserve sandbox API",
   "keywords": [
     "firecracker",

--- a/packages/sdk/src/http.ts
+++ b/packages/sdk/src/http.ts
@@ -15,7 +15,7 @@ import type { ApiExecStreamEvent } from "./types.js"
 
 const DEFAULT_TIMEOUT_MS = 30_000
 
-const SDK_VERSION = "0.7.4"
+const SDK_VERSION = "0.7.6"
 const USER_AGENT = `@superserve/sdk/${SDK_VERSION} (node/${
   typeof process !== "undefined" && process.versions?.node
     ? `v${process.versions.node}`

--- a/uv.lock
+++ b/uv.lock
@@ -492,7 +492,7 @@ wheels = [
 
 [[package]]
 name = "superserve"
-version = "0.7.4"
+version = "0.7.6"
 source = { editable = "packages/python-sdk" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Bumps `@superserve/sdk` (npm) and `superserve` (PyPI) to 0.7.6 for the runtime secret-binding feature (attach/detach at runtime).