### PR TITLE
Reposition SDK, Console & docs → "open agent infrastructure"

### DIFF
--- a/REPOSITIONING-REVIEW.md
+++ b/REPOSITIONING-REVIEW.md
@@ -1,0 +1,123 @@
+# Repositioning Review — Docs (Mintlify)
+
+Surface: `docs/` (Mintlify, MDX + `docs.json`).
+Thesis: Superserve → **open agent infrastructure**. Two composable primitives on one substrate —
+**Sandbox** ("a computer that remembers", already shipping) and **Actor** ("a process that survives",
+the new first-class concept, today only a hand-built pattern). Framing: the platform is the durable
+**body**, any harness is the interchangeable **brain**.
+
+This file holds (a) new-page proposals that I did **not** create, and (b) anything I judged
+higher-risk than a prose touch. Low/medium-risk prose edits were applied directly (listed at the
+bottom). I did **not** invent any SDK/API surface in shipped docs.
+
+---
+
+## A. Proposed new pages (NOT created — need approval + IA decision)
+
+### A1. "Actors" concept page — `docs/concepts/actors.mdx` (or `docs/actors/overview.mdx`)
+
+**Why:** Actor is the new half of the thesis and currently has no home in the docs. It should be
+introduced as a _concept / platform direction_, not as a shipped API — there is no Actor type in the
+SDK today (the pattern is hand-built today, e.g. the orchestrator/runner loop in
+`integrations/managed-agents/claude-managed-agents`). Copy must be forward-looking and must not claim
+methods/endpoints that don't exist.
+
+**Proposed positioning sentence:**
+
+> An **Actor** is a process that survives: a named, durable, single-writer entity that wakes on
+> events, serializes its input through an inbox, checkpoints its state, and hibernates between events
+> — addressable by id from anywhere. Conceptually, **Actor = Sandbox + identity + inbox + durable
+> orchestration**.
+
+**Proposed structure:**
+
+- What an Actor is (body/brain recap; Actor builds on the sandbox body).
+- Actor vs. Sandbox (a sandbox is compute that remembers; an actor adds identity, an inbox, and
+  durable orchestration on top).
+- The durability ladder (see A2) — where each level lands.
+- "Today vs. direction" callout: be explicit that Actors are the **platform direction**. Show the
+  pattern you can build today on sandboxes (find-or-create by metadata id, pause/resume between
+  turns — exactly what the managed-agents guide already does) and frame the first-class Actor API as
+  forthcoming.
+
+**Risk:** Medium-high (introduces a primary concept). Needs product sign-off on how far the
+forward-looking language goes, and a decision on whether a new top-level nav group ("Concepts") is
+created. Hence not written.
+
+### A2. "Harness Contract" page — `docs/concepts/harness-contract.mdx`
+
+**Why:** The body/brain framing relies on a clean contract for swapping brains. Worth stating
+explicitly, but it describes a contract/spec, so it belongs in review rather than being asserted as
+shipped docs.
+
+**Proposed content:**
+
+- The contract in one line: **turn → stream → idle**. A harness receives a turn, streams output, and
+  signals idle; the body handles everything around it (compute, fs, lifecycle, wake/resume).
+- The durability ladder:
+  - **L0 — drop-in:** run any harness/OCI image unchanged on the durable body.
+  - **L1 — event-driven:** the body wakes the harness on events and streams its output.
+  - **L2 — step-level replay:** checkpoint and replay at step granularity.
+- "Bring your OCI image, it just runs": honor the image `ENTRYPOINT`/`CMD`; one call from image.
+  **NOTE:** confirm the one-call-from-image / honor-ENTRYPOINT path actually ships before documenting
+  it as available — the introduction edits intentionally do **not** claim it yet.
+
+**Risk:** Medium-high (new spec-like surface, ladder terminology is product-defining). Not written.
+
+### A3. Nav (`docs.json`) changes implied by A1/A2
+
+If A1/A2 are approved, add a **"Concepts"** group to the Documentation tab, e.g.:
+
+```jsonc
+{
+  "group": "Concepts",
+  "pages": ["concepts/actors", "concepts/harness-contract"],
+}
+```
+
+Top-level nav IA is **high-risk** per the rules, so I did not touch `docs.json` navigation. Proposing
+the exact group above for approval.
+
+---
+
+## B. Higher-risk copy I did NOT change (flagging only)
+
+### B1. `docs.json` `"name": "Superserve"`
+
+Left as-is. The product name is unchanged by this repositioning; "open agent infrastructure" is a
+tagline/positioning line, not a rename. No change proposed unless product wants a navbar tagline.
+
+### B2. Pre-existing `docs:check-nav` failure (NOT mine)
+
+`bun run docs:check-nav` already fails on `main`/baseline, before any of my edits. It is unrelated to
+this repositioning — it checks that the **API Reference** nav in `docs.json` stays in sync with the
+OpenAPI spec, and it reports:
+
+- spec has but nav lacks: `GET /billing/pricing`, `GET /billing/pricing/public`
+- nav has but spec lacks: `POST /sandboxes/{sandbox_id}/exec`, `POST /sandboxes/{sandbox_id}/exec/stream`
+  This is an API/spec drift issue (note the recent commit "remove legacy controlplane exec endpoint").
+  I did **not** edit the API Reference nav and did **not** fix this, since it is out of scope for a docs
+  repositioning and touches the OpenAPI contract. Flagging so it isn't mistaken for regression from my
+  edits.
+
+---
+
+## C. Edits applied directly (low/medium-risk prose)
+
+- `docs/introduction.mdx`
+  - Frontmatter `description` → "open agent infrastructure — durable agents and persistent sandboxes
+    that run any harness, powered by Firecracker MicroVMs."
+  - Added an opening umbrella paragraph (open agent infra + body/brain) and a sandbox = "a computer
+    that remembers" paragraph above the existing template line. Kept all existing sandbox capability
+    bullets verbatim.
+  - Added a "Run any harness" section (body/brain, pause/resume by id, link to integration guides).
+    Only claims shipped features (pause/resume, templates, exec, files).
+- `docs/integrations/agent-harnesses/claude-agent-sdk.mdx` — intro reworded to body/brain ("the brain"
+  / "the durable body it runs on"; "isolated, resumable VM"). No code/API changes.
+- `docs/integrations/agent-harnesses/openai-agents-sdk.mdx` — same body/brain alignment in the intro.
+
+Other integration pages (coding-agents/_, personal-agents/_, managed-agents/_, virtual-filesystems/_)
+were left as-is: their intros are task-specific ("Run X in a Superserve sandbox") and already read
+cleanly; forcing body/brain language into each would be heavier-handed than the "lightly align where
+low-risk" instruction warrants. The two "Agent Harnesses" pages were the natural fit because they
+already framed the sandbox as the runtime for a harness.

--- a/apps/console/README.md
+++ b/apps/console/README.md
@@ -1,6 +1,6 @@
 # @superserve/console
 
-Next.js 16 App Router console for managing Superserve sandboxes.
+Next.js 16 App Router console for Superserve's open agent infrastructure — manage persistent sandboxes, templates, secrets, and API keys.
 
 ## Development
 

--- a/apps/console/REPOSITIONING-REVIEW.md
+++ b/apps/console/REPOSITIONING-REVIEW.md
@@ -1,0 +1,125 @@
+# Console — Repositioning Review (HIGH-risk, needs human approval)
+
+Repositioning thesis: Superserve → **open agent infrastructure**. Two composable
+primitives on one substrate:
+
+- **Sandbox** = "a computer that remembers" — compute + persistent versioned
+  filesystem; exec/fs/ports; hibernate + resume by id. (Ships today; already
+  well-articulated — keep + sharpen.)
+- **Actor** = "a process that survives" — a named, durable, single-writer entity
+  that wakes on events, serializes input through an inbox, checkpoints, hibernates,
+  addressable anywhere. (Platform direction — exists today only as a hand-built
+  pattern, NOT a shipped Console feature or API.)
+
+Body vs brain: the platform is the durable BODY; any harness (Claude Code, Codex,
+Claude Agent SDK, AI SDK, your own loop, …) is the interchangeable BRAIN.
+
+This file lists Console changes that are **HIGH-risk** (product naming, primary nav
+labels, top-level IA, dashboard hero) and were therefore **NOT applied live**. The
+LOW/MED-risk copy edits that ship alongside this are listed at the bottom for context.
+
+---
+
+## 1. Meta title / product surface name — `src/app/layout.tsx`
+
+The browser tab title and OpenGraph/Twitter titles are the product's name in
+search results and link unfurls. Naming is high-risk; proposing for review only.
+
+**Current**
+
+```ts
+title: {
+  default: "Superserve Console",
+  template: "%s | Superserve",
+},
+// openGraph.title / twitter.title: "Superserve Console"
+```
+
+**Proposed (Option A — minimal, recommended)** — keep the name, no change. The
+positioning shift is carried entirely by the meta `description` (already updated
+live, see bottom). Lowest risk; "Console" stays the surface name.
+
+**Proposed (Option B — positioning in the unfurl title only)**
+
+```ts
+default: "Superserve Console — Open agent infrastructure",
+// openGraph.title / twitter.title: "Superserve Console — Open agent infrastructure"
+```
+
+Rationale: surfaces the new tagline where it has the most reach (social/search)
+without renaming the in-app product. Tab title gets longer; verify truncation.
+
+Recommendation: ship Option A now; revisit Option B when the public website hero
+locks the exact tagline so wording stays consistent across surfaces.
+
+---
+
+## 2. Sidebar primary nav — introduce "Actors" (IA change) — `src/components/sidebar/nav-config.ts`
+
+Current main nav:
+`Sandboxes · Templates · Secrets · Audit Logs · API Keys · Plan & Usage · Settings`
+(`Snapshots` is present but commented out: "re-enable when Snapshots ships".)
+
+The repositioning makes **Actor** a first-class primitive alongside **Sandbox**.
+The natural IA expression is a top-level **Actors** nav entry. However:
+
+- There is **no Actors backend, page, or API in the Console today** — Actor is
+  currently a hand-built pattern, not a shipped surface.
+- Adding a nav item that routes nowhere (or to a stub) is a broken-IA / build risk
+  and would over-claim a feature that does not exist.
+
+**Proposal: do NOT add an Actors nav item yet.** Instead:
+
+1. **Group the existing items under a "Sandboxes" / "Compute" heading** so the IA is
+   ready to gain an "Actors" sibling later. (Requires a grouped-nav variant in
+   `SidebarNav`; not currently supported — see note below.)
+2. When the Actors surface ships, add:
+   ```ts
+   { label: "Actors", href: "/actors", icon: LightningIcon },
+   ```
+   positioned directly under `Sandboxes` (the two primitives sit together).
+
+Decision needed from human: do we want a placeholder/"coming soon" Actors nav entry
+now (forward-looking, but routes nowhere), or hold until the surface is real?
+Default recommendation: **hold** — keep nav honest to what ships.
+
+Note: `SidebarNav` currently renders a flat `NavItem[]` with no section headers.
+Introducing primitive groupings ("Compute / Sandboxes", "Durable / Actors") is a
+component change, not just copy — out of scope for a copy pass; flagged here.
+
+---
+
+## 3. Dashboard landing redirect — `src/app/(dashboard)/page.tsx`
+
+**Current:** `/` redirects to `/sandboxes`.
+
+No change proposed. Once an Actors or unified overview surface exists, reconsider the
+default landing route. Listed only so the IA decision is captured in one place.
+
+---
+
+## 4. Sandboxes empty-state TITLE — `src/app/(dashboard)/sandboxes/page.tsx`
+
+The empty-state **title** ("No Sandboxes") is the closest thing the Console has to a
+hero for the core primitive. Title left unchanged (it is accurate and neutral). The
+**secondary description** beneath it WAS updated live (LOW/MED-risk) to carry the
+"a computer that remembers" framing — see bottom. Flagging the title here only so a
+reviewer can decide whether a more evocative title (e.g. "No sandboxes yet") is
+wanted; not changed to avoid touching hero-adjacent copy unilaterally.
+
+---
+
+## LOW/MED-risk edits already applied live (for reviewer context)
+
+| File                                       | Before → After (summary)                                                                                                                                                                                                                |
+| ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/app/layout.tsx`                       | Meta + OG + Twitter `description`: "Deploy and manage cloud sandboxes…" → "Open agent infrastructure from Superserve. Run any harness on persistent, versioned sandboxes — a computer that remembers, with hibernate and resume by id." |
+| `src/app/(dashboard)/sandboxes/page.tsx`   | Empty-state description → "A sandbox is a computer that remembers: compute plus a persistent, versioned filesystem you can hibernate and resume by id. Create one to run any harness or your own code."                                 |
+| `src/app/(dashboard)/templates/page.tsx`   | Empty-state description → "…start from a curated base or bring your own OCI image. Create one to reuse the same environment across sandboxes."                                                                                          |
+| `src/app/(dashboard)/get-started/page.tsx` | Intro subtitle → "Install the SDK and spin up your first persistent sandbox"                                                                                                                                                            |
+| `README.md`                                | Lead sentence → "…console for Superserve's open agent infrastructure — manage persistent sandboxes, templates, secrets, and API keys."                                                                                                  |
+
+All applied edits keep concrete API claims accurate to what ships today
+(pause/resume = hibernate/resume, templates, custom OCI base images, exec). No Actor
+API surface or unbuilt feature is implied in shipped copy. "Run any harness" is used
+as positioning, not as a named API.

--- a/apps/console/src/app/(dashboard)/get-started/page.tsx
+++ b/apps/console/src/app/(dashboard)/get-started/page.tsx
@@ -167,7 +167,7 @@ export default function GetStartedPage() {
         <div className="mx-auto max-w-2xl">
           <div className="flex items-center justify-between">
             <p className="text-sm leading-none tracking-tight text-muted">
-              Install the SDK and create your first sandbox
+              Install the SDK and spin up your first persistent sandbox
             </p>
 
             {/* Language Toggle */}

--- a/apps/console/src/app/(dashboard)/sandboxes/page.tsx
+++ b/apps/console/src/app/(dashboard)/sandboxes/page.tsx
@@ -151,7 +151,7 @@ function SandboxesPageContent() {
         <EmptyState
           icon={CubeIcon}
           title="No Sandboxes"
-          description="Create a sandbox to run code in an isolated cloud environment."
+          description="A sandbox is a computer that remembers: compute plus a persistent, versioned filesystem you can hibernate and resume by id. Create one to run any harness or your own code."
           actionLabel="Create Sandbox"
           onAction={() => setCreateOpen(true)}
         />

--- a/apps/console/src/app/(dashboard)/templates/page.tsx
+++ b/apps/console/src/app/(dashboard)/templates/page.tsx
@@ -93,7 +93,7 @@ function TemplatesPageContent() {
         <EmptyState
           icon={StackIcon}
           title="No templates yet"
-          description="Templates are pre-baked VM images your sandboxes boot from. Create one to reuse the same environment across sandboxes."
+          description="Templates are pre-baked images your sandboxes boot from — start from a curated base or bring your own OCI image. Create one to reuse the same environment across sandboxes."
           actionLabel="Create template"
           onAction={() => setCreateOpen(true)}
         />

--- a/apps/console/src/app/layout.tsx
+++ b/apps/console/src/app/layout.tsx
@@ -26,7 +26,7 @@ export const metadata: Metadata = {
     template: "%s | Superserve",
   },
   description:
-    "Deploy and manage cloud sandboxes with Superserve. Run code in isolated, secure environments.",
+    "Open agent infrastructure from Superserve. Run any harness on persistent, versioned sandboxes — a computer that remembers, with hibernate and resume by id.",
   icons: {
     icon: { url: "/favicon.svg", type: "image/svg+xml" },
   },
@@ -35,7 +35,7 @@ export const metadata: Metadata = {
     type: "website",
     title: "Superserve Console",
     description:
-      "Deploy and manage cloud sandboxes with Superserve. Run code in isolated, secure environments.",
+      "Open agent infrastructure from Superserve. Run any harness on persistent, versioned sandboxes — a computer that remembers, with hibernate and resume by id.",
     siteName: "Superserve",
     images: [{ url: "/og-image.png", width: 1200, height: 630 }],
   },
@@ -43,7 +43,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "Superserve Console",
     description:
-      "Deploy and manage cloud sandboxes with Superserve. Run code in isolated, secure environments.",
+      "Open agent infrastructure from Superserve. Run any harness on persistent, versioned sandboxes — a computer that remembers, with hibernate and resume by id.",
     images: ["/og-image.png"],
   },
   other: {

--- a/docs/integrations/agent-harnesses/claude-agent-sdk.mdx
+++ b/docs/integrations/agent-harnesses/claude-agent-sdk.mdx
@@ -5,7 +5,7 @@ description: Use Superserve sandboxes as the execution runtime for agents built 
 icon: "/logos/integrations/claude-agent-sdk.svg"
 ---
 
-The Claude Agent SDK is Anthropic's framework for building agents with tool-use loops. Expose `sandbox.commands.run` as an in-process MCP tool so every command the agent generates runs in an isolated VM instead of on your machine.
+The Claude Agent SDK is Anthropic's framework for building agents with tool-use loops — the brain. A Superserve sandbox is the durable body it runs on: expose `sandbox.commands.run` as an in-process MCP tool so every command the agent generates runs in an isolated, resumable VM instead of on your machine.
 
 ## Setup
 

--- a/docs/integrations/agent-harnesses/openai-agents-sdk.mdx
+++ b/docs/integrations/agent-harnesses/openai-agents-sdk.mdx
@@ -5,7 +5,7 @@ description: Use Superserve sandboxes as the execution runtime for agents built 
 icon: "/logos/integrations/openai-agents-sdk.svg"
 ---
 
-The OpenAI Agents SDK is OpenAI's framework for building agents with tool-use loops. Expose `sandbox.commands.run` as a function tool so every command the agent generates runs in an isolated VM instead of on your machine.
+The OpenAI Agents SDK is OpenAI's framework for building agents with tool-use loops — the brain. A Superserve sandbox is the durable body it runs on: expose `sandbox.commands.run` as a function tool so every command the agent generates runs in an isolated, resumable VM instead of on your machine.
 
 ## Setup
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,10 +1,12 @@
 ---
 title: "Introduction"
 sidebarTitle: Introduction
-description: Superserve provides sandbox infrastructure to run code in isolated cloud environments powered by Firecracker MicroVMs.
+description: Superserve is open agent infrastructure — durable agents and persistent sandboxes that run any harness, powered by Firecracker MicroVMs.
 ---
 
-Each sandbox starts from a [template](/templates/overview) — a reusable base image with your dependencies baked in.
+Superserve is open agent infrastructure: a durable substrate for the long-running, stateful workloads that agents need. The platform is the durable **body** — compute, a persistent filesystem, networking, lifecycle — and any harness is the interchangeable **brain**. Bring Claude Code, Codex, the Claude Agent SDK, OpenClaw, Hermes, or your own loop; the substrate stays the same.
+
+Today that substrate is exposed as the **sandbox**: a computer that remembers. Each sandbox is an isolated MicroVM with a persistent, versioned filesystem — run commands, move files, open ports, then hibernate it and resume by id exactly where you left off. Each sandbox starts from a [template](/templates/overview) — a reusable base image with your dependencies baked in.
 
 <Tip>
   Use the menu at the top right of any page to add our docs as an MCP server
@@ -21,6 +23,12 @@ Each sandbox starts from a [template](/templates/overview) — a reusable base i
 - **Custom templates** - pre-bake team dependencies into base images and launch from them
 - **Secrets** - give a sandbox an API key without the real value ever entering it
 - **Network controls** - per-sandbox egress allow/deny rules, plus a log of every connection a sandbox made
+
+## Run any harness
+
+A sandbox is the durable body; the harness is the brain. The same persistent VM runs a terminal coding agent, an SDK-driven tool loop, or your own custom loop — whatever you point at it. Because the body outlives any single run, you can pause between turns and resume by id without losing the agent's filesystem or in-flight state.
+
+See the [integration guides](/integrations/coding-agents/claude) for drop-in setups across Claude Code, Codex, the Claude Agent SDK, the OpenAI Agents SDK, OpenClaw, Hermes, and more.
 
 ## Next steps
 

--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -1,6 +1,10 @@
 # superserve
 
-Python SDK for the Superserve sandbox API — run code in isolated Firecracker MicroVMs.
+Python SDK for Superserve — open agent infrastructure: persistent sandboxes that run any harness.
+
+A **Sandbox** is a computer that remembers: compute plus a persistent filesystem, with exec, file, and port access. Run a command, write a file, hibernate the sandbox, then resume it later by ID with its state intact — so any agent harness (Claude Code, Codex, the Claude Agent SDK, or your own loop) gets a durable place to run. Sandboxes are isolated Firecracker MicroVMs.
+
+> Superserve is heading toward two composable primitives on one substrate: the **Sandbox** documented here, and a durable **Actor** — a named, single-writer process that wakes on events and survives restarts. Actors are the platform direction; this SDK ships the Sandbox surface today.
 
 ## Installation
 

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -5,11 +5,11 @@ build-backend = "hatchling.build"
 [project]
 name = "superserve"
 version = "0.7.6"
-description = "Python SDK for the Superserve sandbox API"
+description = "Python SDK for Superserve — open agent infrastructure: persistent sandboxes that run any harness"
 license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.9"
-keywords = ["superserve", "sandbox", "firecracker", "microvm", "sdk"]
+keywords = ["superserve", "sandbox", "agent", "agent-infrastructure", "firecracker", "microvm", "sdk"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",

--- a/packages/python-sdk/src/superserve/__init__.py
+++ b/packages/python-sdk/src/superserve/__init__.py
@@ -1,4 +1,13 @@
-"""Superserve SDK — sandbox infrastructure for running code in isolated cloud environments."""
+"""Superserve SDK — open agent infrastructure for running any harness.
+
+A Sandbox is a computer that remembers: compute plus a persistent filesystem,
+with exec, file, and port access, that you can hibernate and resume by ID. It
+gives any agent harness a durable, isolated place to run. Sandboxes are backed
+by Firecracker MicroVMs.
+
+This SDK ships the Sandbox surface today; durable Actors (named, single-writer
+processes that wake on events and survive restarts) are the platform direction.
+"""
 
 from .async_sandbox import AsyncSandbox
 from .async_secrets import AsyncSecret

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,6 +1,8 @@
 # @superserve/sdk
 
-TypeScript SDK for the Superserve sandbox API — run code in isolated Firecracker MicroVMs.
+TypeScript SDK for Superserve — **open agent infrastructure**. Run code in isolated Firecracker MicroVMs that behave like a computer that remembers: compute plus a persistent, versioned filesystem you can pause and resume by id.
+
+A Superserve sandbox is durable. Call `pause()` and every running process and the full filesystem are preserved; call `resume()` and it picks up where it left off, addressed by the same id. That makes it an ideal **body** for any agent — bring your own **brain** (Claude Code, the Claude Agent SDK, Codex, or your own loop) and let the platform handle the durable compute and state underneath.
 
 ## Installation
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,10 +1,13 @@
 {
   "name": "@superserve/sdk",
   "version": "0.7.6",
-  "description": "TypeScript SDK for the Superserve sandbox API",
+  "description": "TypeScript SDK for Superserve — open agent infrastructure with durable, persistent sandboxes that run any harness",
   "keywords": [
+    "agent-infrastructure",
+    "durable",
     "firecracker",
     "microvm",
+    "pause-resume",
     "sandbox",
     "sdk",
     "superserve"

--- a/packages/sdk/src/Sandbox.ts
+++ b/packages/sdk/src/Sandbox.ts
@@ -1,6 +1,10 @@
 /**
  * Main Sandbox class — the primary entry point for the Superserve SDK.
  *
+ * A Sandbox is a durable computer that remembers: compute plus a persistent
+ * filesystem. `pause()` preserves running processes and file state; `resume()`
+ * brings it back under the same id, so long-lived work survives across restarts.
+ *
  * Static factory methods (create/connect) return a `sandbox`. Call methods on
  * it directly (`sandbox.commands.run(...)`, `sandbox.files.write(...)`, etc.).
  *

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,5 +1,10 @@
 /**
- * Superserve SDK — sandbox infrastructure for running code in isolated cloud environments.
+ * Superserve SDK — open agent infrastructure.
+ *
+ * Durable, persistent sandboxes for running code in isolated cloud
+ * environments: compute plus a versioned filesystem that you can pause and
+ * resume by id. A sandbox is a computer that remembers — the durable body for
+ * any harness you bring as the brain.
  */
 
 export {


### PR DESCRIPTION
**Intention:** Align the SDK package metadata + docstrings, the console UI copy, and the docs introduction with the platform thesis — durable agents + persistent sandboxes that run any harness ("the platform is the durable body; any harness is the interchangeable brain"). Sandbox reframed as "a computer that remembers."

### What's here
- **TS SDK:** `index.ts`/`Sandbox.ts` header docs, `package.json` description + keywords.
- **Python SDK:** `__init__.py` module docstring (honest — ships Sandbox today; Actors named as the platform direction, not a shipped API).
- **Console:** layout metadata (title/OG/Twitter), README, and the sandboxes/templates/get-started empty-state + headline copy.
- **Docs:** `introduction.mdx` umbrella + "Run any harness" section; body/brain alignment in the two agent-harness integration intros.

### Technical decisions
- **Copy/metadata only** — only shipped features are claimed (pause/resume by id, templates, bring-your-OCI, exec, files). Higher-risk new pages (Actors concept, Harness Contract ladder) are written up in `REPOSITIONING-REVIEW.md` for product sign-off rather than asserted as shipped.

### Testing
TS SDK + console typechecks pass (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)