### PR TITLE
docs: group secret attach/detach under Secrets

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -175,9 +175,7 @@
               "POST /sandboxes/{sandbox_id}/pause",
               "POST /sandboxes/{sandbox_id}/resume",
               "POST /sandboxes/{sandbox_id}/activate",
-              "GET /sandboxes/{sandbox_id}/network",
-              "POST /sandboxes/{sandbox_id}/secrets",
-              "DELETE /sandboxes/{sandbox_id}/secrets/{env_key}"
+              "GET /sandboxes/{sandbox_id}/network"
             ]
           },
           {
@@ -214,6 +212,8 @@
               "GET /secrets/{name}",
               "PATCH /secrets/{name}",
               "DELETE /secrets/{name}",
+              "POST /sandboxes/{sandbox_id}/secrets",
+              "DELETE /sandboxes/{sandbox_id}/secrets/{env_key}",
               "GET /secrets/{name}/audit",
               "GET /secrets/{name}/sandboxes",
               "GET /providers"


### PR DESCRIPTION
Moves the secret-binding endpoints into the **Secrets** API-reference group, where they belong with the rest of the secret operations:

- `POST /sandboxes/{sandbox_id}/secrets` (attach)
- `DELETE /sandboxes/{sandbox_id}/secrets/{env_key}` (detach)

They were under **Sandboxes** (grouped by URL path), but the reference groups by resource topic — e.g. `GET /sandboxes/{sandbox_id}/files` already lives under **Files**, not Sandboxes. This applies the same convention to secret binding, so a developer finds all secret operations (lifecycle + attach/detach + audit) in one place. No spec change; `check-nav` stays green (37 operations).