### PR TITLE
fix: console OG image was referencing a missing file

### DIFF
--- a/apps/console/src/app/layout.tsx
+++ b/apps/console/src/app/layout.tsx
@@ -37,14 +37,16 @@ export const metadata: Metadata = {
     description:
       "Deploy and manage cloud sandboxes with Superserve. Run code in isolated, secure environments.",
     siteName: "Superserve",
-    images: [{ url: "/og-image.png", width: 1200, height: 630 }],
+    images: [
+      { url: "https://www.superserve.ai/cover.png", width: 1200, height: 630 },
+    ],
   },
   twitter: {
     card: "summary_large_image",
     title: "Superserve Console",
     description:
       "Deploy and manage cloud sandboxes with Superserve. Run code in isolated, secure environments.",
-    images: ["/og-image.png"],
+    images: ["https://www.superserve.ai/cover.png"],
   },
   other: {
     "theme-color": "#0a0a0a",


### PR DESCRIPTION
## Summary

- `apps/console/src/app/layout.tsx`: OG image was set to `/og-image.png` which doesn't exist in `public/` — would return 404 for any social share preview
- Changed to `https://www.superserve.ai/cover.png` (the main site's OG image) which is a valid, publicly accessible URL

## Test plan

- [ ] Verify `og:image` in console HTML source resolves to a 200 image