### PR TITLE
fix: noindex auth routes + PostHog proxy on docs

### DIFF
--- a/apps/console/src/app/(auth)/layout.tsx
+++ b/apps/console/src/app/(auth)/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+}
+
+export default function AuthLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -236,8 +236,8 @@
   },
   "integrations": {
     "posthog": {
-      "apiKey": "phc_gjpDKKQJAnkxkqLrPGrAhoariKsaHNuTpI5rVhkYre",
-      "apiHost": "https://us.i.posthog.com"
+      "apiKey": "phc_gjpDKKKQJAnkxkqLrPGrAhoariKsaHNuTpI5rVhkYre",
+      "apiHost": "https://p.superserve.ai"
     }
   }
 }


### PR DESCRIPTION
## Summary
- **Auth routes noindex**: Added `(auth)` group layout setting `robots: noindex, nofollow` — covers all auth pages and their query-string variants (`?next=`, `?utm_source=`) in one place, fixing the "Duplicate pages without canonical" Ahrefs audit issue
- **Docs PostHog proxy**: Updated `docs/docs.json` to route PostHog through the managed reverse proxy at `p.superserve.ai` and corrected the API key — fixes the "JavaScript broken" (1 page) and "Page has broken JavaScript" (74 docs pages) Ahrefs audit issues

## Test plan
- [ ] Console auth pages (`/auth/signin/`, `/auth/signup/`) render `noindex` in `<head>`
- [ ] PostHog events from docs route through `p.superserve.ai`