### PR TITLE
console: warn in-product when a team nears its sandbox limit

### DIFF
--- a/apps/console/src/components/layout/dashboard-shell.tsx
+++ b/apps/console/src/components/layout/dashboard-shell.tsx
@@ -7,6 +7,7 @@ import {
   ImpersonationStateProvider,
 } from "@/components/admin/impersonation-context"
 import { CommandPalette } from "@/components/command-palette"
+import { QuotaWarningBanner } from "@/components/quota/quota-warning-banner"
 import { Sidebar } from "@/components/sidebar/sidebar"
 import {
   SidebarProvider,
@@ -42,7 +43,10 @@ function DashboardContent({
             isCollapsed ? "ml-16" : "ml-64",
           )}
         >
-          {children}
+          <QuotaWarningBanner />
+          {/* Owns the height left after the banner so full-height (h-full) pages
+              measure the remaining space instead of overflowing the clipped main. */}
+          <div className="flex min-h-0 flex-1 flex-col">{children}</div>
         </main>
       </div>
     </div>

--- a/apps/console/src/components/quota/quota-warning-banner.tsx
+++ b/apps/console/src/components/quota/quota-warning-banner.tsx
@@ -28,11 +28,15 @@ export function QuotaWarningBanner() {
 
   return (
     <div className="px-4 pt-4">
-      <Alert variant="warning" title="You're approaching your sandbox limit">
+      <Alert
+        variant="warning"
+        title="You're approaching your sandbox limit"
+        className="max-w-3xl"
+      >
         <div className="flex items-start justify-between gap-3">
           <p>
             You're using {data.activeSandboxes} of {data.maxSandboxes} sandboxes
-            ({data.pct}%). Contact the team at{" "}
+            ({data.pct}%). Free up room by pausing or deleting some, or contact{" "}
             <a
               href={CONTACT_HREF}
               className="text-foreground underline underline-offset-4 hover:text-primary"

--- a/apps/console/src/components/quota/quota-warning-banner.tsx
+++ b/apps/console/src/components/quota/quota-warning-banner.tsx
@@ -6,8 +6,8 @@ import { useState } from "react"
 
 import { QUOTA_WARNING_PCT, useQuotaUsage } from "@/hooks/use-quota-usage"
 
-const MEETING_HREF =
-  "https://www.superserve.ai/meet/?utm_source=console&utm_medium=quota_banner"
+const CONTACT_HREF =
+  "mailto:support@superserve.ai?subject=Increase%20sandbox%20limit"
 
 // Warns once a team reaches QUOTA_WARNING_PCT of its sandbox limit. Reads live
 // usage (self-clears on delete); dismiss is per-session so it returns next visit.
@@ -36,16 +36,14 @@ export function QuotaWarningBanner() {
         <div className="flex items-start justify-between gap-3">
           <p>
             You're using {data.activeSandboxes} of {data.maxSandboxes}{" "}
-            sandboxes.{" "}
+            sandboxes. Contact us at{" "}
             <a
-              href={MEETING_HREF}
-              target="_blank"
-              rel="noreferrer"
+              href={CONTACT_HREF}
               className="text-foreground underline underline-offset-4 hover:text-primary"
             >
-              Reach out
+              support@superserve.ai
             </a>{" "}
-            to raise your limit.
+            to increase your limit.
           </p>
           <Button
             variant="ghost"

--- a/apps/console/src/components/quota/quota-warning-banner.tsx
+++ b/apps/console/src/components/quota/quota-warning-banner.tsx
@@ -6,8 +6,8 @@ import { useState } from "react"
 
 import { QUOTA_WARNING_PCT, useQuotaUsage } from "@/hooks/use-quota-usage"
 
-const CONTACT_HREF =
-  "mailto:support@superserve.ai?subject=Raise%20sandbox%20limit"
+const MEETING_HREF =
+  "https://www.superserve.ai/meet/?utm_source=console&utm_medium=quota_banner"
 
 // Warns once a team reaches QUOTA_WARNING_PCT of its sandbox limit. Reads live
 // usage (self-clears on delete); dismiss is per-session so it returns next visit.
@@ -35,13 +35,15 @@ export function QuotaWarningBanner() {
       >
         <div className="flex items-start justify-between gap-3">
           <p>
-            You're using {data.activeSandboxes} of {data.maxSandboxes} sandboxes
-            ({data.pct}%). Free up room by pausing or deleting some, or contact{" "}
+            You're using {data.activeSandboxes} of {data.maxSandboxes}{" "}
+            sandboxes.{" "}
             <a
-              href={CONTACT_HREF}
+              href={MEETING_HREF}
+              target="_blank"
+              rel="noreferrer"
               className="text-foreground underline underline-offset-4 hover:text-primary"
             >
-              support@superserve.ai
+              Reach out
             </a>{" "}
             to raise your limit.
           </p>

--- a/apps/console/src/components/quota/quota-warning-banner.tsx
+++ b/apps/console/src/components/quota/quota-warning-banner.tsx
@@ -31,7 +31,7 @@ export function QuotaWarningBanner() {
       <Alert
         variant="warning"
         title="You're approaching your sandbox limit"
-        className="max-w-3xl"
+        className="ml-auto max-w-3xl"
       >
         <div className="flex items-start justify-between gap-3">
           <p>

--- a/apps/console/src/components/quota/quota-warning-banner.tsx
+++ b/apps/console/src/components/quota/quota-warning-banner.tsx
@@ -1,0 +1,56 @@
+"use client"
+
+import { XIcon } from "@phosphor-icons/react"
+import { Alert, Button } from "@superserve/ui"
+import { useState } from "react"
+
+import { QUOTA_WARNING_PCT, useQuotaUsage } from "@/hooks/use-quota-usage"
+
+const CONTACT_HREF =
+  "mailto:support@superserve.ai?subject=Raise%20sandbox%20limit"
+
+// Warns once a team reaches QUOTA_WARNING_PCT of its sandbox limit. Reads live
+// usage (self-clears on delete); dismiss is per-session so it returns next visit.
+export function QuotaWarningBanner() {
+  const [dismissed, setDismissed] = useState(false)
+  const { data } = useQuotaUsage()
+
+  // Integer compare (not data.pct) to match the watcher exactly, so banner and
+  // email never disagree at the boundary.
+  const atWarning =
+    !!data &&
+    data.maxSandboxes > 0 &&
+    data.activeSandboxes * 100 >= data.maxSandboxes * QUOTA_WARNING_PCT
+
+  if (dismissed || !atWarning) {
+    return null
+  }
+
+  return (
+    <div className="px-4 pt-4">
+      <Alert variant="warning" title="You're approaching your sandbox limit">
+        <div className="flex items-start justify-between gap-3">
+          <p>
+            You're using {data.activeSandboxes} of {data.maxSandboxes} sandboxes
+            ({data.pct}%). Contact the team at{" "}
+            <a
+              href={CONTACT_HREF}
+              className="text-foreground underline underline-offset-4 hover:text-primary"
+            >
+              support@superserve.ai
+            </a>{" "}
+            to raise your limit.
+          </p>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Dismiss"
+            onClick={() => setDismissed(true)}
+          >
+            <XIcon className="size-3.5" weight="light" />
+          </Button>
+        </div>
+      </Alert>
+    </div>
+  )
+}

--- a/apps/console/src/hooks/use-quota-usage.ts
+++ b/apps/console/src/hooks/use-quota-usage.ts
@@ -1,0 +1,19 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+
+import { quotaKeys } from "@/lib/api/query-keys"
+import { getQuotaUsageAction } from "@/lib/api/quota-actions"
+
+/** Usage at or above this percent of the sandbox limit surfaces the banner. */
+export const QUOTA_WARNING_PCT = 80
+
+export function useQuotaUsage() {
+  return useQuery({
+    queryKey: quotaKeys.usage(),
+    queryFn: getQuotaUsageAction,
+    staleTime: 60_000,
+    refetchInterval: 5 * 60_000,
+    refetchIntervalInBackground: false,
+  })
+}

--- a/apps/console/src/lib/api/query-keys.ts
+++ b/apps/console/src/lib/api/query-keys.ts
@@ -83,3 +83,8 @@ export const templateKeys = {
   build: (templateId: string, buildId: string) =>
     [...templateKeys.builds(templateId), buildId] as const,
 }
+
+export const quotaKeys = {
+  all: ["quota"] as const,
+  usage: () => [...quotaKeys.all, "usage"] as const,
+}

--- a/apps/console/src/lib/api/quota-actions.ts
+++ b/apps/console/src/lib/api/quota-actions.ts
@@ -40,7 +40,9 @@ export async function getQuotaUsageAction(): Promise<QuotaUsageResponse | null> 
   const supabase = await createServerClient()
   const {
     data: { user },
+    error: authError,
   } = await supabase.auth.getUser()
+  if (authError) throw authError
   if (!user) throw new Error("Not authenticated")
 
   const teamId = await getTeamId(user.id)

--- a/apps/console/src/lib/api/quota-actions.ts
+++ b/apps/console/src/lib/api/quota-actions.ts
@@ -1,0 +1,65 @@
+"use server"
+
+import { createAdminClient } from "@/lib/supabase/admin"
+import { createServerClient } from "@/lib/supabase/server"
+
+export interface QuotaUsageResponse {
+  activeSandboxes: number
+  maxSandboxes: number
+  pct: number
+}
+
+async function getTeamId(userId: string): Promise<string | null> {
+  const admin = createAdminClient()
+  const { data, error } = await admin
+    .from("team_member")
+    .select("team_id")
+    .eq("profile_id", userId)
+
+  if (error) throw new Error(error.message)
+  if (!data?.length) return null
+
+  const teamIds = [
+    ...new Set(
+      data
+        .map((row) => row.team_id)
+        .filter((teamId): teamId is string => typeof teamId === "string"),
+    ),
+  ]
+  // Ambient poller with no team-selector: an ambiguous (multi-team) membership
+  // renders nothing rather than throwing on every poll (which would spam logs).
+  if (teamIds.length !== 1) {
+    return null
+  }
+  return teamIds[0]
+}
+
+// Current team's sandbox usage for the in-product quota banner; null when the
+// user has no team yet.
+export async function getQuotaUsageAction(): Promise<QuotaUsageResponse | null> {
+  const supabase = await createServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) throw new Error("Not authenticated")
+
+  const teamId = await getTeamId(user.id)
+  if (!teamId) return null
+
+  const admin = createAdminClient()
+  const { data, error } = await admin
+    .from("team")
+    .select("active_sandbox_count, max_sandboxes")
+    .eq("id", teamId)
+    .single()
+  if (error) throw new Error(error.message)
+
+  const activeSandboxes = data.active_sandbox_count ?? 0
+  const maxSandboxes = data.max_sandboxes ?? 0
+  // Floor via integer division, matching the watcher's `used*100 >= limit*pct`,
+  // so the banner never shows "80%" or fires below the email threshold.
+  const pct =
+    maxSandboxes > 0 ? Math.floor((activeSandboxes * 100) / maxSandboxes) : 0
+
+  return { activeSandboxes, maxSandboxes, pct }
+}


### PR DESCRIPTION
Shows a warning banner once a team reaches 80% of its sandbox limit, complementing the email/Slack alerts from the control plane.

- Live read of the team's sandbox usage (self-clears when sandboxes are deleted).
- Threshold check mirrors the control-plane integer math so banner and email never disagree.
- Per-session dismiss; renders nothing for multi-team users (no error spam).
- Mounted in the dashboard shell above page content.