### PR TITLE
sdk: auto-resume a paused sandbox on data-plane 503 (TS + Python)

### DIFF
--- a/packages/python-sdk/src/superserve/_token_retry.py
+++ b/packages/python-sdk/src/superserve/_token_retry.py
@@ -1,0 +1,66 @@
+"""Shared self-healing retry for data-plane operations.
+
+A paused sandbox answers the data plane two ways: ``401`` (the per-sandbox
+access token is no longer valid) or ``503`` (the VM isn't running). Both clear
+by ``POST /activate``, which resumes the sandbox and rotates the access token.
+So on either signal we activate once and retry the operation with the fresh
+token — this is what makes "a command/file op auto-resumes a paused sandbox"
+true. Any other failure (404, 409, a genuine 500, ...) propagates untouched.
+
+``commands`` and ``files`` (sync and async) all run through this single
+predicate so the resume policy can't drift between them.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+from .errors import AuthenticationError, SandboxError, ServerError
+
+T = TypeVar("T")
+
+
+def is_resumable(err: SandboxError) -> bool:
+    """Does this error mean the sandbox is paused/unreachable and a
+    ``POST /activate`` would fix it? 401/403 (stale token) or 503 (VM not
+    running). A genuine 500 is NOT resumable — only 503 signals a paused
+    sandbox.
+    """
+    if isinstance(err, AuthenticationError):
+        return True
+    if isinstance(err, ServerError):
+        return err.status_code == 503
+    return False
+
+
+def with_token_retry(
+    get_access_token: Callable[[], str],
+    refresh_activate: Callable[[], str],
+    send: Callable[[str], T],
+) -> T:
+    """Run ``send`` with the current token; on a resumable failure, activate
+    (resume + rotate token) and retry exactly once with the fresh token.
+    """
+    try:
+        return send(get_access_token())
+    except SandboxError as err:
+        if not is_resumable(err):
+            raise
+        fresh = refresh_activate()
+        return send(fresh)
+
+
+async def async_with_token_retry(
+    get_access_token: Callable[[], str],
+    refresh_activate: Callable[[], Awaitable[str]],
+    send: Callable[[str], Awaitable[T]],
+) -> T:
+    """Async variant of :func:`with_token_retry`."""
+    try:
+        return await send(get_access_token())
+    except SandboxError as err:
+        if not is_resumable(err):
+            raise
+        fresh = await refresh_activate()
+        return await send(fresh)

--- a/packages/python-sdk/src/superserve/async_sandbox.py
+++ b/packages/python-sdk/src/superserve/async_sandbox.py
@@ -13,7 +13,7 @@ from ._config import ResolvedConfig, preview_url, resolve_config
 from ._http import async_api_request
 from .commands import AsyncCommands, AsyncCommandsDeps
 from .errors import NotFoundError, SandboxError
-from .files import AsyncFiles
+from .files import AsyncFiles, AsyncFilesDeps
 from .types import (
     NetworkConfig,
     NetworkLogPage,
@@ -61,7 +61,13 @@ class AsyncSandbox:
             client=self._http_client,
         )
         self.files = AsyncFiles(
-            self.id, config.sandbox_host, self._access_token, client=self._http_client
+            AsyncFilesDeps(
+                sandbox_id=self.id,
+                sandbox_host=config.sandbox_host,
+                get_access_token=lambda: self._access_token,
+                refresh_activate=self._refresh_activate,
+            ),
+            client=self._http_client,
         )
 
     async def _post_and_rotate_token(self, endpoint: str) -> str:
@@ -79,12 +85,6 @@ class AsyncSandbox:
                 "missing access_token"
             )
         self._access_token = token
-        self.files = AsyncFiles(
-            self.id,
-            self._config.sandbox_host,
-            self._access_token,
-            client=self._http_client,
-        )
         return token
 
     async def _refresh_activate(self) -> str:
@@ -274,8 +274,8 @@ class AsyncSandbox:
     async def resume(self) -> None:
         """Resume a paused sandbox.
 
-        The access token is rotated; the SDK rebuilds ``sandbox.files`` with
-        the fresh token transparently.
+        The access token is rotated; ``sandbox.commands`` and ``sandbox.files``
+        pick up the fresh token transparently.
         """
         self._require_live()
         await self._post_and_rotate_token("resume")

--- a/packages/python-sdk/src/superserve/commands.py
+++ b/packages/python-sdk/src/superserve/commands.py
@@ -1,24 +1,24 @@
 """``sandbox.commands`` - run shell commands inside a sandbox.
 
-Hits the per-sandbox data plane with the access token. On 401 the SDK
-auto-refreshes via ``POST /activate`` and retries once.
+Hits the per-sandbox data plane with the access token. A paused sandbox (401
+stale token, or 503 because the VM isn't running) is transparently resumed via
+``POST /activate`` and the call is retried once — see ``_token_retry``.
 """
 
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any, NoReturn, TypeVar
+from typing import Any, NoReturn
 
 import httpx
 
 from ._config import data_plane_target
 from ._http import api_request, async_api_request, async_stream_sse, stream_sse
+from ._token_retry import async_with_token_retry, with_token_retry
 from .command_session import AsyncCommandSession, AsyncSpawnDeps, spawn_command
-from .errors import AuthenticationError, SandboxError
+from .errors import SandboxError
 from .types import CommandResult
-
-T = TypeVar("T")
 
 
 @dataclass(frozen=True)
@@ -111,7 +111,9 @@ class Commands:
                 client=self._client,
             )
 
-        raw: dict[str, Any] = self._with_token_retry(send)
+        raw: dict[str, Any] = with_token_retry(
+            self._deps.get_access_token, self._deps.refresh_activate, send
+        )
         return CommandResult(
             stdout=raw.get("stdout", ""),
             stderr=raw.get("stderr", ""),
@@ -135,18 +137,11 @@ class Commands:
                 timeout_seconds,
             )
 
-        return self._with_token_retry(send)
-
-    # Safe for streaming: 401 is returned in the HTTP status code before
-    # any SSE data is written, so the retry can't double-emit callbacks.
-    # The try/except wraps `send` only — if `refresh_activate` itself 401s
-    # (bad API key), it propagates uncaught, so no recursion is possible.
-    def _with_token_retry(self, send: Callable[[str], T]) -> T:
-        try:
-            return send(self._deps.get_access_token())
-        except AuthenticationError:
-            fresh = self._deps.refresh_activate()
-            return send(fresh)
+        # Safe for streaming: the resumable status (401/503) arrives before any
+        # SSE data is written, so a retry can't double-emit callbacks.
+        return with_token_retry(
+            self._deps.get_access_token, self._deps.refresh_activate, send
+        )
 
     def _consume_stream(
         self,
@@ -304,7 +299,9 @@ class AsyncCommands:
                 client=self._client,
             )
 
-        raw: dict[str, Any] = await self._with_token_retry(send)
+        raw: dict[str, Any] = await async_with_token_retry(
+            self._deps.get_access_token, self._deps.refresh_activate, send
+        )
         return CommandResult(
             stdout=raw.get("stdout", ""),
             stderr=raw.get("stderr", ""),
@@ -328,14 +325,9 @@ class AsyncCommands:
                 timeout_seconds,
             )
 
-        return await self._with_token_retry(send)
-
-    async def _with_token_retry(self, send: Callable[[str], Awaitable[T]]) -> T:
-        try:
-            return await send(self._deps.get_access_token())
-        except AuthenticationError:
-            fresh = await self._deps.refresh_activate()
-            return await send(fresh)
+        return await async_with_token_retry(
+            self._deps.get_access_token, self._deps.refresh_activate, send
+        )
 
     async def _consume_stream(
         self,

--- a/packages/python-sdk/src/superserve/errors.py
+++ b/packages/python-sdk/src/superserve/errors.py
@@ -64,8 +64,9 @@ class ServerError(SandboxError):
         self,
         message: str = "Internal server error",
         code: str | None = None,
+        status_code: int = 500,
     ) -> None:
-        super().__init__(message, status_code=500, code=code)
+        super().__init__(message, status_code=status_code, code=code)
 
 
 class RateLimitError(SandboxError):
@@ -133,5 +134,5 @@ def map_api_error(status_code: int, body: dict[str, Any]) -> SandboxError:
     elif status_code == 429:
         return RateLimitError(message, code=code)
     elif status_code >= 500:
-        return ServerError(message, code=code)
+        return ServerError(message, code=code, status_code=status_code)
     return SandboxError(message, status_code=status_code, code=code)

--- a/packages/python-sdk/src/superserve/files.py
+++ b/packages/python-sdk/src/superserve/files.py
@@ -1,7 +1,14 @@
-"""`sandbox.files` - read and write files inside a sandbox."""
+"""``sandbox.files`` - read and write files inside a sandbox.
+
+Hits the data plane with the per-sandbox access token. A paused sandbox (401
+stale token, or 503 because the VM isn't running) is transparently resumed via
+``POST /activate`` and the op is retried once — see ``_token_retry``.
+"""
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from typing import Any
 from urllib.parse import quote
 
@@ -14,6 +21,7 @@ from ._http import (
     download_bytes,
     upload_bytes,
 )
+from ._token_retry import async_with_token_retry, with_token_retry
 from .errors import ValidationError
 
 
@@ -24,20 +32,38 @@ def _validate_path(path: str) -> None:
         raise ValidationError(f'Path must not contain ".." segments: {path}')
 
 
+@dataclass(frozen=True)
+class FilesDeps:
+    """Internal deps from Sandbox. ``refresh_activate`` resumes + rotates."""
+
+    sandbox_id: str
+    sandbox_host: str
+    get_access_token: Callable[[], str]
+    refresh_activate: Callable[[], str]
+
+
+@dataclass(frozen=True)
+class AsyncFilesDeps:
+    """Async variant of FilesDeps."""
+
+    sandbox_id: str
+    sandbox_host: str
+    get_access_token: Callable[[], str]
+    refresh_activate: Callable[[], Awaitable[str]]
+
+
 class Files:
     """Sync file operations. Access as ``sandbox.files``."""
 
     def __init__(
         self,
-        sandbox_id: str,
-        sandbox_host: str,
-        access_token: str,
+        deps: FilesDeps,
         client: httpx.Client | None = None,
     ) -> None:
-        target = data_plane_target(sandbox_id, sandbox_host)
+        self._deps = deps
+        target = data_plane_target(deps.sandbox_id, deps.sandbox_host)
         self._base_url = target.url
         self._routing_headers = target.headers
-        self._access_token = access_token
         self._client = client
 
     def write(
@@ -48,15 +74,19 @@ class Files:
         if isinstance(content, str):
             content = content.encode("utf-8")
         url = f"{self._base_url}/files?path={quote(path, safe='')}"
-        kwargs: dict[str, Any] = {
-            "url": url,
-            "headers": {**self._routing_headers, "X-Access-Token": self._access_token},
-            "content": content,
-            "client": self._client,
-        }
-        if timeout is not None:
-            kwargs["timeout"] = timeout
-        upload_bytes(**kwargs)
+
+        def send(token: str) -> None:
+            kwargs: dict[str, Any] = {
+                "url": url,
+                "headers": {**self._routing_headers, "X-Access-Token": token},
+                "content": content,
+                "client": self._client,
+            }
+            if timeout is not None:
+                kwargs["timeout"] = timeout
+            upload_bytes(**kwargs)
+
+        with_token_retry(self._deps.get_access_token, self._deps.refresh_activate, send)
 
     def read(
         self,
@@ -71,20 +101,25 @@ class Files:
         """
         _validate_path(path)
         url = f"{self._base_url}/files?path={quote(path, safe='')}"
-        kwargs: dict[str, Any] = {
-            "url": url,
-            "headers": {**self._routing_headers, "X-Access-Token": self._access_token},
-            "client": self._client,
-        }
-        if timeout is not None:
-            kwargs["timeout"] = timeout
-        if max_bytes is not None:
-            kwargs["max_bytes"] = max_bytes
-        return download_bytes(**kwargs)
+
+        def send(token: str) -> bytes:
+            kwargs: dict[str, Any] = {
+                "url": url,
+                "headers": {**self._routing_headers, "X-Access-Token": token},
+                "client": self._client,
+            }
+            if timeout is not None:
+                kwargs["timeout"] = timeout
+            if max_bytes is not None:
+                kwargs["max_bytes"] = max_bytes
+            return download_bytes(**kwargs)
+
+        return with_token_retry(
+            self._deps.get_access_token, self._deps.refresh_activate, send
+        )
 
     def read_text(self, path: str, *, timeout: float | None = None) -> str:
         """Read a file from the sandbox as a UTF-8 string."""
-        _validate_path(path)
         return self.read(path, timeout=timeout).decode("utf-8")
 
     def download_dir(
@@ -108,16 +143,22 @@ class Files:
         """
         _validate_path(path)
         url = f"{self._base_url}/files?path={quote(path, safe='')}&format=zip"
-        kwargs: dict[str, Any] = {
-            "url": url,
-            "headers": {**self._routing_headers, "X-Access-Token": self._access_token},
-            "client": self._client,
-        }
-        if timeout is not None:
-            kwargs["timeout"] = timeout
-        if max_bytes is not None:
-            kwargs["max_bytes"] = max_bytes
-        return download_bytes(**kwargs)
+
+        def send(token: str) -> bytes:
+            kwargs: dict[str, Any] = {
+                "url": url,
+                "headers": {**self._routing_headers, "X-Access-Token": token},
+                "client": self._client,
+            }
+            if timeout is not None:
+                kwargs["timeout"] = timeout
+            if max_bytes is not None:
+                kwargs["max_bytes"] = max_bytes
+            return download_bytes(**kwargs)
+
+        return with_token_retry(
+            self._deps.get_access_token, self._deps.refresh_activate, send
+        )
 
 
 class AsyncFiles:
@@ -125,15 +166,13 @@ class AsyncFiles:
 
     def __init__(
         self,
-        sandbox_id: str,
-        sandbox_host: str,
-        access_token: str,
+        deps: AsyncFilesDeps,
         client: httpx.AsyncClient | None = None,
     ) -> None:
-        target = data_plane_target(sandbox_id, sandbox_host)
+        self._deps = deps
+        target = data_plane_target(deps.sandbox_id, deps.sandbox_host)
         self._base_url = target.url
         self._routing_headers = target.headers
-        self._access_token = access_token
         self._client = client
 
     async def write(
@@ -144,15 +183,21 @@ class AsyncFiles:
         if isinstance(content, str):
             content = content.encode("utf-8")
         url = f"{self._base_url}/files?path={quote(path, safe='')}"
-        kwargs: dict[str, Any] = {
-            "url": url,
-            "headers": {**self._routing_headers, "X-Access-Token": self._access_token},
-            "content": content,
-            "client": self._client,
-        }
-        if timeout is not None:
-            kwargs["timeout"] = timeout
-        await async_upload_bytes(**kwargs)
+
+        async def send(token: str) -> None:
+            kwargs: dict[str, Any] = {
+                "url": url,
+                "headers": {**self._routing_headers, "X-Access-Token": token},
+                "content": content,
+                "client": self._client,
+            }
+            if timeout is not None:
+                kwargs["timeout"] = timeout
+            await async_upload_bytes(**kwargs)
+
+        await async_with_token_retry(
+            self._deps.get_access_token, self._deps.refresh_activate, send
+        )
 
     async def read(
         self,
@@ -167,20 +212,25 @@ class AsyncFiles:
         """
         _validate_path(path)
         url = f"{self._base_url}/files?path={quote(path, safe='')}"
-        kwargs: dict[str, Any] = {
-            "url": url,
-            "headers": {**self._routing_headers, "X-Access-Token": self._access_token},
-            "client": self._client,
-        }
-        if timeout is not None:
-            kwargs["timeout"] = timeout
-        if max_bytes is not None:
-            kwargs["max_bytes"] = max_bytes
-        return await async_download_bytes(**kwargs)
+
+        async def send(token: str) -> bytes:
+            kwargs: dict[str, Any] = {
+                "url": url,
+                "headers": {**self._routing_headers, "X-Access-Token": token},
+                "client": self._client,
+            }
+            if timeout is not None:
+                kwargs["timeout"] = timeout
+            if max_bytes is not None:
+                kwargs["max_bytes"] = max_bytes
+            return await async_download_bytes(**kwargs)
+
+        return await async_with_token_retry(
+            self._deps.get_access_token, self._deps.refresh_activate, send
+        )
 
     async def read_text(self, path: str, *, timeout: float | None = None) -> str:
         """Read a file from the sandbox as a UTF-8 string."""
-        _validate_path(path)
         raw = await self.read(path, timeout=timeout)
         return raw.decode("utf-8")
 
@@ -205,13 +255,19 @@ class AsyncFiles:
         """
         _validate_path(path)
         url = f"{self._base_url}/files?path={quote(path, safe='')}&format=zip"
-        kwargs: dict[str, Any] = {
-            "url": url,
-            "headers": {**self._routing_headers, "X-Access-Token": self._access_token},
-            "client": self._client,
-        }
-        if timeout is not None:
-            kwargs["timeout"] = timeout
-        if max_bytes is not None:
-            kwargs["max_bytes"] = max_bytes
-        return await async_download_bytes(**kwargs)
+
+        async def send(token: str) -> bytes:
+            kwargs: dict[str, Any] = {
+                "url": url,
+                "headers": {**self._routing_headers, "X-Access-Token": token},
+                "client": self._client,
+            }
+            if timeout is not None:
+                kwargs["timeout"] = timeout
+            if max_bytes is not None:
+                kwargs["max_bytes"] = max_bytes
+            return await async_download_bytes(**kwargs)
+
+        return await async_with_token_retry(
+            self._deps.get_access_token, self._deps.refresh_activate, send
+        )

--- a/packages/python-sdk/src/superserve/sandbox.py
+++ b/packages/python-sdk/src/superserve/sandbox.py
@@ -13,7 +13,7 @@ from ._config import ResolvedConfig, preview_url, resolve_config
 from ._http import api_request
 from .commands import Commands, CommandsDeps
 from .errors import NotFoundError, SandboxError
-from .files import Files
+from .files import Files, FilesDeps
 from .types import (
     NetworkConfig,
     NetworkLogPage,
@@ -61,13 +61,19 @@ class Sandbox:
             client=self._http_client,
         )
         self.files = Files(
-            self.id, config.sandbox_host, self._access_token, client=self._http_client
+            FilesDeps(
+                sandbox_id=self.id,
+                sandbox_host=config.sandbox_host,
+                get_access_token=lambda: self._access_token,
+                refresh_activate=self._refresh_activate,
+            ),
+            client=self._http_client,
         )
 
     def _post_and_rotate_token(self, endpoint: str) -> str:
-        """POST a token-rotating endpoint (``resume`` or ``activate``), update
-        the cached token, rebuild ``self.files`` with the fresh token.
-        Returns the new token.
+        """POST a token-rotating endpoint (``resume`` or ``activate``) and
+        update the cached token. ``commands`` and ``files`` read the token
+        live, so they pick up the rotation. Returns the new token.
         """
         raw = api_request(
             "POST",
@@ -82,12 +88,6 @@ class Sandbox:
                 "missing access_token"
             )
         self._access_token = token
-        self.files = Files(
-            self.id,
-            self._config.sandbox_host,
-            self._access_token,
-            client=self._http_client,
-        )
         return token
 
     def _refresh_activate(self) -> str:
@@ -280,8 +280,8 @@ class Sandbox:
     def resume(self) -> None:
         """Resume a paused sandbox.
 
-        The access token is rotated; the SDK rebuilds ``sandbox.files`` with
-        the fresh token transparently.
+        The access token is rotated; ``sandbox.commands`` and ``sandbox.files``
+        pick up the fresh token transparently.
         """
         self._require_live()
         self._post_and_rotate_token("resume")

--- a/packages/python-sdk/tests/test_async.py
+++ b/packages/python-sdk/tests/test_async.py
@@ -149,7 +149,7 @@ class TestAsyncSandboxSmoke:
             finally:
                 await sbx._close_http_client()
 
-    async def test_resume_rotates_token_and_rebuilds_files(self) -> None:
+    async def test_resume_rotates_token_files_reads_it_live(self) -> None:
         with respx.mock() as router:
             router.post(f"{API}/sandboxes/sbx-1/activate").mock(
                 return_value=httpx.Response(200, json=_raw())
@@ -170,7 +170,8 @@ class TestAsyncSandboxSmoke:
                 result = await sbx.resume()
                 assert result is None
                 assert sbx._access_token == "rotated-tok"
-                assert sbx.files is not old_files
+                # files reads the token live — same instance, picks up rotation
+                assert sbx.files is old_files
             finally:
                 await sbx._close_http_client()
 
@@ -271,9 +272,7 @@ class TestAsyncConcurrentRefresh:
             nonlocal exec_call_count
             exec_call_count += 1
             if exec_call_count <= 2:
-                return httpx.Response(
-                    401, json={"error": {"code": "auth_failed"}}
-                )
+                return httpx.Response(401, json={"error": {"code": "auth_failed"}})
             return httpx.Response(
                 200, json={"stdout": "ok", "stderr": "", "exit_code": 0}
             )
@@ -301,9 +300,7 @@ class TestAsyncConcurrentRefresh:
             )
             router.post(f"{data_plane}/exec").mock(side_effect=exec_response)
 
-            sbx = await AsyncSandbox.connect(
-                sbx_id, api_key="ss_live_x", base_url=API
-            )
+            sbx = await AsyncSandbox.connect(sbx_id, api_key="ss_live_x", base_url=API)
             try:
                 sbx._config = sbx._config.__class__(
                     api_key=sbx._config.api_key,
@@ -323,3 +320,71 @@ class TestAsyncConcurrentRefresh:
                 assert exec_call_count == 4
             finally:
                 await sbx._close_http_client()
+
+
+class TestAsyncAutoResumeOn503:
+    """A paused sandbox answers the data plane with 503; async ops resume."""
+
+    async def test_commands_resumes_and_retries_on_503(self) -> None:
+        from superserve.commands import AsyncCommands, AsyncCommandsDeps
+
+        host = "sandbox.example.com"
+        data_plane = f"https://boxd-sbx-1.{host}"
+        state = {"token": "tok-stale", "refreshes": 0}
+
+        async def refresh() -> str:
+            state["refreshes"] += 1
+            state["token"] = "tok-fresh"
+            return state["token"]
+
+        deps = AsyncCommandsDeps(
+            sandbox_id="sbx-1",
+            sandbox_host=host,
+            get_access_token=lambda: state["token"],
+            refresh_activate=refresh,
+        )
+        with respx.mock() as router:
+            router.post(f"{data_plane}/exec").mock(
+                side_effect=[
+                    httpx.Response(
+                        503, json={"error": {"message": "sandbox is paused"}}
+                    ),
+                    httpx.Response(
+                        200, json={"stdout": "ok\n", "stderr": "", "exit_code": 0}
+                    ),
+                ]
+            )
+            result = await AsyncCommands(deps).run("echo")
+            assert result.stdout == "ok\n"
+            assert state["refreshes"] == 1
+
+    async def test_files_write_resumes_and_retries_on_503(self) -> None:
+        from superserve.files import AsyncFiles, AsyncFilesDeps
+
+        host = "sandbox.example.com"
+        data_plane = f"https://boxd-sbx-1.{host}"
+        state = {"token": "tok-stale", "refreshes": 0}
+
+        async def refresh() -> str:
+            state["refreshes"] += 1
+            state["token"] = "tok-fresh"
+            return state["token"]
+
+        deps = AsyncFilesDeps(
+            sandbox_id="sbx-1",
+            sandbox_host=host,
+            get_access_token=lambda: state["token"],
+            refresh_activate=refresh,
+        )
+        with respx.mock() as router:
+            route = router.post(f"{data_plane}/files").mock(
+                side_effect=[
+                    httpx.Response(
+                        503, json={"error": {"message": "sandbox is paused"}}
+                    ),
+                    httpx.Response(200),
+                ]
+            )
+            await AsyncFiles(deps).write("/app/f.txt", "hello")
+            assert state["refreshes"] == 1
+            assert route.calls.last.request.headers["x-access-token"] == "tok-fresh"

--- a/packages/python-sdk/tests/test_commands.py
+++ b/packages/python-sdk/tests/test_commands.py
@@ -109,6 +109,30 @@ class TestCommandsRun:
                 Commands(deps).run("echo")
         assert state["refreshes"] == 0
 
+    def test_resumes_and_retries_on_503(self) -> None:
+        deps, state = _make_deps()
+        with respx.mock() as router:
+            router.post(f"{DATA_PLANE}/exec").mock(
+                side_effect=[
+                    httpx.Response(
+                        503,
+                        json={
+                            "error": {
+                                "code": "sandbox_paused",
+                                "message": "sandbox is paused",
+                            }
+                        },
+                    ),
+                    httpx.Response(
+                        200,
+                        json={"stdout": "ok\n", "stderr": "", "exit_code": 0},
+                    ),
+                ]
+            )
+            result = Commands(deps).run("echo")
+            assert result.stdout == "ok\n"
+            assert state["refreshes"] == 1
+
     def test_propagates_auth_error_when_refresh_also_fails(self) -> None:
         deps, _ = _make_deps()
         with respx.mock() as router:
@@ -164,9 +188,7 @@ class TestCommandsStreaming:
                 )
             )
             with pytest.raises(SandboxError, match="finished"):
-                _make_commands().run(
-                    "echo partial", on_stdout=lambda _c: None
-                )
+                _make_commands().run("echo partial", on_stdout=lambda _c: None)
 
     def test_streaming_with_nonzero_exit_code(self) -> None:
         sse_body = (
@@ -192,8 +214,7 @@ class TestCommandsStreaming:
     ) -> None:
         deps, state = _make_deps()
         sse_body = (
-            'data: {"stdout": "one"}\n\n'
-            'data: {"finished": true, "exit_code": 0}\n\n'
+            'data: {"stdout": "one"}\n\ndata: {"finished": true, "exit_code": 0}\n\n'
         )
         with respx.mock() as router:
             router.post(f"{DATA_PLANE}/exec/stream").mock(
@@ -263,8 +284,7 @@ class TestCommandsSharedHostRouting:
             refresh_activate=lambda: "tok",
         )
         sse_body = (
-            'data: {"stdout": "x"}\n\n'
-            'data: {"finished": true, "exit_code": 0}\n\n'
+            'data: {"stdout": "x"}\n\ndata: {"finished": true, "exit_code": 0}\n\n'
         )
         with respx.mock() as router:
             route = router.post("https://sandbox.superserve.ai/exec/stream").mock(

--- a/packages/python-sdk/tests/test_errors.py
+++ b/packages/python-sdk/tests/test_errors.py
@@ -98,6 +98,14 @@ class TestMapApiError:
         err = map_api_error(502, {"error": {"message": "gateway"}})
         assert isinstance(err, ServerError)
 
+    def test_503_returns_server_error_preserving_status(self) -> None:
+        err = map_api_error(
+            503,
+            {"error": {"code": "sandbox_paused", "message": "sandbox is paused"}},
+        )
+        assert isinstance(err, ServerError)
+        assert err.status_code == 503
+
     def test_code_preserved_on_unknown(self) -> None:
         err = map_api_error(
             418, {"error": {"message": "teapot", "code": "teapot_error"}}

--- a/packages/python-sdk/tests/test_files.py
+++ b/packages/python-sdk/tests/test_files.py
@@ -2,27 +2,56 @@
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
+
 import httpx
 import pytest
 import respx
-from superserve.errors import ValidationError
-from superserve.files import AsyncFiles, Files
+from superserve.errors import SandboxError, ValidationError
+from superserve.files import AsyncFiles, AsyncFilesDeps, Files, FilesDeps
+
+HOST = "sandbox.example.com"
+SBX = "abc-123"
+DATA_PLANE = f"https://boxd-{SBX}.{HOST}"
+
+
+def _deps(
+    token: str = "tok-xyz",
+    *,
+    host: str = HOST,
+    refresh: Callable[[], str] | None = None,
+) -> FilesDeps:
+    return FilesDeps(
+        sandbox_id=SBX,
+        sandbox_host=host,
+        get_access_token=lambda: token,
+        refresh_activate=refresh if refresh is not None else (lambda: token),
+    )
+
+
+def _async_deps(
+    token: str = "tok-xyz",
+    *,
+    host: str = HOST,
+    refresh: Callable[[], Awaitable[str]] | None = None,
+) -> AsyncFilesDeps:
+    async def _noop() -> str:
+        return token
+
+    return AsyncFilesDeps(
+        sandbox_id=SBX,
+        sandbox_host=host,
+        get_access_token=lambda: token,
+        refresh_activate=refresh if refresh is not None else _noop,
+    )
 
 
 def _make_files() -> Files:
-    return Files(
-        sandbox_id="abc-123",
-        sandbox_host="sandbox.example.com",
-        access_token="tok-xyz",
-    )
+    return Files(_deps())
 
 
 def _make_async_files() -> AsyncFiles:
-    return AsyncFiles(
-        sandbox_id="abc-123",
-        sandbox_host="sandbox.example.com",
-        access_token="tok-xyz",
-    )
+    return AsyncFiles(_async_deps())
 
 
 class TestPathValidation:
@@ -62,7 +91,7 @@ class TestPathValidation:
 class TestFilesWrite:
     def test_sends_access_token_header(self) -> None:
         with respx.mock() as router:
-            route = router.post("https://boxd-abc-123.sandbox.example.com/files").mock(
+            route = router.post(f"{DATA_PLANE}/files").mock(
                 return_value=httpx.Response(200)
             )
             _make_files().write("/home/x.txt", "hello")
@@ -71,7 +100,7 @@ class TestFilesWrite:
 
     def test_accepts_bytes_content(self) -> None:
         with respx.mock() as router:
-            route = router.post("https://boxd-abc-123.sandbox.example.com/files").mock(
+            route = router.post(f"{DATA_PLANE}/files").mock(
                 return_value=httpx.Response(200)
             )
             _make_files().write("/home/x.bin", b"\x00\x01\x02")
@@ -79,7 +108,7 @@ class TestFilesWrite:
 
     def test_encodes_str_as_utf8(self) -> None:
         with respx.mock() as router:
-            route = router.post("https://boxd-abc-123.sandbox.example.com/files").mock(
+            route = router.post(f"{DATA_PLANE}/files").mock(
                 return_value=httpx.Response(200)
             )
             _make_files().write("/home/x.txt", "héllo")
@@ -89,7 +118,7 @@ class TestFilesWrite:
 class TestFilesRead:
     def test_returns_bytes(self) -> None:
         with respx.mock() as router:
-            router.get("https://boxd-abc-123.sandbox.example.com/files").mock(
+            router.get(f"{DATA_PLANE}/files").mock(
                 return_value=httpx.Response(200, content=b"\x00raw bytes\x00")
             )
             result = _make_files().read("/home/x.bin")
@@ -97,7 +126,7 @@ class TestFilesRead:
 
     def test_sends_access_token_header(self) -> None:
         with respx.mock() as router:
-            route = router.get("https://boxd-abc-123.sandbox.example.com/files").mock(
+            route = router.get(f"{DATA_PLANE}/files").mock(
                 return_value=httpx.Response(200, content=b"ok")
             )
             _make_files().read("/home/x.txt")
@@ -107,14 +136,14 @@ class TestFilesRead:
 class TestFilesReadText:
     def test_returns_string(self) -> None:
         with respx.mock() as router:
-            router.get("https://boxd-abc-123.sandbox.example.com/files").mock(
+            router.get(f"{DATA_PLANE}/files").mock(
                 return_value=httpx.Response(200, content=b"hello world")
             )
             assert _make_files().read_text("/home/x.txt") == "hello world"
 
     def test_handles_utf8(self) -> None:
         with respx.mock() as router:
-            router.get("https://boxd-abc-123.sandbox.example.com/files").mock(
+            router.get(f"{DATA_PLANE}/files").mock(
                 return_value=httpx.Response(200, content="héllo".encode())
             )
             assert _make_files().read_text("/home/x.txt") == "héllo"
@@ -123,7 +152,7 @@ class TestFilesReadText:
 class TestFilesDownloadDir:
     def test_returns_zip_bytes(self) -> None:
         with respx.mock() as router:
-            router.get("https://boxd-abc-123.sandbox.example.com/files").mock(
+            router.get(f"{DATA_PLANE}/files").mock(
                 return_value=httpx.Response(200, content=b"PK\x03\x04zip")
             )
             result = _make_files().download_dir("/home/project")
@@ -131,7 +160,7 @@ class TestFilesDownloadDir:
 
     def test_sends_format_zip_and_access_token(self) -> None:
         with respx.mock() as router:
-            route = router.get("https://boxd-abc-123.sandbox.example.com/files").mock(
+            route = router.get(f"{DATA_PLANE}/files").mock(
                 return_value=httpx.Response(200, content=b"PK")
             )
             _make_files().download_dir("/home/project")
@@ -144,7 +173,7 @@ class TestFilesDownloadDir:
 class TestFilesDownloadByteCap:
     def test_read_over_cap_raises(self) -> None:
         with respx.mock() as router:
-            router.get("https://boxd-abc-123.sandbox.example.com/files").mock(
+            router.get(f"{DATA_PLANE}/files").mock(
                 return_value=httpx.Response(200, content=b"x" * 100)
             )
             with pytest.raises(ValidationError, match="maximum size of 10 bytes"):
@@ -152,21 +181,21 @@ class TestFilesDownloadByteCap:
 
     def test_read_under_cap_returns_bytes(self) -> None:
         with respx.mock() as router:
-            router.get("https://boxd-abc-123.sandbox.example.com/files").mock(
+            router.get(f"{DATA_PLANE}/files").mock(
                 return_value=httpx.Response(200, content=b"small")
             )
             assert _make_files().read("/home/small.bin", max_bytes=1024) == b"small"
 
     def test_read_at_cap_returns_bytes(self) -> None:
         with respx.mock() as router:
-            router.get("https://boxd-abc-123.sandbox.example.com/files").mock(
+            router.get(f"{DATA_PLANE}/files").mock(
                 return_value=httpx.Response(200, content=b"abcde")
             )
             assert _make_files().read("/home/exact.bin", max_bytes=5) == b"abcde"
 
     def test_download_dir_over_cap_raises(self) -> None:
         with respx.mock() as router:
-            router.get("https://boxd-abc-123.sandbox.example.com/files").mock(
+            router.get(f"{DATA_PLANE}/files").mock(
                 return_value=httpx.Response(200, content=b"PK" + b"z" * 100)
             )
             with pytest.raises(ValidationError, match="maximum size"):
@@ -174,7 +203,7 @@ class TestFilesDownloadByteCap:
 
     async def test_async_read_over_cap_raises(self) -> None:
         with respx.mock() as router:
-            router.get("https://boxd-abc-123.sandbox.example.com/files").mock(
+            router.get(f"{DATA_PLANE}/files").mock(
                 return_value=httpx.Response(200, content=b"y" * 100)
             )
             with pytest.raises(ValidationError, match="maximum size of 10 bytes"):
@@ -182,7 +211,7 @@ class TestFilesDownloadByteCap:
 
     async def test_async_read_under_cap_returns_bytes(self) -> None:
         with respx.mock() as router:
-            router.get("https://boxd-abc-123.sandbox.example.com/files").mock(
+            router.get(f"{DATA_PLANE}/files").mock(
                 return_value=httpx.Response(200, content=b"tiny")
             )
             result = await _make_async_files().read("/home/tiny.bin", max_bytes=1024)
@@ -192,7 +221,7 @@ class TestFilesDownloadByteCap:
 class TestAsyncFilesDownloadDir:
     async def test_returns_zip_bytes(self) -> None:
         with respx.mock() as router:
-            router.get("https://boxd-abc-123.sandbox.example.com/files").mock(
+            router.get(f"{DATA_PLANE}/files").mock(
                 return_value=httpx.Response(200, content=b"PK\x03\x04zip")
             )
             result = await _make_async_files().download_dir("/home/project")
@@ -200,7 +229,7 @@ class TestAsyncFilesDownloadDir:
 
     async def test_sends_format_zip_and_access_token(self) -> None:
         with respx.mock() as router:
-            route = router.get("https://boxd-abc-123.sandbox.example.com/files").mock(
+            route = router.get(f"{DATA_PLANE}/files").mock(
                 return_value=httpx.Response(200, content=b"PK")
             )
             await _make_async_files().download_dir("/home/project")
@@ -209,13 +238,166 @@ class TestAsyncFilesDownloadDir:
             assert req.headers["X-Access-Token"] == "tok-xyz"
 
 
+class TestFilesAutoResume:
+    """A paused sandbox answers file ops with 503; the op should resume."""
+
+    def test_write_resumes_and_retries_on_503(self) -> None:
+        state = {"token": "tok-stale", "refreshes": 0}
+
+        def refresh() -> str:
+            state["refreshes"] += 1
+            state["token"] = "tok-fresh"
+            return state["token"]
+
+        deps = FilesDeps(
+            sandbox_id=SBX,
+            sandbox_host=HOST,
+            get_access_token=lambda: state["token"],
+            refresh_activate=refresh,
+        )
+        with respx.mock() as router:
+            route = router.post(f"{DATA_PLANE}/files").mock(
+                side_effect=[
+                    httpx.Response(
+                        503, json={"error": {"message": "sandbox is paused"}}
+                    ),
+                    httpx.Response(200),
+                ]
+            )
+            Files(deps).write("/app/f.txt", "hello")
+            assert state["refreshes"] == 1
+            assert route.call_count == 2
+            assert route.calls.last.request.headers["x-access-token"] == "tok-fresh"
+
+    def test_read_resumes_and_retries_on_503(self) -> None:
+        state = {"token": "tok-stale", "refreshes": 0}
+
+        def refresh() -> str:
+            state["refreshes"] += 1
+            state["token"] = "tok-fresh"
+            return state["token"]
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.headers.get("x-access-token") == "tok-fresh":
+                return httpx.Response(200, content=b"data")
+            return httpx.Response(503, json={"error": {"message": "sandbox is paused"}})
+
+        deps = FilesDeps(
+            sandbox_id=SBX,
+            sandbox_host=HOST,
+            get_access_token=lambda: state["token"],
+            refresh_activate=refresh,
+        )
+        with respx.mock() as router:
+            router.get(f"{DATA_PLANE}/files").mock(side_effect=handler)
+            result = Files(deps).read("/app/f.bin")
+            assert result == b"data"
+            assert state["refreshes"] == 1
+
+    def test_download_dir_resumes_and_retries_on_503(self) -> None:
+        state = {"token": "tok-stale", "refreshes": 0}
+
+        def refresh() -> str:
+            state["refreshes"] += 1
+            state["token"] = "tok-fresh"
+            return state["token"]
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.headers.get("x-access-token") == "tok-fresh":
+                return httpx.Response(200, content=b"PK")
+            return httpx.Response(503, json={"error": {"message": "sandbox is paused"}})
+
+        deps = FilesDeps(
+            sandbox_id=SBX,
+            sandbox_host=HOST,
+            get_access_token=lambda: state["token"],
+            refresh_activate=refresh,
+        )
+        with respx.mock() as router:
+            router.get(f"{DATA_PLANE}/files").mock(side_effect=handler)
+            result = Files(deps).download_dir("/app/output")
+            assert result == b"PK"
+            assert state["refreshes"] == 1
+
+    def test_does_not_resume_on_404(self) -> None:
+        state = {"refreshes": 0}
+
+        def refresh() -> str:
+            state["refreshes"] += 1
+            return "tok-fresh"
+
+        deps = FilesDeps(
+            sandbox_id=SBX,
+            sandbox_host=HOST,
+            get_access_token=lambda: "tok-stale",
+            refresh_activate=refresh,
+        )
+        with respx.mock() as router:
+            router.get(f"{DATA_PLANE}/files").mock(
+                return_value=httpx.Response(404, json={"error": {"code": "not_found"}})
+            )
+            with pytest.raises(SandboxError):
+                Files(deps).read("/missing")
+            assert state["refreshes"] == 0
+
+
+class TestAsyncFilesAutoResume:
+    async def test_write_resumes_and_retries_on_503(self) -> None:
+        state = {"token": "tok-stale", "refreshes": 0}
+
+        async def refresh() -> str:
+            state["refreshes"] += 1
+            state["token"] = "tok-fresh"
+            return state["token"]
+
+        deps = AsyncFilesDeps(
+            sandbox_id=SBX,
+            sandbox_host=HOST,
+            get_access_token=lambda: state["token"],
+            refresh_activate=refresh,
+        )
+        with respx.mock() as router:
+            route = router.post(f"{DATA_PLANE}/files").mock(
+                side_effect=[
+                    httpx.Response(
+                        503, json={"error": {"message": "sandbox is paused"}}
+                    ),
+                    httpx.Response(200),
+                ]
+            )
+            await AsyncFiles(deps).write("/app/f.txt", "hello")
+            assert state["refreshes"] == 1
+            assert route.calls.last.request.headers["x-access-token"] == "tok-fresh"
+
+    async def test_read_resumes_and_retries_on_503(self) -> None:
+        state = {"token": "tok-stale", "refreshes": 0}
+
+        async def refresh() -> str:
+            state["refreshes"] += 1
+            state["token"] = "tok-fresh"
+            return state["token"]
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.headers.get("x-access-token") == "tok-fresh":
+                return httpx.Response(200, content=b"data")
+            return httpx.Response(503, json={"error": {"message": "sandbox is paused"}})
+
+        deps = AsyncFilesDeps(
+            sandbox_id=SBX,
+            sandbox_host=HOST,
+            get_access_token=lambda: state["token"],
+            refresh_activate=refresh,
+        )
+        with respx.mock() as router:
+            router.get(f"{DATA_PLANE}/files").mock(side_effect=handler)
+            result = await AsyncFiles(deps).read("/app/f.bin")
+            assert result == b"data"
+            assert state["refreshes"] == 1
+
+
 class TestFilesSharedHostRouting:
     def test_uses_shared_host_when_supported(self) -> None:
-        files = Files(
-            sandbox_id="abc-123",
-            sandbox_host="sandbox.superserve.ai",
-            access_token="tok-xyz",
-        )
+        files = Files(_deps(host="sandbox.superserve.ai"))
         with respx.mock() as router:
             route = router.post("https://sandbox.superserve.ai/files").mock(
                 return_value=httpx.Response(200)
@@ -226,11 +408,7 @@ class TestFilesSharedHostRouting:
             assert req.headers.get("x-access-token") == "tok-xyz"
 
     def test_read_also_carries_sandbox_id_header_on_shared_host(self) -> None:
-        files = Files(
-            sandbox_id="abc-123",
-            sandbox_host="sandbox.superserve.ai",
-            access_token="tok-xyz",
-        )
+        files = Files(_deps(host="sandbox.superserve.ai"))
         with respx.mock() as router:
             route = router.get("https://sandbox.superserve.ai/files").mock(
                 return_value=httpx.Response(200, content=b"hello")

--- a/packages/python-sdk/tests/test_sandbox.py
+++ b/packages/python-sdk/tests/test_sandbox.py
@@ -230,7 +230,7 @@ class TestInstanceMethods:
             finally:
                 sbx._close_http_client()
 
-    def test_resume_rotates_token_and_rebuilds_files(self) -> None:
+    def test_resume_rotates_token_files_reads_it_live(self) -> None:
         with respx.mock() as router:
             router.post(f"{API}/sandboxes/sbx-1/activate").mock(
                 return_value=httpx.Response(200, json=_raw())
@@ -251,8 +251,8 @@ class TestInstanceMethods:
                 result = sbx.resume()
                 assert result is None
                 assert sbx._access_token == "rotated-tok"
-                # files sub-module rebuilt
-                assert sbx.files is not old_files
+                # files reads the token live — same instance, picks up rotation
+                assert sbx.files is old_files
             finally:
                 sbx._close_http_client()
 
@@ -415,9 +415,7 @@ class TestConcurrentRefresh:
                 this_call = exec_call_count
             # First two calls (one per thread) 401; subsequent succeed
             if this_call <= 2:
-                return httpx.Response(
-                    401, json={"error": {"code": "auth_failed"}}
-                )
+                return httpx.Response(401, json={"error": {"code": "auth_failed"}})
             return httpx.Response(
                 200, json={"stdout": "ok", "stderr": "", "exit_code": 0}
             )
@@ -441,17 +439,13 @@ class TestConcurrentRefresh:
                 },
             )
 
-        with respx.mock(
-            base_url=API, assert_all_called=False
-        ) as router:
+        with respx.mock(base_url=API, assert_all_called=False) as router:
             router.post(f"{API}/sandboxes/{sbx_id}/activate").mock(
                 side_effect=activate_response
             )
             router.post(f"{data_plane}/exec").mock(side_effect=exec_response)
 
-            sbx = Sandbox.connect(
-                sbx_id, api_key="ss_live_x", base_url=API
-            )
+            sbx = Sandbox.connect(sbx_id, api_key="ss_live_x", base_url=API)
             try:
                 # Override sandbox_host so the data-plane URL matches our mock
                 sbx._config = sbx._config.__class__(
@@ -479,9 +473,7 @@ class TestConcurrentRefresh:
 
                 # Both must succeed (no 409 from lost-race second refresh)
                 for r in results:
-                    assert not isinstance(
-                        r, Exception
-                    ), f"expected success, got {r!r}"
+                    assert not isinstance(r, Exception), f"expected success, got {r!r}"
                 assert results[0] == "ok"
                 assert results[1] == "ok"
 

--- a/packages/sdk/src/Sandbox.ts
+++ b/packages/sdk/src/Sandbox.ts
@@ -59,9 +59,10 @@ export class Sandbox {
   /**
    * Upload and download files to/from this sandbox.
    *
-   * Rebuilt transparently after `resume()` to pick up the rotated token.
+   * Reads the per-sandbox access token live, so a `resume()` or an auto-resume
+   * (rotating the token) is picked up transparently.
    */
-  files: Files
+  readonly files: Files
 
   private _accessToken: string
   private _refreshInFlight: Promise<string> | null = null
@@ -87,13 +88,18 @@ export class Sandbox {
       getAccessToken: () => this._accessToken,
       refreshActivate: () => this._refreshActivate(),
     })
-    this.files = new Files(this.id, config.sandboxHost, this._accessToken)
+    this.files = new Files({
+      sandboxId: this.id,
+      sandboxHost: config.sandboxHost,
+      getAccessToken: () => this._accessToken,
+      refreshActivate: () => this._refreshActivate(),
+    })
   }
 
   /**
-   * POST a token-rotating endpoint (`/resume` or `/activate`), update the
-   * cached token, and rebuild `this.files` with the fresh token. Returns
-   * the new token. @internal
+   * POST a token-rotating endpoint (`/resume` or `/activate`) and update the
+   * cached token. `commands` and `files` read the token live, so they pick up
+   * the rotation transparently. Returns the new token. @internal
    */
   private async _postAndRotateToken(
     endpoint: "resume" | "activate",
@@ -109,7 +115,6 @@ export class Sandbox {
       )
     }
     this._accessToken = raw.access_token
-    this.files = new Files(this.id, this._config.sandboxHost, this._accessToken)
     return this._accessToken
   }
 
@@ -304,8 +309,8 @@ export class Sandbox {
 
   /**
    * Resume a paused sandbox. Status transitions back to `active`.
-   * The access token is rotated; the SDK rebuilds `sandbox.files` with the
-   * fresh token transparently.
+   * The access token is rotated; `sandbox.commands` and `sandbox.files` pick
+   * up the fresh token transparently.
    */
   async resume(): Promise<void> {
     await this._postAndRotateToken("resume")

--- a/packages/sdk/src/commands.ts
+++ b/packages/sdk/src/commands.ts
@@ -1,16 +1,19 @@
 /**
  * `sandbox.commands` - run shell commands inside a sandbox.
  *
- * Hits the per-sandbox data plane with the access token. On 401 the
- * SDK auto-refreshes via `POST /activate` and retries once.
+ * Hits the per-sandbox data plane with the access token. A paused sandbox
+ * (401 stale token, or 503 because the VM isn't running) is transparently
+ * resumed via `POST /activate` and the call is retried once — see
+ * `tokenRetry.ts`.
  *
  * Accessed as `sandbox.commands.run(...)`.
  */
 
 import { spawnCommand } from "./commandSession.js"
 import { dataPlaneTarget } from "./config.js"
-import { AuthenticationError, SandboxError } from "./errors.js"
+import { SandboxError } from "./errors.js"
 import { request, streamSSE } from "./http.js"
+import { withTokenRetry } from "./tokenRetry.js"
 import type {
   ApiExecResult,
   ApiExecStreamEvent,
@@ -125,7 +128,7 @@ export class Commands {
         signal: options.signal,
       })
 
-    const raw = await this._withTokenRetry(send)
+    const raw = await withTokenRetry(this._deps, send)
     return {
       stdout: raw.stdout ?? "",
       stderr: raw.stderr ?? "",
@@ -144,23 +147,9 @@ export class Commands {
         body,
         options,
       )
-    return this._withTokenRetry(send)
-  }
-
-  // Safe for streaming: 401 is returned in the HTTP status code before
-  // any SSE data is written, so the retry can't double-emit callbacks.
-  // The try/catch wraps `send` only — if `refreshActivate` itself 401s
-  // (bad API key), it propagates uncaught, so no recursion is possible.
-  private async _withTokenRetry<T>(
-    send: (token: string) => Promise<T>,
-  ): Promise<T> {
-    try {
-      return await send(this._deps.getAccessToken())
-    } catch (err) {
-      if (!(err instanceof AuthenticationError)) throw err
-      const fresh = await this._deps.refreshActivate()
-      return send(fresh)
-    }
+    // Safe for streaming: the resumable status (401/503) is returned before any
+    // SSE data is written, so a retry can't double-emit callbacks.
+    return withTokenRetry(this._deps, send)
   }
 
   private async _consumeStream(

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -83,8 +83,12 @@ export class RateLimitError extends SandboxError {
 }
 
 export class ServerError extends SandboxError {
-  constructor(message = "Internal server error", code?: string) {
-    super(message, 500, code)
+  constructor(
+    message = "Internal server error",
+    code?: string,
+    statusCode = 500,
+  ) {
+    super(message, statusCode, code)
     this.name = "ServerError"
   }
 }
@@ -141,7 +145,7 @@ export function mapApiError(
     case 429:
       return new RateLimitError(message, code)
     default:
-      if (status >= 500) return new ServerError(message, code)
+      if (status >= 500) return new ServerError(message, code, status)
       return new SandboxError(message, status, code)
   }
 }

--- a/packages/sdk/src/files.ts
+++ b/packages/sdk/src/files.ts
@@ -1,8 +1,10 @@
 /**
  * `sandbox.files` - read and write files inside a sandbox.
  *
- * Hits the data plane with the per-sandbox access token. The
- * control-plane API key is not used for file operations.
+ * Hits the data plane with the per-sandbox access token. The control-plane API
+ * key is not used for file operations. A paused sandbox (401 stale token, or
+ * 503 because the VM isn't running) is transparently resumed via
+ * `POST /activate` and the op is retried once — see `tokenRetry.ts`.
  *
  * Accessed as `sandbox.files.write(...)` / `sandbox.files.read(...)`.
  */
@@ -10,6 +12,7 @@
 import { dataPlaneTarget } from "./config.js"
 import { ValidationError } from "./errors.js"
 import { downloadBytes, uploadBytes } from "./http.js"
+import { withTokenRetry } from "./tokenRetry.js"
 import type { FileInput } from "./types.js"
 
 function validatePath(path: string): void {
@@ -21,17 +24,21 @@ function validatePath(path: string): void {
   }
 }
 
+/** @internal Live token accessor + slow-path resume, supplied by Sandbox. */
+export interface FilesDeps {
+  sandboxId: string
+  sandboxHost: string
+  getAccessToken: () => string
+  refreshActivate: () => Promise<string>
+}
+
 export class Files {
   private readonly _dataPlaneBaseUrl: string
   private readonly _routingHeaders: Record<string, string>
 
   /** @internal */
-  constructor(
-    sandboxId: string,
-    sandboxHost: string,
-    private readonly _accessToken: string,
-  ) {
-    const target = dataPlaneTarget(sandboxId, sandboxHost)
+  constructor(private readonly _deps: FilesDeps) {
+    const target = dataPlaneTarget(_deps.sandboxId, _deps.sandboxHost)
     this._dataPlaneBaseUrl = target.url
     this._routingHeaders = target.headers
   }
@@ -56,13 +63,15 @@ export class Files {
     validatePath(path)
     const body = toBody(content)
     const url = `${this._dataPlaneBaseUrl}/files?path=${encodeURIComponent(path)}`
-    await uploadBytes({
-      url,
-      headers: { ...this._routingHeaders, "X-Access-Token": this._accessToken },
-      body,
-      timeoutMs: options.timeoutMs,
-      signal: options.signal,
-    })
+    await withTokenRetry(this._deps, (token) =>
+      uploadBytes({
+        url,
+        headers: { ...this._routingHeaders, "X-Access-Token": token },
+        body,
+        timeoutMs: options.timeoutMs,
+        signal: options.signal,
+      }),
+    )
   }
 
   /**
@@ -85,13 +94,15 @@ export class Files {
   ): Promise<Uint8Array> {
     validatePath(path)
     const url = `${this._dataPlaneBaseUrl}/files?path=${encodeURIComponent(path)}`
-    return downloadBytes({
-      url,
-      headers: { ...this._routingHeaders, "X-Access-Token": this._accessToken },
-      timeoutMs: options.timeoutMs,
-      signal: options.signal,
-      maxBytes: options.maxBytes,
-    })
+    return withTokenRetry(this._deps, (token) =>
+      downloadBytes({
+        url,
+        headers: { ...this._routingHeaders, "X-Access-Token": token },
+        timeoutMs: options.timeoutMs,
+        signal: options.signal,
+        maxBytes: options.maxBytes,
+      }),
+    )
   }
 
   /**
@@ -107,7 +118,6 @@ export class Files {
     path: string,
     options: { timeoutMs?: number; signal?: AbortSignal } = {},
   ): Promise<string> {
-    validatePath(path)
     const bytes = await this.read(path, options)
     return new TextDecoder().decode(bytes)
   }
@@ -146,13 +156,15 @@ export class Files {
     const url = `${this._dataPlaneBaseUrl}/files?path=${encodeURIComponent(
       path,
     )}&format=zip`
-    return downloadBytes({
-      url,
-      headers: { ...this._routingHeaders, "X-Access-Token": this._accessToken },
-      timeoutMs: options.timeoutMs,
-      signal: options.signal,
-      maxBytes: options.maxBytes,
-    })
+    return withTokenRetry(this._deps, (token) =>
+      downloadBytes({
+        url,
+        headers: { ...this._routingHeaders, "X-Access-Token": token },
+        timeoutMs: options.timeoutMs,
+        signal: options.signal,
+        maxBytes: options.maxBytes,
+      }),
+    )
   }
 }
 

--- a/packages/sdk/src/tokenRetry.ts
+++ b/packages/sdk/src/tokenRetry.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared self-healing retry for data-plane operations.
+ *
+ * A paused sandbox answers the data plane two ways: `401` (the per-sandbox
+ * access token is no longer valid) or `503` (the VM isn't running). Both clear
+ * by `POST /activate`, which resumes the sandbox and rotates the access token.
+ * So on either signal we activate once and retry the operation with the fresh
+ * token — this is what makes "a command/file op auto-resumes a paused sandbox"
+ * true. Any other failure (404, 409, a genuine 500, …) propagates untouched.
+ *
+ * `commands` and `files` both run through this single predicate so the resume
+ * policy can't drift between them.
+ */
+
+import { AuthenticationError, ServerError } from "./errors.js"
+
+/** @internal Live token accessor + the slow-path resume both share. */
+export interface TokenRetryDeps {
+  getAccessToken: () => string
+  refreshActivate: () => Promise<string>
+}
+
+/**
+ * Does this error mean the sandbox is paused/unreachable and a `POST /activate`
+ * would fix it? 401/403 (stale token) or 503 (VM not running). A genuine 500
+ * is NOT resumable — only 503 signals a paused sandbox.
+ * @internal
+ */
+export function isResumable(err: unknown): boolean {
+  if (err instanceof AuthenticationError) return true
+  if (err instanceof ServerError) return err.statusCode === 503
+  return false
+}
+
+/**
+ * Run `send` with the current access token. On a resumable failure, activate
+ * (resume + rotate token) and retry exactly once with the fresh token.
+ * @internal
+ */
+export async function withTokenRetry<T>(
+  deps: TokenRetryDeps,
+  send: (token: string) => Promise<T>,
+): Promise<T> {
+  try {
+    return await send(deps.getAccessToken())
+  } catch (err) {
+    if (!isResumable(err)) throw err
+    const fresh = await deps.refreshActivate()
+    return send(fresh)
+  }
+}

--- a/packages/sdk/tests/commands.test.ts
+++ b/packages/sdk/tests/commands.test.ts
@@ -130,6 +130,59 @@ describe("Commands.run (sync)", () => {
     await expect(commands.run("echo")).rejects.toBeInstanceOf(SandboxError)
   })
 
+  it("resumes + retries on 503 (paused sandbox), then succeeds", async () => {
+    let refreshCalled = 0
+    const deps = makeDeps({
+      refreshActivate: async () => {
+        refreshCalled += 1
+        return "tok-refreshed"
+      },
+    })
+
+    const mock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        jsonResponse(
+          { error: { code: "sandbox_paused", message: "sandbox is paused" } },
+          503,
+        ),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ stdout: "ok\n", stderr: "", exit_code: 0 }),
+      )
+    vi.stubGlobal("fetch", mock)
+
+    const result = await new Commands(deps).run("echo")
+
+    expect(result.stdout).toBe("ok\n")
+    expect(refreshCalled).toBe(1)
+    expect(mock).toHaveBeenCalledTimes(2)
+    const [, secondInit] = mock.mock.calls[1] as [string, RequestInit]
+    expect(
+      (secondInit.headers as Record<string, string>)["X-Access-Token"],
+    ).toBe("tok-refreshed")
+  })
+
+  it("does NOT resume on a genuine 500 (only 503 means paused)", async () => {
+    let refreshCalled = 0
+    const deps = makeDeps({
+      refreshActivate: async () => {
+        refreshCalled += 1
+        return "tok-refreshed"
+      },
+    })
+    const mock = vi.fn(async () =>
+      jsonResponse({ error: { code: "server_error" } }, 500),
+    )
+    vi.stubGlobal("fetch", mock)
+
+    await expect(new Commands(deps).run("echo")).rejects.toBeInstanceOf(
+      SandboxError,
+    )
+    expect(refreshCalled).toBe(0)
+    expect(mock).toHaveBeenCalledTimes(1)
+  })
+
   it("propagates AuthenticationError if refresh also fails", async () => {
     const deps = makeDeps({
       refreshActivate: async () => "tok-refreshed",

--- a/packages/sdk/tests/errors.test.ts
+++ b/packages/sdk/tests/errors.test.ts
@@ -127,6 +127,15 @@ describe("mapApiError", () => {
     expect(err).toBeInstanceOf(ServerError)
   })
 
+  it("maps 503 to ServerError preserving the 503 status", () => {
+    const err = mapApiError(
+      503,
+      withError("sandbox_paused", "sandbox is paused"),
+    )
+    expect(err).toBeInstanceOf(ServerError)
+    expect(err.statusCode).toBe(503)
+  })
+
   it("unknown 4xx status falls back to base SandboxError", () => {
     const err = mapApiError(418, withError("teapot", "short and stout"))
     expect(err).toBeInstanceOf(SandboxError)

--- a/packages/sdk/tests/files.test.ts
+++ b/packages/sdk/tests/files.test.ts
@@ -1,11 +1,32 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { ValidationError } from "../src/errors.js"
-import { Files } from "../src/files.js"
+import { Files, type FilesDeps } from "../src/files.js"
 
 const sandboxId = "sbx-1"
 const sandboxHost = "sandbox.example.com"
 const accessToken = "tok-abc"
+
+/** Build Files deps with a static token, overridable per test. */
+function deps(
+  token = accessToken,
+  overrides: Partial<FilesDeps> = {},
+): FilesDeps {
+  return {
+    sandboxId,
+    sandboxHost,
+    getAccessToken: () => token,
+    refreshActivate: async () => token,
+    ...overrides,
+  }
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+}
 
 async function readBodyAsBytes(
   body: BodyInit | null | undefined,
@@ -29,7 +50,7 @@ async function readBodyAsBytes(
 }
 
 describe("Files path validation", () => {
-  const files = new Files(sandboxId, sandboxHost, accessToken)
+  const files = new Files(deps())
 
   it("write rejects relative paths", async () => {
     await expect(files.write("relative/path", "x")).rejects.toBeInstanceOf(
@@ -91,7 +112,7 @@ describe("Files.downloadDir", () => {
     )
     vi.stubGlobal("fetch", mock)
 
-    const files = new Files(sandboxId, sandboxHost, accessToken)
+    const files = new Files(deps())
     await files.downloadDir("/app/output")
 
     const [url, init] = mock.mock.calls[0] as [string, RequestInit]
@@ -112,7 +133,7 @@ describe("Files.downloadDir", () => {
       vi.fn(async () => new Response(zip, { status: 200 })),
     )
 
-    const files = new Files(sandboxId, sandboxHost, accessToken)
+    const files = new Files(deps())
     const out = await files.downloadDir("/app/output")
     expect(out).toBeInstanceOf(Uint8Array)
     expect(Array.from(out)).toEqual([0x50, 0x4b, 0x03, 0x04])
@@ -132,7 +153,7 @@ describe("Files.downloadDir", () => {
       vi.fn(async () => new Response(stream, { status: 200 })),
     )
 
-    const files = new Files(sandboxId, sandboxHost, accessToken)
+    const files = new Files(deps())
     await expect(
       files.downloadDir("/app/output", { maxBytes: 4 }),
     ).rejects.toBeInstanceOf(ValidationError)
@@ -145,7 +166,7 @@ describe("Files.downloadDir", () => {
       vi.fn(async () => new Response(zip, { status: 200 })),
     )
 
-    const files = new Files(sandboxId, sandboxHost, accessToken)
+    const files = new Files(deps())
     const out = await files.downloadDir("/app/output", { maxBytes: 1024 })
     expect(out).toBeInstanceOf(Uint8Array)
     expect(Array.from(out)).toEqual([0x50, 0x4b, 0x03, 0x04])
@@ -159,7 +180,9 @@ describe("Files.downloadDir", () => {
       )
     vi.stubGlobal("fetch", mock)
 
-    const files = new Files(sandboxId, "sandbox.superserve.ai", accessToken)
+    const files = new Files(
+      deps(accessToken, { sandboxHost: "sandbox.superserve.ai" }),
+    )
     await files.downloadDir("/app/output")
 
     const [url, init] = mock.mock.calls[0] as [string, RequestInit]
@@ -183,7 +206,7 @@ describe("Files.write", () => {
     const mock = vi.fn(async () => new Response(null, { status: 200 }))
     vi.stubGlobal("fetch", mock)
 
-    const files = new Files(sandboxId, sandboxHost, accessToken)
+    const files = new Files(deps())
     await files.write("/app/file.txt", "hello")
 
     const [url, init] = mock.mock.calls[0] as [string, RequestInit]
@@ -201,7 +224,7 @@ describe("Files.write", () => {
     const mock = vi.fn(async () => new Response(null, { status: 200 }))
     vi.stubGlobal("fetch", mock)
 
-    const files = new Files(sandboxId, sandboxHost, accessToken)
+    const files = new Files(deps())
     await files.write("/app/file.txt", "héllo")
 
     const init = mock.mock.calls[0]?.[1] as RequestInit
@@ -213,7 +236,7 @@ describe("Files.write", () => {
     const mock = vi.fn(async () => new Response(null, { status: 200 }))
     vi.stubGlobal("fetch", mock)
 
-    const files = new Files(sandboxId, sandboxHost, accessToken)
+    const files = new Files(deps())
     const data = new Uint8Array([1, 2, 3, 4, 5])
     await files.write("/app/binary.dat", data)
 
@@ -235,7 +258,7 @@ describe("Files.read", () => {
       vi.fn(async () => new Response(payload, { status: 200 })),
     )
 
-    const files = new Files(sandboxId, sandboxHost, accessToken)
+    const files = new Files(deps())
     const out = await files.read("/app/file.bin")
     expect(out).toBeInstanceOf(Uint8Array)
     expect(Array.from(out)).toEqual([10, 20, 30])
@@ -248,7 +271,7 @@ describe("Files.read", () => {
       vi.fn(async () => new Response(payload, { status: 200 })),
     )
 
-    const files = new Files(sandboxId, sandboxHost, accessToken)
+    const files = new Files(deps())
     await expect(
       files.read("/app/file.bin", { maxBytes: 2 }),
     ).rejects.toBeInstanceOf(ValidationError)
@@ -267,9 +290,125 @@ describe("Files.readText", () => {
       vi.fn(async () => new Response(bytes, { status: 200 })),
     )
 
-    const files = new Files(sandboxId, sandboxHost, accessToken)
+    const files = new Files(deps())
     const out = await files.readText("/app/file.txt")
     expect(out).toBe("héllo world")
+  })
+})
+
+describe("Files auto-resume (paused sandbox)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("write resumes + retries on 503, using the rotated token", async () => {
+    let refreshCalled = 0
+    let token = "tok-stale"
+    const mock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        jsonResponse({ error: { message: "sandbox is paused" } }, 503),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+    vi.stubGlobal("fetch", mock)
+
+    const files = new Files({
+      sandboxId,
+      sandboxHost,
+      getAccessToken: () => token,
+      refreshActivate: async () => {
+        refreshCalled += 1
+        token = "tok-fresh"
+        return token
+      },
+    })
+    await files.write("/app/f.txt", "hello")
+
+    expect(refreshCalled).toBe(1)
+    expect(mock).toHaveBeenCalledTimes(2)
+    const [, secondInit] = mock.mock.calls[1] as [string, RequestInit]
+    expect(
+      (secondInit.headers as Record<string, string>)["X-Access-Token"],
+    ).toBe("tok-fresh")
+  })
+
+  it("read resumes + retries on 503, using the rotated token", async () => {
+    let refreshCalled = 0
+    let token = "tok-stale"
+    const mock = vi.fn<typeof fetch>(async (_url, init) => {
+      const tok = (init?.headers as Record<string, string>)?.["X-Access-Token"]
+      if (tok === "tok-fresh") {
+        return new Response(new Uint8Array([1, 2, 3]), { status: 200 })
+      }
+      return jsonResponse({ error: { message: "sandbox is paused" } }, 503)
+    })
+    vi.stubGlobal("fetch", mock)
+
+    const files = new Files({
+      sandboxId,
+      sandboxHost,
+      getAccessToken: () => token,
+      refreshActivate: async () => {
+        refreshCalled += 1
+        token = "tok-fresh"
+        return token
+      },
+    })
+    const out = await files.read("/app/f.bin")
+
+    expect(Array.from(out)).toEqual([1, 2, 3])
+    expect(refreshCalled).toBe(1)
+  })
+
+  it("downloadDir resumes + retries on 503, using the rotated token", async () => {
+    let refreshCalled = 0
+    let token = "tok-stale"
+    const mock = vi.fn<typeof fetch>(async (_url, init) => {
+      const tok = (init?.headers as Record<string, string>)?.["X-Access-Token"]
+      if (tok === "tok-fresh") {
+        return new Response(new Uint8Array([0x50, 0x4b]), { status: 200 })
+      }
+      return jsonResponse({ error: { message: "sandbox is paused" } }, 503)
+    })
+    vi.stubGlobal("fetch", mock)
+
+    const files = new Files({
+      sandboxId,
+      sandboxHost,
+      getAccessToken: () => token,
+      refreshActivate: async () => {
+        refreshCalled += 1
+        token = "tok-fresh"
+        return token
+      },
+    })
+    const out = await files.downloadDir("/app/output")
+
+    expect(Array.from(out)).toEqual([0x50, 0x4b])
+    expect(refreshCalled).toBe(1)
+  })
+
+  it("does NOT resume on a 404 (path not found)", async () => {
+    let refreshCalled = 0
+    const mock = vi.fn(async () =>
+      jsonResponse(
+        { error: { code: "not_found", message: "no such file" } },
+        404,
+      ),
+    )
+    vi.stubGlobal("fetch", mock)
+
+    const files = new Files({
+      sandboxId,
+      sandboxHost,
+      getAccessToken: () => "tok-stale",
+      refreshActivate: async () => {
+        refreshCalled += 1
+        return "tok-fresh"
+      },
+    })
+    await expect(files.read("/missing")).rejects.toBeInstanceOf(Error)
+    expect(refreshCalled).toBe(0)
   })
 })
 
@@ -284,7 +423,9 @@ describe("Files shared-host routing", () => {
       .mockResolvedValueOnce(new Response("ok", { status: 200 }))
     vi.stubGlobal("fetch", mock)
 
-    const files = new Files(sandboxId, "sandbox.superserve.ai", accessToken)
+    const files = new Files(
+      deps(accessToken, { sandboxHost: "sandbox.superserve.ai" }),
+    )
     await files.write("/tmp/f.txt", "data")
 
     const [url, init] = mock.mock.calls[0] as [string, RequestInit]
@@ -304,7 +445,9 @@ describe("Files shared-host routing", () => {
       )
     vi.stubGlobal("fetch", mock)
 
-    const files = new Files(sandboxId, "sandbox.superserve.ai", accessToken)
+    const files = new Files(
+      deps(accessToken, { sandboxHost: "sandbox.superserve.ai" }),
+    )
     await files.read("/tmp/f.bin")
 
     const [url, init] = mock.mock.calls[0] as [string, RequestInit]

--- a/packages/sdk/tests/sandbox.test.ts
+++ b/packages/sdk/tests/sandbox.test.ts
@@ -269,7 +269,7 @@ describe("Sandbox instance methods", () => {
     expect(url).toBe("https://api.superserve.ai/sandboxes/sbx-1/secrets/A%2FB")
   })
 
-  it("sandbox.resume rotates access token and rebuilds files sub-module", async () => {
+  it("sandbox.resume rotates access token; files uses it transparently", async () => {
     const sandbox = await makeSandbox()
     const filesBefore = sandbox.files
 
@@ -290,8 +290,9 @@ describe("Sandbox instance methods", () => {
     expect(url).toBe("https://api.superserve.ai/sandboxes/sbx-1/resume")
     expect(init.method).toBe("POST")
 
-    // Files sub-module was rebuilt (new instance)
-    expect(sandbox.files).not.toBe(filesBefore)
+    // Files sub-module is the same stable instance (it reads the token live,
+    // so there's no rebuild to swap the token in)
+    expect(sandbox.files).toBe(filesBefore)
 
     // Verify subsequent file ops use the rotated token
     vi.unstubAllGlobals()


### PR DESCRIPTION
## Summary

Fixes the SDK bug @meAmitPatil reported on #228: the data plane returns **503** for a paused sandbox, but the SDKs only auto-resumed on **401**, so `pause()` + an immediate `run()` / file op failed with "sandbox is paused" instead of transparently resuming. `files` had **no resume path at all** (it held a static access token and was only swapped out on an explicit `resume()`).

After this change, a command **or** a file op against a paused sandbox transparently calls `POST /activate` (resume + token rotation) and retries once — making the promise in the docstrings (and the SS-91 skill) actually true.

## Root cause

- `ServerError` collapsed every 5xx to `statusCode = 500`, so a 503 was indistinguishable from a genuine 500.
- `commands` only retried on `AuthenticationError` (401/403).
- `files` was constructed with a static token and had no `refreshActivate`, so it could never self-heal — a paused file op just threw.

## Changes (TS + Python, kept in lockstep)

- `ServerError` now carries the real status code; `mapApiError` / `map_api_error` pass it through.
- New shared helper (`tokenRetry.ts` / `_token_retry.py`): `isResumable` (401/403 **or 503** only — a genuine 500 is *not* resumable) + `withTokenRetry` / `async_with_token_retry`. One source of the resume policy so `commands` and `files` can't drift.
- `commands` (sync + async) use the shared helper.
- `files` (sync + async) now take the same `{ getAccessToken, refreshActivate }` deps and wrap `write` / `read` / `downloadDir` in the retry; `readText` delegates to `read`.
- `Sandbox` constructs `files` once with a live token getter and no longer rebuilds it on rotate — `files` is a stable instance that reads the rotated token live.

## Tests

- **TS:** 200 pass (`bun run test`), typecheck + oxlint clean. New: 503-resume for `commands`; 503-resume for `files` `write`/`read`/`downloadDir`; "no resume on a genuine 500"; "no resume on 404"; the resume test now asserts `files` is a stable instance using the rotated token.
- **Python:** 261 pass (`uv run pytest`), mypy + ruff clean. Mirror coverage including the async paths.
- Written test-first — the new 503 tests fail against the old code and pass with the fix.

## Notes

- Separate from the docs PR #228 (kept docs-only); this is the code change that makes #228's "a command/file op auto-resumes a paused sandbox" line true.
- No version bump — leaving that to the maintainer's release step (`SDK_VERSION` tracks the last published version).
- 503-detection keys on the status code; if the backend later exposes a stable `code` for paused, `isResumable` can be tightened to match it.