### PR TITLE
console: mint region-prefixed API keys (ss_live_<region>_...)

### DIFF
--- a/apps/console/src/lib/api/api-keys-actions.create.test.ts
+++ b/apps/console/src/lib/api/api-keys-actions.create.test.ts
@@ -1,0 +1,99 @@
+import crypto from "node:crypto"
+
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/lib/admin/impersonation", () => ({
+  getImpersonationTeamId: async () => null,
+}))
+vi.mock("@/lib/supabase/server", () => ({
+  createServerClient: async () => ({
+    auth: {
+      getUser: async () => ({
+        data: { user: { id: "a1", email: "amit@superserve.ai" } },
+      }),
+    },
+  }),
+}))
+
+// Per-test knobs read lazily by the admin-client mock.
+let homeRegionResult: { data: unknown; error: unknown } = {
+  data: { home_region: "usw" },
+  error: null,
+}
+let insertedApiKeyRow: Record<string, unknown> | null = null
+
+// Minimal chainable stub: every builder method returns the chain; single()
+// resolves to the configured result.
+function chain(result: { data: unknown; error: unknown }) {
+  const c: Record<string, unknown> = {}
+  for (const m of ["select", "eq", "is", "neq", "order", "limit", "update"]) {
+    c[m] = () => c
+  }
+  c.single = async () => result
+  return c
+}
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({
+    from: (table: string) => {
+      switch (table) {
+        case "profile":
+          return chain({ data: { id: "a1" }, error: null })
+        case "team_member":
+          return chain({ data: { team_id: "team-1" }, error: null })
+        case "team":
+          return chain(homeRegionResult)
+        case "api_key": {
+          const c = chain({
+            data: { id: "k1", name: "test", created_at: "2026-07-01" },
+            error: null,
+          }) as Record<string, unknown> & {
+            insert?: (row: Record<string, unknown>) => unknown
+          }
+          c.insert = (row: Record<string, unknown>) => {
+            insertedApiKeyRow = row
+            return c
+          }
+          return c
+        }
+        default:
+          throw new Error(`unexpected table ${table}`)
+      }
+    },
+  }),
+}))
+
+import { createApiKeyAction } from "./api-keys-actions"
+
+describe("createApiKeyAction region-prefixed keys", () => {
+  beforeEach(() => {
+    insertedApiKeyRow = null
+  })
+
+  it("mints a key carrying the team's home region", async () => {
+    homeRegionResult = { data: { home_region: "usw" }, error: null }
+    const res = await createApiKeyAction("test")
+
+    expect(res.key).toMatch(/^ss_live_usw_[A-Za-z0-9_-]{32}$/)
+    expect(res.prefix).toBe(`${res.key.slice(0, 20)}...`)
+    // Stored hash covers the full key string, region segment included.
+    const wantHash = crypto.createHash("sha256").update(res.key).digest("hex")
+    expect(insertedApiKeyRow?.key_hash).toBe(wantHash)
+  })
+
+  it("falls back to the default region when home_region is missing", async () => {
+    // Simulates the column not existing yet (migration not applied).
+    homeRegionResult = {
+      data: null,
+      error: { message: "column team.home_region does not exist" },
+    }
+    const res = await createApiKeyAction("test")
+    expect(res.key).toMatch(/^ss_live_use_/)
+  })
+
+  it("falls back to the default region on an unknown region code", async () => {
+    homeRegionResult = { data: { home_region: "mars" }, error: null }
+    const res = await createApiKeyAction("test")
+    expect(res.key).toMatch(/^ss_live_use_/)
+  })
+})

--- a/apps/console/src/lib/api/api-keys-actions.create.test.ts
+++ b/apps/console/src/lib/api/api-keys-actions.create.test.ts
@@ -75,7 +75,9 @@ describe("createApiKeyAction region-prefixed keys", () => {
     const res = await createApiKeyAction("test")
 
     expect(res.key).toMatch(/^ss_live_usw_[A-Za-z0-9_-]{32}$/)
-    expect(res.prefix).toBe(`${res.key.slice(0, 20)}...`)
+    // Exactly 8 random chars after the region segment.
+    const randomPart = res.key.slice("ss_live_usw_".length)
+    expect(res.prefix).toBe(`ss_live_usw_${randomPart.slice(0, 8)}...`)
     // Stored hash covers the full key string, region segment included.
     const wantHash = crypto.createHash("sha256").update(res.key).digest("hex")
     expect(insertedApiKeyRow?.key_hash).toBe(wantHash)

--- a/apps/console/src/lib/api/api-keys-actions.ts
+++ b/apps/console/src/lib/api/api-keys-actions.ts
@@ -6,9 +6,37 @@ import { getImpersonationTeamId } from "@/lib/admin/impersonation"
 import { createAdminClient } from "@/lib/supabase/admin"
 import { createServerClient } from "@/lib/supabase/server"
 
-function generateRawKey(): string {
+// Region codes embedded in new API keys (ss_live_<region>_...). Must stay in
+// sync with the team_home_region_valid CHECK constraint in the control-plane
+// schema. The region segment lets the API edge route a request to the team's
+// home cell from the key string alone — no directory lookup. Legacy keys
+// without a region segment keep working: the control plane hashes the whole
+// string, so the format is opaque to auth.
+const REGION_CODES = new Set(["use", "usw"])
+const DEFAULT_REGION = "use"
+
+function generateRawKey(region: string): string {
   const bytes = crypto.randomBytes(24)
-  return `ss_live_${bytes.toString("base64url")}`
+  return `ss_live_${region}_${bytes.toString("base64url")}`
+}
+
+/**
+ * A team's home region determines which cell serves its API traffic; new keys
+ * carry it as a routing hint. Falls back to the default region if the
+ * home_region migration hasn't been applied yet or the value is unknown, so
+ * key creation never breaks on schema skew.
+ */
+async function getTeamHomeRegion(teamId: string): Promise<string> {
+  const admin = createAdminClient()
+  const { data, error } = await admin
+    .from("team")
+    .select("home_region")
+    .eq("id", teamId)
+    .single()
+  if (error || !data?.home_region || !REGION_CODES.has(data.home_region)) {
+    return DEFAULT_REGION
+  }
+  return data.home_region as string
 }
 
 function hashKey(key: string): string {
@@ -132,9 +160,11 @@ export async function createApiKeyAction(name: string) {
 
   const teamId = await getOrCreateTeamForUser(user.id, user.email ?? user.id)
 
-  const rawKey = generateRawKey()
+  const region = await getTeamHomeRegion(teamId)
+  const rawKey = generateRawKey(region)
   const keyHash = hashKey(rawKey)
-  const keyPrefix = `ss_live_${rawKey.slice(8, 16)}...`
+  // ss_live_<region>_ plus the first 8 random chars, e.g. "ss_live_use_AbCdEfGh..."
+  const keyPrefix = `${rawKey.slice(0, 20)}...`
 
   const admin = createAdminClient()
   const { data, error } = await admin

--- a/apps/console/src/lib/api/api-keys-actions.ts
+++ b/apps/console/src/lib/api/api-keys-actions.ts
@@ -164,7 +164,9 @@ export async function createApiKeyAction(name: string) {
   const rawKey = generateRawKey(region)
   const keyHash = hashKey(rawKey)
   // ss_live_<region>_ plus the first 8 random chars, e.g. "ss_live_use_AbCdEfGh..."
-  const keyPrefix = `${rawKey.slice(0, 20)}...`
+  // Sliced relative to the region length so a future region code of a
+  // different length still shows exactly 8 random chars.
+  const keyPrefix = `${rawKey.slice(0, `ss_live_${region}_`.length + 8)}...`
 
   const admin = createAdminClient()
   const { data, error } = await admin


### PR DESCRIPTION
New customer API keys embed the team's home region — `ss_live_<region>_<random>`, read from `team.home_region` — so the API edge can route a request to the team's home cell from the key string alone, no directory lookup. Legacy keys are untouched and keep working. Part of the two-region rollout; pairs with the control-plane migration adding the column (sandbox#161).

## Technical decisions

- Schema skew is safe in both directions: a missing `home_region` column (migration not yet applied) or an unknown code falls back to `use`, so key creation never breaks on deploy order.
- The control plane hashes the whole key string, so the format is opaque to auth — the region segment is inert until cell routing exists.
- Internal console keys (`__console_proxy__`, impersonation) stay region-less deliberately; they're HMAC-derived and only talk to the single control plane today.

## Testing

3 new vitest cases: region embedding + hash-covers-full-string, fallback on missing column, fallback on unknown region code. Existing impersonation-refusal test unchanged. Typecheck + oxlint clean.