### PR TITLE
docs: merge SDK and API reference into one tab, add Cookbook tab

### DIFF
--- a/docs/cookbook/pr-loop.mdx
+++ b/docs/cookbook/pr-loop.mdx
@@ -1,0 +1,20 @@
+---
+title: "PR Loop"
+sidebarTitle: PR Loop
+description: Run a coding agent in a sandbox that iterates on a pull request until CI passes.
+icon: "arrows-rotate"
+---
+
+The **PR loop** pattern runs a coding agent inside a Superserve sandbox against a real branch: the agent makes a change, pushes it, watches the checks, and iterates on the feedback until the pull request is green — all in an isolated microVM with its own credentials and network policy.
+
+This recipe will cover:
+
+- Launching a sandbox from a template with your repo and toolchain ready
+- Scoping a GitHub token to a single repository
+- Driving the agent loop: change → push → poll checks → read feedback → retry
+- Deciding when to stop: green CI, review approval, or an iteration cap
+
+<Note>
+  This recipe is coming soon. In the meantime, see the [Integration
+  Guides](/integrations/mcp) for running coding agents in a sandbox today.
+</Note>

--- a/docs/cookbook/pr-loop.mdx
+++ b/docs/cookbook/pr-loop.mdx
@@ -15,6 +15,7 @@ This recipe will cover:
 - Deciding when to stop: green CI, review approval, or an iteration cap
 
 <Note>
-  This recipe is coming soon. In the meantime, see the [Integration
-  Guides](/integrations/mcp) for running coding agents in a sandbox today.
+  This recipe is coming soon. In the meantime, see the [integration
+  guides](/integrations/mcp) in this cookbook for running coding agents in a
+  sandbox today.
 </Note>

--- a/docs/cookbook/software-factory.mdx
+++ b/docs/cookbook/software-factory.mdx
@@ -1,0 +1,20 @@
+---
+title: "Software Factory"
+sidebarTitle: Software Factory
+description: Orchestrate a fleet of sandboxed agents that plan, build, and review features in parallel.
+icon: "industry"
+---
+
+The **software factory** pattern scales the PR loop out: an orchestrator fans work out to many sandboxes in parallel — one agent per task — then gathers, reviews, and merges the results. Each agent gets its own isolated microVM, its own scoped credentials, and its own audit trail.
+
+This recipe will cover:
+
+- Decomposing a feature into independent tasks an agent can own end to end
+- Spawning one sandbox per task and tracking the fleet
+- Reviewing agent output with a second pass of sandboxed reviewer agents
+- Collecting results: merging green branches and retrying failed tasks
+
+<Note>
+  This recipe is coming soon. In the meantime, see the [Integration
+  Guides](/integrations/mcp) for running coding agents in a sandbox today.
+</Note>

--- a/docs/cookbook/software-factory.mdx
+++ b/docs/cookbook/software-factory.mdx
@@ -15,6 +15,7 @@ This recipe will cover:
 - Collecting results: merging green branches and retrying failed tasks
 
 <Note>
-  This recipe is coming soon. In the meantime, see the [Integration
-  Guides](/integrations/mcp) for running coding agents in a sandbox today.
+  This recipe is coming soon. In the meantime, see the [integration
+  guides](/integrations/mcp) in this cookbook for running coding agents in a
+  sandbox today.
 </Note>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -227,8 +227,12 @@
         ]
       },
       {
-        "tab": "Integration Guides",
+        "tab": "Cookbook",
         "groups": [
+          {
+            "group": "Recipes",
+            "pages": ["cookbook/pr-loop", "cookbook/software-factory"]
+          },
           {
             "group": "MCP",
             "tag": "NEW",
@@ -260,15 +264,6 @@
               "integrations/agent-harnesses/claude-agent-sdk",
               "integrations/agent-harnesses/openai-agents-sdk"
             ]
-          }
-        ]
-      },
-      {
-        "tab": "Cookbook",
-        "groups": [
-          {
-            "group": "Recipes",
-            "pages": ["cookbook/pr-loop", "cookbook/software-factory"]
           }
         ]
       }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -124,16 +124,104 @@
         ]
       },
       {
-        "tab": "SDK Reference",
-        "groups": [
+        "tab": "Reference",
+        "dropdowns": [
           {
-            "group": "Reference",
-            "pages": [
-              "sdk-reference/sandbox",
-              "sdk-reference/secret",
-              "sdk-reference/template",
-              "sdk-reference/commands",
-              "sdk-reference/files"
+            "dropdown": "SDK Reference",
+            "icon": "code",
+            "groups": [
+              {
+                "group": "Reference",
+                "pages": [
+                  "sdk-reference/sandbox",
+                  "sdk-reference/secret",
+                  "sdk-reference/template",
+                  "sdk-reference/commands",
+                  "sdk-reference/files"
+                ]
+              }
+            ]
+          },
+          {
+            "dropdown": "REST API",
+            "icon": "server",
+            "openapi": "https://raw.githubusercontent.com/superserve-ai/sandbox/refs/heads/main/api/openapi.yaml",
+            "groups": [
+              {
+                "group": "Sandboxes",
+                "pages": [
+                  "GET /sandboxes",
+                  "POST /sandboxes",
+                  "GET /sandboxes/{sandbox_id}",
+                  "PATCH /sandboxes/{sandbox_id}",
+                  "DELETE /sandboxes/{sandbox_id}",
+                  "POST /sandboxes/{sandbox_id}/pause",
+                  "POST /sandboxes/{sandbox_id}/resume",
+                  "POST /sandboxes/{sandbox_id}/activate",
+                  "GET /sandboxes/{sandbox_id}/network"
+                ]
+              },
+              {
+                "group": "Exec",
+                "pages": [
+                  "POST /exec",
+                  "POST /exec/stream",
+                  "GET /exec/connect"
+                ]
+              },
+              {
+                "group": "Files",
+                "pages": [
+                  "GET /sandboxes/{sandbox_id}/files",
+                  "GET /files",
+                  "POST /files"
+                ]
+              },
+              {
+                "group": "Templates",
+                "pages": [
+                  "GET /templates",
+                  "POST /templates",
+                  "GET /templates/{template_id}",
+                  "DELETE /templates/{template_id}",
+                  "GET /templates/{template_id}/builds",
+                  "POST /templates/{template_id}/builds",
+                  "GET /templates/{template_id}/builds/{build_id}",
+                  "DELETE /templates/{template_id}/builds/{build_id}",
+                  "GET /templates/{template_id}/builds/{build_id}/logs"
+                ]
+              },
+              {
+                "group": "Secrets",
+                "pages": [
+                  "POST /secrets",
+                  "GET /secrets",
+                  "GET /secrets/{name}",
+                  "PATCH /secrets/{name}",
+                  "DELETE /secrets/{name}",
+                  "POST /sandboxes/{sandbox_id}/secrets",
+                  "DELETE /sandboxes/{sandbox_id}/secrets/{env_key}",
+                  "GET /secrets/{name}/audit",
+                  "GET /secrets/{name}/sandboxes",
+                  "GET /providers"
+                ]
+              },
+              {
+                "group": "Billing",
+                "pages": ["GET /billing/pricing", "GET /billing/pricing/public"]
+              },
+              {
+                "group": "Team Management",
+                "pages": [
+                  "GET /teams/{team_id}/management",
+                  "GET /teams/{team_id}/members",
+                  "POST /teams/{team_id}/members",
+                  "DELETE /teams/{team_id}/members/{user_id}",
+                  "GET /teams/{team_id}/roles",
+                  "POST /teams/{team_id}/roles",
+                  "DELETE /teams/{team_id}/roles/{assignment_id}"
+                ]
+              }
             ]
           }
         ]
@@ -176,79 +264,11 @@
         ]
       },
       {
-        "tab": "API Reference",
-        "openapi": "https://raw.githubusercontent.com/superserve-ai/sandbox/refs/heads/main/api/openapi.yaml",
+        "tab": "Cookbook",
         "groups": [
           {
-            "group": "Sandboxes",
-            "pages": [
-              "GET /sandboxes",
-              "POST /sandboxes",
-              "GET /sandboxes/{sandbox_id}",
-              "PATCH /sandboxes/{sandbox_id}",
-              "DELETE /sandboxes/{sandbox_id}",
-              "POST /sandboxes/{sandbox_id}/pause",
-              "POST /sandboxes/{sandbox_id}/resume",
-              "POST /sandboxes/{sandbox_id}/activate",
-              "GET /sandboxes/{sandbox_id}/network"
-            ]
-          },
-          {
-            "group": "Exec",
-            "pages": ["POST /exec", "POST /exec/stream", "GET /exec/connect"]
-          },
-          {
-            "group": "Files",
-            "pages": [
-              "GET /sandboxes/{sandbox_id}/files",
-              "GET /files",
-              "POST /files"
-            ]
-          },
-          {
-            "group": "Templates",
-            "pages": [
-              "GET /templates",
-              "POST /templates",
-              "GET /templates/{template_id}",
-              "DELETE /templates/{template_id}",
-              "GET /templates/{template_id}/builds",
-              "POST /templates/{template_id}/builds",
-              "GET /templates/{template_id}/builds/{build_id}",
-              "DELETE /templates/{template_id}/builds/{build_id}",
-              "GET /templates/{template_id}/builds/{build_id}/logs"
-            ]
-          },
-          {
-            "group": "Secrets",
-            "pages": [
-              "POST /secrets",
-              "GET /secrets",
-              "GET /secrets/{name}",
-              "PATCH /secrets/{name}",
-              "DELETE /secrets/{name}",
-              "POST /sandboxes/{sandbox_id}/secrets",
-              "DELETE /sandboxes/{sandbox_id}/secrets/{env_key}",
-              "GET /secrets/{name}/audit",
-              "GET /secrets/{name}/sandboxes",
-              "GET /providers"
-            ]
-          },
-          {
-            "group": "Billing",
-            "pages": ["GET /billing/pricing", "GET /billing/pricing/public"]
-          },
-          {
-            "group": "Team Management",
-            "pages": [
-              "GET /teams/{team_id}/management",
-              "GET /teams/{team_id}/members",
-              "POST /teams/{team_id}/members",
-              "DELETE /teams/{team_id}/members/{user_id}",
-              "GET /teams/{team_id}/roles",
-              "POST /teams/{team_id}/roles",
-              "DELETE /teams/{team_id}/roles/{assignment_id}"
-            ]
+            "group": "Recipes",
+            "pages": ["cookbook/pr-loop", "cookbook/software-factory"]
           }
         ]
       }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -63,9 +63,10 @@
     }
   ],
   "navigation": {
-    "tabs": [
+    "anchors": [
       {
-        "tab": "Documentation",
+        "anchor": "Documentation",
+        "icon": "book-open",
         "groups": [
           {
             "group": "Get Started",
@@ -124,110 +125,102 @@
         ]
       },
       {
-        "tab": "Reference",
-        "dropdowns": [
+        "anchor": "SDK Reference",
+        "icon": "code",
+        "groups": [
           {
-            "dropdown": "SDK Reference",
-            "icon": "code",
-            "groups": [
-              {
-                "group": "Reference",
-                "pages": [
-                  "sdk-reference/sandbox",
-                  "sdk-reference/secret",
-                  "sdk-reference/template",
-                  "sdk-reference/commands",
-                  "sdk-reference/files"
-                ]
-              }
-            ]
-          },
-          {
-            "dropdown": "REST API",
-            "icon": "server",
-            "openapi": "https://raw.githubusercontent.com/superserve-ai/sandbox/refs/heads/main/api/openapi.yaml",
-            "groups": [
-              {
-                "group": "Sandboxes",
-                "pages": [
-                  "GET /sandboxes",
-                  "POST /sandboxes",
-                  "GET /sandboxes/{sandbox_id}",
-                  "PATCH /sandboxes/{sandbox_id}",
-                  "DELETE /sandboxes/{sandbox_id}",
-                  "POST /sandboxes/{sandbox_id}/pause",
-                  "POST /sandboxes/{sandbox_id}/resume",
-                  "POST /sandboxes/{sandbox_id}/activate",
-                  "GET /sandboxes/{sandbox_id}/network"
-                ]
-              },
-              {
-                "group": "Exec",
-                "pages": [
-                  "POST /exec",
-                  "POST /exec/stream",
-                  "GET /exec/connect"
-                ]
-              },
-              {
-                "group": "Files",
-                "pages": [
-                  "GET /sandboxes/{sandbox_id}/files",
-                  "GET /files",
-                  "POST /files"
-                ]
-              },
-              {
-                "group": "Templates",
-                "pages": [
-                  "GET /templates",
-                  "POST /templates",
-                  "GET /templates/{template_id}",
-                  "DELETE /templates/{template_id}",
-                  "GET /templates/{template_id}/builds",
-                  "POST /templates/{template_id}/builds",
-                  "GET /templates/{template_id}/builds/{build_id}",
-                  "DELETE /templates/{template_id}/builds/{build_id}",
-                  "GET /templates/{template_id}/builds/{build_id}/logs"
-                ]
-              },
-              {
-                "group": "Secrets",
-                "pages": [
-                  "POST /secrets",
-                  "GET /secrets",
-                  "GET /secrets/{name}",
-                  "PATCH /secrets/{name}",
-                  "DELETE /secrets/{name}",
-                  "POST /sandboxes/{sandbox_id}/secrets",
-                  "DELETE /sandboxes/{sandbox_id}/secrets/{env_key}",
-                  "GET /secrets/{name}/audit",
-                  "GET /secrets/{name}/sandboxes",
-                  "GET /providers"
-                ]
-              },
-              {
-                "group": "Billing",
-                "pages": ["GET /billing/pricing", "GET /billing/pricing/public"]
-              },
-              {
-                "group": "Team Management",
-                "pages": [
-                  "GET /teams/{team_id}/management",
-                  "GET /teams/{team_id}/members",
-                  "POST /teams/{team_id}/members",
-                  "DELETE /teams/{team_id}/members/{user_id}",
-                  "GET /teams/{team_id}/roles",
-                  "POST /teams/{team_id}/roles",
-                  "DELETE /teams/{team_id}/roles/{assignment_id}"
-                ]
-              }
+            "group": "Reference",
+            "pages": [
+              "sdk-reference/sandbox",
+              "sdk-reference/secret",
+              "sdk-reference/template",
+              "sdk-reference/commands",
+              "sdk-reference/files"
             ]
           }
         ]
       },
       {
-        "tab": "Cookbook",
+        "anchor": "REST API",
+        "icon": "server",
+        "groups": [
+          {
+            "group": "Sandboxes",
+            "pages": [
+              "GET /sandboxes",
+              "POST /sandboxes",
+              "GET /sandboxes/{sandbox_id}",
+              "PATCH /sandboxes/{sandbox_id}",
+              "DELETE /sandboxes/{sandbox_id}",
+              "POST /sandboxes/{sandbox_id}/pause",
+              "POST /sandboxes/{sandbox_id}/resume",
+              "POST /sandboxes/{sandbox_id}/activate",
+              "GET /sandboxes/{sandbox_id}/network"
+            ]
+          },
+          {
+            "group": "Exec",
+            "pages": ["POST /exec", "POST /exec/stream", "GET /exec/connect"]
+          },
+          {
+            "group": "Files",
+            "pages": [
+              "GET /sandboxes/{sandbox_id}/files",
+              "GET /files",
+              "POST /files"
+            ]
+          },
+          {
+            "group": "Templates",
+            "pages": [
+              "GET /templates",
+              "POST /templates",
+              "GET /templates/{template_id}",
+              "DELETE /templates/{template_id}",
+              "GET /templates/{template_id}/builds",
+              "POST /templates/{template_id}/builds",
+              "GET /templates/{template_id}/builds/{build_id}",
+              "DELETE /templates/{template_id}/builds/{build_id}",
+              "GET /templates/{template_id}/builds/{build_id}/logs"
+            ]
+          },
+          {
+            "group": "Secrets",
+            "pages": [
+              "POST /secrets",
+              "GET /secrets",
+              "GET /secrets/{name}",
+              "PATCH /secrets/{name}",
+              "DELETE /secrets/{name}",
+              "POST /sandboxes/{sandbox_id}/secrets",
+              "DELETE /sandboxes/{sandbox_id}/secrets/{env_key}",
+              "GET /secrets/{name}/audit",
+              "GET /secrets/{name}/sandboxes",
+              "GET /providers"
+            ]
+          },
+          {
+            "group": "Billing",
+            "pages": ["GET /billing/pricing", "GET /billing/pricing/public"]
+          },
+          {
+            "group": "Team Management",
+            "pages": [
+              "GET /teams/{team_id}/management",
+              "GET /teams/{team_id}/members",
+              "POST /teams/{team_id}/members",
+              "DELETE /teams/{team_id}/members/{user_id}",
+              "GET /teams/{team_id}/roles",
+              "POST /teams/{team_id}/roles",
+              "DELETE /teams/{team_id}/roles/{assignment_id}"
+            ]
+          }
+        ],
+        "openapi": "https://raw.githubusercontent.com/superserve-ai/sandbox/refs/heads/main/api/openapi.yaml"
+      },
+      {
+        "anchor": "Cookbook",
+        "icon": "utensils",
         "groups": [
           {
             "group": "Recipes",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -223,10 +223,6 @@
         "icon": "utensils",
         "groups": [
           {
-            "group": "Recipes",
-            "pages": ["cookbook/pr-loop", "cookbook/software-factory"]
-          },
-          {
             "group": "MCP",
             "tag": "NEW",
             "pages": ["integrations/mcp"]

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "test": "turbo run test",
     "test:coverage": "turbo run test:coverage",
     "test:e2e": "turbo run e2e",
-    "docs:dev": "mintlify dev --dir docs",
-    "docs:build": "mintlify build --dir docs",
+    "docs:dev": "cd docs && mintlify dev",
+    "docs:build": "cd docs && mintlify validate",
     "docs:check-nav": "bun run scripts/check-docs-nav.ts",
     "prepare": "husky"
   },

--- a/scripts/check-docs-nav.ts
+++ b/scripts/check-docs-nav.ts
@@ -30,40 +30,43 @@ const EXEMPT_PATHS = new Set([
 
 const OP_RE = new RegExp(`^(${HTTP_METHODS.join("|")})\\s+/`)
 
-type NavDivision = {
-  openapi?: string
-  groups?: Array<{ pages: unknown[] }>
-}
-
 type DocsConfig = {
-  navigation: {
-    tabs: Array<NavDivision & { tab: string; dropdowns?: NavDivision[] }>
-  }
+  navigation: unknown
 }
 
+// Walks the whole navigation tree so the check works regardless of which
+// division type (tab, anchor, dropdown, group, ...) carries the `openapi`
+// field and the endpoint entries.
 function navOpsFromDocs(docs: DocsConfig): {
   ops: Set<string>
   specUrl: string
 } {
-  const divisions: NavDivision[] = []
-  for (const tab of docs.navigation?.tabs ?? []) {
-    divisions.push(tab, ...(tab.dropdowns ?? []))
+  const ops = new Set<string>()
+  const specUrls = new Set<string>()
+
+  function walk(node: unknown): void {
+    if (Array.isArray(node)) {
+      for (const item of node) walk(item)
+      return
+    }
+    if (!node || typeof node !== "object") {
+      if (typeof node === "string" && OP_RE.test(node)) {
+        ops.add(node.replace(/\s+/g, " ").trim())
+      }
+      return
+    }
+    const record = node as Record<string, unknown>
+    if (typeof record.openapi === "string") specUrls.add(record.openapi)
+    for (const value of Object.values(record)) walk(value)
   }
-  const apiDivision = divisions.find((d) => typeof d.openapi === "string")
-  if (!apiDivision?.openapi) {
+
+  walk(docs.navigation)
+  if (specUrls.size !== 1) {
     throw new Error(
-      "no tab or dropdown with an `openapi` field found in docs.json",
+      `expected exactly one distinct \`openapi\` spec URL in docs.json navigation, found ${specUrls.size}`,
     )
   }
-  const ops = new Set<string>()
-  for (const group of apiDivision.groups ?? []) {
-    for (const page of group.pages ?? []) {
-      if (typeof page === "string" && OP_RE.test(page)) {
-        ops.add(page.replace(/\s+/g, " ").trim())
-      }
-    }
-  }
-  return { ops, specUrl: apiDivision.openapi }
+  return { ops, specUrl: [...specUrls][0] }
 }
 
 function specOps(spec: unknown): Set<string> {

--- a/scripts/check-docs-nav.ts
+++ b/scripts/check-docs-nav.ts
@@ -30,13 +30,14 @@ const EXEMPT_PATHS = new Set([
 
 const OP_RE = new RegExp(`^(${HTTP_METHODS.join("|")})\\s+/`)
 
+type NavDivision = {
+  openapi?: string
+  groups?: Array<{ pages: unknown[] }>
+}
+
 type DocsConfig = {
   navigation: {
-    tabs: Array<{
-      tab: string
-      openapi?: string
-      groups?: Array<{ pages: unknown[] }>
-    }>
+    tabs: Array<NavDivision & { tab: string; dropdowns?: NavDivision[] }>
   }
 }
 
@@ -44,21 +45,25 @@ function navOpsFromDocs(docs: DocsConfig): {
   ops: Set<string>
   specUrl: string
 } {
-  const apiTab = docs.navigation?.tabs?.find(
-    (t) => typeof t.openapi === "string",
-  )
-  if (!apiTab?.openapi) {
-    throw new Error("no tab with an `openapi` field found in docs.json")
+  const divisions: NavDivision[] = []
+  for (const tab of docs.navigation?.tabs ?? []) {
+    divisions.push(tab, ...(tab.dropdowns ?? []))
+  }
+  const apiDivision = divisions.find((d) => typeof d.openapi === "string")
+  if (!apiDivision?.openapi) {
+    throw new Error(
+      "no tab or dropdown with an `openapi` field found in docs.json",
+    )
   }
   const ops = new Set<string>()
-  for (const group of apiTab.groups ?? []) {
+  for (const group of apiDivision.groups ?? []) {
     for (const page of group.pages ?? []) {
       if (typeof page === "string" && OP_RE.test(page)) {
         ops.add(page.replace(/\s+/g, " ").trim())
       }
     }
   }
-  return { ops, specUrl: apiTab.openapi }
+  return { ops, specUrl: apiDivision.openapi }
 }
 
 function specOps(spec: unknown): Set<string> {


### PR DESCRIPTION
## Summary

Restructures the docs site navigation. The former 4-tab layout (Documentation · SDK Reference · Integration Guides · API Reference) becomes a single-axis **anchors** layout: no top tab bar; four icon-labeled sections pinned at the top of the sidebar, selected via a layout comparison across five rendered variants (#257–#260).

- **Documentation** — content and grouping unchanged.
- **SDK Reference** — the 5 existing pages, unchanged URLs.
- **REST API** — the OpenAPI-generated reference, moved as-is.
- **Cookbook** — new section holding the former Integration Guides: MCP, Coding Agents, Personal Agents, Managed Agents, and Agent Harnesses. All integration page URLs unchanged. A "Recipes" group (PR Loop, Software Factory placeholders) exists on disk under `docs/cookbook/` but is **hidden from the nav** until real content is ready — the pages aren't deleted, just not listed in `docs.json`.
- `scripts/check-docs-nav.ts`: the nav-sync check is now division-agnostic — it walks the whole navigation tree for endpoint entries and the `openapi` spec URL instead of assuming a tabs layout.
- `package.json`: `docs:build` and `docs:dev` were broken with the current Mintlify CLI (`build` command removed, `--dir` no longer honored); both now `cd docs` and use `mintlify validate` / `mintlify dev`.

## Test plan

- [x] `mintlify validate` passes (strict build validation)
- [x] `mintlify broken-links` passes
- [x] `bun run docs:check-nav` passes (44 operations in sync with the OpenAPI spec)
- [x] All 43 production `/api-reference/...` endpoint URLs (from the live sitemap) verified to still resolve 200 on the local preview — endpoint slugs are derived from the OpenAPI spec, not nav structure, so **no redirects needed**
- [x] Anchors layout rendered locally and screenshot-compared against tabs, dropdown, flat, and global-anchor variants
- [x] Confirmed Recipes group no longer renders in the Cookbook sidebar while `cookbook/pr-loop.mdx` and `cookbook/software-factory.mdx` remain on disk
- [ ] Verify the anchors sidebar renders as expected on the deployed Mintlify preview