### PR TITLE
docs: replace sub-second cold start claims with <50ms

### DIFF
--- a/docs/integrations/managed-agents/claude-managed-agents.mdx
+++ b/docs/integrations/managed-agents/claude-managed-agents.mdx
@@ -501,7 +501,7 @@ The orchestrator reads `superserve.sandbox_id` from `work.data.metadata` and con
 ## What you get
 
 - **Firecracker microVM isolation.** Each session runs in its own lightweight VM - not a shared container. Process tree, filesystem, and network namespace are fully isolated. A compromised sandbox cannot affect others.
-- **Fast startup (<50ms).** Sandboxes are ready instantly. No image pull, no package install, no boot sequence at session time.
+- **Fast startup (`<50ms`).** Sandboxes are ready instantly. No image pull, no package install, no boot sequence at session time.
 - **Pause and resume.** Checkpoint the full sandbox state between turns. Resume picks up exactly where it left off - running processes, open files, in-memory state. Pay for compute only when the agent is actively working.
 - **Per-sandbox network isolation.** Each sandbox gets its own network namespace with CIDR and domain-based egress filtering. Lock the agent down to `api.anthropic.com` only, or open access to specific internal services.
 - **The sandbox is yours.** Beyond running the agent's tools, you control the full VM. Pre-install packages in the template, mount data via the files API, stream command output for observability. The tool runner is one process in a VM you own.

--- a/docs/integrations/managed-agents/claude-managed-agents.mdx
+++ b/docs/integrations/managed-agents/claude-managed-agents.mdx
@@ -363,7 +363,7 @@ Keep `ANTHROPIC_ENVIRONMENT_KEY` on the orchestrator host only. The orchestrator
 </Warning>
 
 <Tip>
-To reduce costs, pause sandboxes that sit idle between turns. Superserve's `pause()` checkpoints the full VM state - memory, processes, and filesystem - at zero compute cost. The next work item for that session calls `resume()` and picks up exactly where it left off, in under a second.
+To reduce costs, pause sandboxes that sit idle between turns. Superserve's `pause()` checkpoints the full VM state - memory, processes, and filesystem - at zero compute cost. The next work item for that session calls `resume()` and picks up exactly where it left off, in under 50ms.
 </Tip>
 
 ## Start a session

--- a/docs/integrations/managed-agents/claude-managed-agents.mdx
+++ b/docs/integrations/managed-agents/claude-managed-agents.mdx
@@ -90,7 +90,7 @@ agent = client.beta.agents.create(
 
 ## Build the sandbox template
 
-Build a Superserve template with Python and the Anthropic SDK pre-installed. Sandboxes created from this template boot in under a second - no image pull or package install at session time.
+Build a Superserve template with Python and the Anthropic SDK pre-installed. Sandboxes created from this template boot in under 50ms - no image pull or package install at session time.
 
 <CodeGroup>
 ```typescript TypeScript
@@ -501,7 +501,7 @@ The orchestrator reads `superserve.sandbox_id` from `work.data.metadata` and con
 ## What you get
 
 - **Firecracker microVM isolation.** Each session runs in its own lightweight VM - not a shared container. Process tree, filesystem, and network namespace are fully isolated. A compromised sandbox cannot affect others.
-- **Sub-second startup.** Sandboxes are ready instantly. No image pull, no package install, no boot sequence at session time.
+- **Fast startup (<50ms).** Sandboxes are ready instantly. No image pull, no package install, no boot sequence at session time.
 - **Pause and resume.** Checkpoint the full sandbox state between turns. Resume picks up exactly where it left off - running processes, open files, in-memory state. Pay for compute only when the agent is actively working.
 - **Per-sandbox network isolation.** Each sandbox gets its own network namespace with CIDR and domain-based egress filtering. Lock the agent down to `api.anthropic.com` only, or open access to specific internal services.
 - **The sandbox is yours.** Beyond running the agent's tools, you control the full VM. Pre-install packages in the template, mount data via the files API, stream command output for observability. The tool runner is one process in a VM you own.

--- a/guides/managed-agents/claude-managed-agents/README.md
+++ b/guides/managed-agents/claude-managed-agents/README.md
@@ -1,6 +1,6 @@
 # Claude Managed Agents on Superserve
 
-Run [Claude Managed Agents](https://platform.claude.com/docs/en/managed-agents/overview) inside [Superserve sandboxes](https://superserve.ai) — isolated Firecracker microVMs with fast (<50ms) startup, pause/resume, and per-sandbox network isolation.
+Run [Claude Managed Agents](https://platform.claude.com/docs/en/managed-agents/overview) inside [Superserve sandboxes](https://superserve.ai) — isolated Firecracker microVMs with fast (`<50ms`) startup, pause/resume, and per-sandbox network isolation.
 
 Anthropic runs the harness. Superserve runs the sandbox. You wire them together with an orchestrator.
 

--- a/guides/managed-agents/claude-managed-agents/README.md
+++ b/guides/managed-agents/claude-managed-agents/README.md
@@ -1,13 +1,13 @@
 # Claude Managed Agents on Superserve
 
-Run [Claude Managed Agents](https://platform.claude.com/docs/en/managed-agents/overview) inside [Superserve sandboxes](https://superserve.ai) — isolated Firecracker microVMs with sub-second startup, pause/resume, and per-sandbox network isolation.
+Run [Claude Managed Agents](https://platform.claude.com/docs/en/managed-agents/overview) inside [Superserve sandboxes](https://superserve.ai) — isolated Firecracker microVMs with fast (<50ms) startup, pause/resume, and per-sandbox network isolation.
 
 Anthropic runs the harness. Superserve runs the sandbox. You wire them together with an orchestrator.
 
 ## How it fits together
 
 - [**Claude Managed Agents**](https://platform.claude.com/docs/en/managed-agents/overview) — Anthropic's remote agent harness. Orchestrates the agent loop, manages sessions, dispatches tool calls via a work queue.
-- [**Superserve**](https://docs.superserve.ai) — Firecracker microVM sandboxes. Each session gets its own VM with a full filesystem, shell, and network namespace. Sandboxes boot in under a second and can be paused between turns.
+- [**Superserve**](https://docs.superserve.ai) — Firecracker microVM sandboxes. Each session gets its own VM with a full filesystem, shell, and network namespace. Sandboxes boot in under 50ms and can be paused between turns.
 
 The orchestrator polls Anthropic's work queue, creates (or resumes) a Superserve sandbox for each session, and starts a runner inside it. The runner executes tool calls — `bash`, `read`, `write`, `edit`, `glob`, `grep` — against the sandbox and posts results back.
 

--- a/guides/managed-agents/claude-managed-agents/recipes/parallel-benchmark-agent/README.md
+++ b/guides/managed-agents/claude-managed-agents/recipes/parallel-benchmark-agent/README.md
@@ -2,7 +2,7 @@
 
 A Claude Managed Agent that benchmarks code across multiple configurations simultaneously. The agent writes a parallel harness that spins up N isolated Superserve sandboxes — one per variant — runs them all concurrently, collects timing results, and synthesizes a comparison report.
 
-**The core pitch:** Benchmarking 9 configurations sequentially takes 9× longer than benchmarking them in parallel. Superserve sandboxes boot in under a second and run truly isolated. The agent drives all of this autonomously.
+**The core pitch:** Benchmarking 9 configurations sequentially takes 9× longer than benchmarking them in parallel. Superserve sandboxes boot in under 50ms and run truly isolated. The agent drives all of this autonomously.
 
 This is the **technical showpiece** recipe — it demonstrates hierarchical sandbox usage (an agent that creates sandboxes) and Superserve's architecture most clearly.
 


### PR DESCRIPTION
## Summary
- Several public docs described sandbox cold starts as "sub-second" — undersells actual latency and reads as vague marketing copy
- Replaced with "<50ms" / "fast (<50ms)" across the Claude Managed Agents integration docs, guide README, and parallel-benchmark-agent recipe README

## Testing
- Docs-only change