### PR TITLE
docs(layout): sidebar dropdown section switcher

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -63,9 +63,10 @@
     }
   ],
   "navigation": {
-    "tabs": [
+    "dropdowns": [
       {
-        "tab": "Documentation",
+        "dropdown": "Documentation",
+        "icon": "book-open",
         "groups": [
           {
             "group": "Get Started",
@@ -124,110 +125,102 @@
         ]
       },
       {
-        "tab": "Reference",
-        "dropdowns": [
+        "dropdown": "SDK Reference",
+        "icon": "code",
+        "groups": [
           {
-            "dropdown": "SDK Reference",
-            "icon": "code",
-            "groups": [
-              {
-                "group": "Reference",
-                "pages": [
-                  "sdk-reference/sandbox",
-                  "sdk-reference/secret",
-                  "sdk-reference/template",
-                  "sdk-reference/commands",
-                  "sdk-reference/files"
-                ]
-              }
-            ]
-          },
-          {
-            "dropdown": "REST API",
-            "icon": "server",
-            "openapi": "https://raw.githubusercontent.com/superserve-ai/sandbox/refs/heads/main/api/openapi.yaml",
-            "groups": [
-              {
-                "group": "Sandboxes",
-                "pages": [
-                  "GET /sandboxes",
-                  "POST /sandboxes",
-                  "GET /sandboxes/{sandbox_id}",
-                  "PATCH /sandboxes/{sandbox_id}",
-                  "DELETE /sandboxes/{sandbox_id}",
-                  "POST /sandboxes/{sandbox_id}/pause",
-                  "POST /sandboxes/{sandbox_id}/resume",
-                  "POST /sandboxes/{sandbox_id}/activate",
-                  "GET /sandboxes/{sandbox_id}/network"
-                ]
-              },
-              {
-                "group": "Exec",
-                "pages": [
-                  "POST /exec",
-                  "POST /exec/stream",
-                  "GET /exec/connect"
-                ]
-              },
-              {
-                "group": "Files",
-                "pages": [
-                  "GET /sandboxes/{sandbox_id}/files",
-                  "GET /files",
-                  "POST /files"
-                ]
-              },
-              {
-                "group": "Templates",
-                "pages": [
-                  "GET /templates",
-                  "POST /templates",
-                  "GET /templates/{template_id}",
-                  "DELETE /templates/{template_id}",
-                  "GET /templates/{template_id}/builds",
-                  "POST /templates/{template_id}/builds",
-                  "GET /templates/{template_id}/builds/{build_id}",
-                  "DELETE /templates/{template_id}/builds/{build_id}",
-                  "GET /templates/{template_id}/builds/{build_id}/logs"
-                ]
-              },
-              {
-                "group": "Secrets",
-                "pages": [
-                  "POST /secrets",
-                  "GET /secrets",
-                  "GET /secrets/{name}",
-                  "PATCH /secrets/{name}",
-                  "DELETE /secrets/{name}",
-                  "POST /sandboxes/{sandbox_id}/secrets",
-                  "DELETE /sandboxes/{sandbox_id}/secrets/{env_key}",
-                  "GET /secrets/{name}/audit",
-                  "GET /secrets/{name}/sandboxes",
-                  "GET /providers"
-                ]
-              },
-              {
-                "group": "Billing",
-                "pages": ["GET /billing/pricing", "GET /billing/pricing/public"]
-              },
-              {
-                "group": "Team Management",
-                "pages": [
-                  "GET /teams/{team_id}/management",
-                  "GET /teams/{team_id}/members",
-                  "POST /teams/{team_id}/members",
-                  "DELETE /teams/{team_id}/members/{user_id}",
-                  "GET /teams/{team_id}/roles",
-                  "POST /teams/{team_id}/roles",
-                  "DELETE /teams/{team_id}/roles/{assignment_id}"
-                ]
-              }
+            "group": "Reference",
+            "pages": [
+              "sdk-reference/sandbox",
+              "sdk-reference/secret",
+              "sdk-reference/template",
+              "sdk-reference/commands",
+              "sdk-reference/files"
             ]
           }
         ]
       },
       {
-        "tab": "Cookbook",
+        "dropdown": "REST API",
+        "icon": "server",
+        "groups": [
+          {
+            "group": "Sandboxes",
+            "pages": [
+              "GET /sandboxes",
+              "POST /sandboxes",
+              "GET /sandboxes/{sandbox_id}",
+              "PATCH /sandboxes/{sandbox_id}",
+              "DELETE /sandboxes/{sandbox_id}",
+              "POST /sandboxes/{sandbox_id}/pause",
+              "POST /sandboxes/{sandbox_id}/resume",
+              "POST /sandboxes/{sandbox_id}/activate",
+              "GET /sandboxes/{sandbox_id}/network"
+            ]
+          },
+          {
+            "group": "Exec",
+            "pages": ["POST /exec", "POST /exec/stream", "GET /exec/connect"]
+          },
+          {
+            "group": "Files",
+            "pages": [
+              "GET /sandboxes/{sandbox_id}/files",
+              "GET /files",
+              "POST /files"
+            ]
+          },
+          {
+            "group": "Templates",
+            "pages": [
+              "GET /templates",
+              "POST /templates",
+              "GET /templates/{template_id}",
+              "DELETE /templates/{template_id}",
+              "GET /templates/{template_id}/builds",
+              "POST /templates/{template_id}/builds",
+              "GET /templates/{template_id}/builds/{build_id}",
+              "DELETE /templates/{template_id}/builds/{build_id}",
+              "GET /templates/{template_id}/builds/{build_id}/logs"
+            ]
+          },
+          {
+            "group": "Secrets",
+            "pages": [
+              "POST /secrets",
+              "GET /secrets",
+              "GET /secrets/{name}",
+              "PATCH /secrets/{name}",
+              "DELETE /secrets/{name}",
+              "POST /sandboxes/{sandbox_id}/secrets",
+              "DELETE /sandboxes/{sandbox_id}/secrets/{env_key}",
+              "GET /secrets/{name}/audit",
+              "GET /secrets/{name}/sandboxes",
+              "GET /providers"
+            ]
+          },
+          {
+            "group": "Billing",
+            "pages": ["GET /billing/pricing", "GET /billing/pricing/public"]
+          },
+          {
+            "group": "Team Management",
+            "pages": [
+              "GET /teams/{team_id}/management",
+              "GET /teams/{team_id}/members",
+              "POST /teams/{team_id}/members",
+              "DELETE /teams/{team_id}/members/{user_id}",
+              "GET /teams/{team_id}/roles",
+              "POST /teams/{team_id}/roles",
+              "DELETE /teams/{team_id}/roles/{assignment_id}"
+            ]
+          }
+        ],
+        "openapi": "https://raw.githubusercontent.com/superserve-ai/sandbox/refs/heads/main/api/openapi.yaml"
+      },
+      {
+        "dropdown": "Cookbook",
+        "icon": "utensils",
         "groups": [
           {
             "group": "Recipes",


### PR DESCRIPTION
## Summary

Layout variant for comparison (stacked on #255). Replaces the top tab bar with a **dropdown selector** at the top of the sidebar: one dropdown switches between Documentation, SDK Reference, REST API, and Cookbook. Minimal chrome; sections are hidden until the dropdown is opened.

Pure `docs/docs.json` change; no page files move and all URLs are unchanged.

## Test plan

- [x] `mintlify validate` passes
- [x] `bun run docs:check-nav` passes (44 operations)
- [x] Rendered locally and screenshotted (see the layout comparison in the workspace)

One of four alternative-layout PRs: anchors, dropdowns, flat sidebar, global anchors. Close the ones we don't pick.