### PR TITLE
docs(layout): add global Console and GitHub anchors

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -63,6 +63,20 @@
     }
   ],
   "navigation": {
+    "global": {
+      "anchors": [
+        {
+          "anchor": "Console",
+          "href": "https://console.superserve.ai",
+          "icon": "gauge"
+        },
+        {
+          "anchor": "GitHub",
+          "href": "https://github.com/superserve-ai/superserve",
+          "icon": "github"
+        }
+      ]
+    },
     "tabs": [
       {
         "tab": "Documentation",


### PR DESCRIPTION
## Summary

Layout variant for comparison (stacked on #255). Keeps the current tab layout and adds **global anchors** — persistent Console and GitHub links pinned above the sidebar on every page, in every section.

Unlike the other three variants this is additive rather than an alternative shape, so it could also be combined with whichever layout wins.

Pure `docs/docs.json` change (+14 lines); no page files move and all URLs are unchanged.

## Test plan

- [x] `mintlify validate` passes
- [x] `bun run docs:check-nav` passes (44 operations)
- [x] Rendered locally and screenshotted (see the layout comparison in the workspace)

One of four alternative-layout PRs: anchors, dropdowns, flat sidebar, global anchors. Close the ones we don't pick.