### PR TITLE
sdk: derive API endpoint from region-tagged API keys

### DIFF
--- a/packages/python-sdk/src/superserve/_config.py
+++ b/packages/python-sdk/src/superserve/_config.py
@@ -22,17 +22,22 @@ DEFAULT_SANDBOX_HOST = "sandbox.superserve.ai"
 # ``usw`` will be added once https://api-usw.superserve.ai /
 # usw-sandbox.superserve.ai serve their cell.
 #
-# Legacy keys (``ss_live_<random>``, whose base64url random part may itself
-# contain ``_``) can coincidentally parse as having a region segment. That is
-# harmless by design: any token not in this map falls back to the defaults,
-# which is correct for every legacy key (they are all us-east).
+# Legacy keys (``ss_live_<random>``) can never be misread as region-tagged:
+# both key formats embed the same fixed-length 32-char base64url random tail
+# (from 24 random bytes), and ``_REGION_KEY_RE`` requires that exact tail
+# length anchored to the end of the string. A legacy key has no room left
+# over for a region segment on top of its own 32-char tail, so no random
+# legacy key can ever collide with a real region token — this holds
+# regardless of how many regions ``_KNOWN_REGIONS`` ends up containing.
 _KNOWN_REGIONS: dict[str, tuple[str, str]] = {
     "use": ("https://api.superserve.ai", "sandbox.superserve.ai"),
 }
 
 # Region token in ``ss_live_<region>_<random>``: 1-17 lowercase alphanumeric
-# chars, followed by at least one more character of key material.
-_REGION_KEY_RE = re.compile(r"^ss_live_([a-z0-9]{1,17})_.")
+# chars, then ``_``, then exactly the 32-char base64url tail every key is
+# minted with — anchored to the end so a legacy key's own tail can never be
+# mistaken for ``<region>_<tail>``.
+_REGION_KEY_RE = re.compile(r"^ss_live_([a-z0-9]{1,17})_[A-Za-z0-9_-]{32}$")
 
 
 @dataclass(frozen=True)
@@ -155,10 +160,11 @@ def preview_url(sandbox_id: str, host: str, port: int) -> str:
 
 
 def _region_from_api_key(api_key: str) -> str | None:
-    """Extract the candidate region token from an API key, if any.
+    """Extract the region token from an API key, if any.
 
     Returns ``None`` for legacy keys and anything else that doesn't match
-    ``ss_live_<region>_<random>``. Never raises on weird keys.
+    ``ss_live_<region>_<random-32-char-base64url>``. Never raises on weird
+    keys.
     """
     match = _REGION_KEY_RE.match(api_key)
     return match.group(1) if match else None

--- a/packages/python-sdk/src/superserve/_config.py
+++ b/packages/python-sdk/src/superserve/_config.py
@@ -15,9 +15,12 @@ DEFAULT_SANDBOX_HOST = "sandbox.superserve.ai"
 # Known Superserve regions, keyed by the region token embedded in API keys
 # (``ss_live_<region>_<random>``) and mapped to (base URL, sandbox host).
 #
-# Only regions whose DNS is live may be listed here: the SDK must never
-# construct a hostname before that region's endpoints exist. ``usw`` will be
-# added once https://api-usw.superserve.ai / usw-sandbox.superserve.ai are up.
+# A region may be listed here only once its endpoints ACTUALLY SERVE THE
+# API — DNS resolving is not the bar: superserve.ai has a catch-all wildcard,
+# so every derived hostname resolves and answers with a valid-TLS 404 from
+# the wrong infrastructure. Verify with a live /health check, not dig.
+# ``usw`` will be added once https://api-usw.superserve.ai /
+# usw-sandbox.superserve.ai serve their cell.
 #
 # Legacy keys (``ss_live_<random>``, whose base64url random part may itself
 # contain ``_``) can coincidentally parse as having a region segment. That is

--- a/packages/python-sdk/src/superserve/_config.py
+++ b/packages/python-sdk/src/superserve/_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 from dataclasses import dataclass
 from urllib.parse import urlparse
 
@@ -10,6 +11,25 @@ from .errors import AuthenticationError, ValidationError
 
 DEFAULT_BASE_URL = "https://api.superserve.ai"
 DEFAULT_SANDBOX_HOST = "sandbox.superserve.ai"
+
+# Known Superserve regions, keyed by the region token embedded in API keys
+# (``ss_live_<region>_<random>``) and mapped to (base URL, sandbox host).
+#
+# Only regions whose DNS is live may be listed here: the SDK must never
+# construct a hostname before that region's endpoints exist. ``usw`` will be
+# added once https://api-usw.superserve.ai / usw-sandbox.superserve.ai are up.
+#
+# Legacy keys (``ss_live_<random>``, whose base64url random part may itself
+# contain ``_``) can coincidentally parse as having a region segment. That is
+# harmless by design: any token not in this map falls back to the defaults,
+# which is correct for every legacy key (they are all us-east).
+_KNOWN_REGIONS: dict[str, tuple[str, str]] = {
+    "use": ("https://api.superserve.ai", "sandbox.superserve.ai"),
+}
+
+# Region token in ``ss_live_<region>_<random>``: 1-17 lowercase alphanumeric
+# chars, followed by at least one more character of key material.
+_REGION_KEY_RE = re.compile(r"^ss_live_([a-z0-9]{1,17})_.")
 
 
 @dataclass(frozen=True)
@@ -23,15 +43,30 @@ def resolve_config(
     api_key: str | None = None,
     base_url: str | None = None,
 ) -> ResolvedConfig:
-    """Resolve connection config from explicit args + environment variables."""
+    """Resolve connection config from explicit args + environment variables.
+
+    Base URL precedence: explicit ``base_url`` > ``SUPERSERVE_BASE_URL`` env
+    var > region derived from the API key > ``DEFAULT_BASE_URL``. The sandbox
+    host follows the same source (derived from the override URL, or taken
+    from the region map).
+    """
     resolved_key = api_key or os.environ.get("SUPERSERVE_API_KEY")
     if not resolved_key:
         raise AuthenticationError(
             "Missing API key. Pass `api_key` or set the "
             "SUPERSERVE_API_KEY environment variable."
         )
-    resolved_url = base_url or os.environ.get("SUPERSERVE_BASE_URL", DEFAULT_BASE_URL)
-    sandbox_host = _derive_sandbox_host(resolved_url)
+    resolved_url = base_url or os.environ.get("SUPERSERVE_BASE_URL")
+    if resolved_url is not None:
+        sandbox_host = _derive_sandbox_host(resolved_url)
+    else:
+        region = _region_from_api_key(resolved_key)
+        endpoints = _KNOWN_REGIONS.get(region) if region else None
+        if endpoints is not None:
+            resolved_url, sandbox_host = endpoints
+        else:
+            resolved_url = DEFAULT_BASE_URL
+            sandbox_host = DEFAULT_SANDBOX_HOST
     return ResolvedConfig(
         api_key=resolved_key,
         base_url=resolved_url,
@@ -114,6 +149,16 @@ def preview_url(sandbox_id: str, host: str, port: int) -> str:
             f"(< {MIN_PREVIEW_PORT}) are not proxied."
         )
     return f"https://{port}-{sandbox_id}.{host}"
+
+
+def _region_from_api_key(api_key: str) -> str | None:
+    """Extract the candidate region token from an API key, if any.
+
+    Returns ``None`` for legacy keys and anything else that doesn't match
+    ``ss_live_<region>_<random>``. Never raises on weird keys.
+    """
+    match = _REGION_KEY_RE.match(api_key)
+    return match.group(1) if match else None
 
 
 def _derive_sandbox_host(base_url: str) -> str:

--- a/packages/python-sdk/tests/test_config.py
+++ b/packages/python-sdk/tests/test_config.py
@@ -9,6 +9,7 @@ from superserve._config import (
     MAX_PREVIEW_PORT,
     MIN_PREVIEW_PORT,
     _derive_sandbox_host,
+    _region_from_api_key,
     data_plane_target,
     preview_url,
     resolve_config,
@@ -53,6 +54,80 @@ class TestResolveConfig:
         monkeypatch.delenv("SUPERSERVE_BASE_URL", raising=False)
         cfg = resolve_config()
         assert cfg.base_url == DEFAULT_BASE_URL
+
+
+class TestRegionDerivation:
+    @pytest.fixture(autouse=True)
+    def _no_base_url_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SUPERSERVE_BASE_URL", raising=False)
+
+    def test_known_region_key_resolves_mapped_endpoints(self) -> None:
+        cfg = resolve_config(api_key="ss_live_use_abc123")
+        assert cfg.base_url == "https://api.superserve.ai"
+        assert cfg.sandbox_host == "sandbox.superserve.ai"
+
+    def test_unknown_region_falls_back_to_default(self) -> None:
+        # `usw` won't enter the known-regions map until its DNS is live.
+        cfg = resolve_config(api_key="ss_live_usw_abc123")
+        assert cfg.base_url == DEFAULT_BASE_URL
+        assert cfg.sandbox_host == DEFAULT_SANDBOX_HOST
+
+    def test_legacy_key_uses_default(self) -> None:
+        cfg = resolve_config(api_key="ss_live_a1B2c3D4")
+        assert cfg.base_url == DEFAULT_BASE_URL
+        assert cfg.sandbox_host == DEFAULT_SANDBOX_HOST
+
+    def test_legacy_key_with_underscore_collision_uses_default(self) -> None:
+        # Legacy base64url random parts may contain `_`, so this key parses
+        # as region "abc123" — not in the map, so defaults win, which is
+        # correct for all legacy keys (they are all us-east).
+        cfg = resolve_config(api_key="ss_live_abc123_def456")
+        assert cfg.base_url == DEFAULT_BASE_URL
+        assert cfg.sandbox_host == DEFAULT_SANDBOX_HOST
+
+    def test_explicit_base_url_beats_region(self) -> None:
+        cfg = resolve_config(
+            api_key="ss_live_use_abc123", base_url="https://arg.example.com"
+        )
+        assert cfg.base_url == "https://arg.example.com"
+        assert cfg.sandbox_host == DEFAULT_SANDBOX_HOST
+
+    def test_env_base_url_beats_region(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SUPERSERVE_BASE_URL", "https://env.example.com")
+        cfg = resolve_config(api_key="ss_live_use_abc123")
+        assert cfg.base_url == "https://env.example.com"
+
+
+class TestRegionFromApiKey:
+    @pytest.mark.parametrize(
+        ("key", "region"),
+        [
+            ("ss_live_use_abc123", "use"),
+            ("ss_live_usw_abc123", "usw"),
+            ("ss_live_a_b", "a"),
+            ("ss_live_" + "a" * 17 + "_rest", "a" * 17),
+        ],
+    )
+    def test_extracts_valid_region_tokens(self, key: str, region: str) -> None:
+        assert _region_from_api_key(key) == region
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "ss_live_a1B2c3D4",  # legacy: no second segment
+            "ss_live_USE_abc",  # uppercase is not a region token
+            "ss_live_us-e_abc",  # non-alphanumeric
+            "ss_live_" + "a" * 18 + "_rest",  # too long
+            "ss_live_use_",  # nothing after the region
+            "ss_live__abc",  # empty region
+            "ss_test_use_abc",  # wrong prefix
+            "ss_live_",
+            "",
+            "not a key",
+        ],
+    )
+    def test_returns_none_for_legacy_or_weird_keys(self, key: str) -> None:
+        assert _region_from_api_key(key) is None
 
 
 class TestDeriveSandboxHost:

--- a/packages/python-sdk/tests/test_config.py
+++ b/packages/python-sdk/tests/test_config.py
@@ -56,51 +56,62 @@ class TestResolveConfig:
         assert cfg.base_url == DEFAULT_BASE_URL
 
 
+# A realistic 32-char base64url random tail, matching the length every
+# ``ss_live_`` key (legacy or region-tagged) is minted with. Test keys are
+# built from this so the exact-length anchor in `_REGION_KEY_RE` is
+# actually exercised instead of trivially failing on a too-short fixture.
+_TAIL = "AbCdEfGhIjKlMnOpQrStUvWxYz012345"
+assert len(_TAIL) == 32
+
+
 class TestRegionDerivation:
     @pytest.fixture(autouse=True)
     def _no_base_url_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("SUPERSERVE_BASE_URL", raising=False)
 
     def test_known_region_key_resolves_mapped_endpoints(self) -> None:
-        cfg = resolve_config(api_key="ss_live_use_abc123")
+        cfg = resolve_config(api_key=f"ss_live_use_{_TAIL}")
         assert cfg.base_url == "https://api.superserve.ai"
         assert cfg.sandbox_host == "sandbox.superserve.ai"
 
     def test_unknown_region_falls_back_to_default(self) -> None:
         # `usw` won't enter the known-regions map until its DNS is live.
-        cfg = resolve_config(api_key="ss_live_usw_abc123")
+        cfg = resolve_config(api_key=f"ss_live_usw_{_TAIL}")
         assert cfg.base_url == DEFAULT_BASE_URL
         assert cfg.sandbox_host == DEFAULT_SANDBOX_HOST
 
     def test_legacy_key_uses_default(self) -> None:
-        cfg = resolve_config(api_key="ss_live_a1B2c3D4")
+        cfg = resolve_config(api_key=f"ss_live_{_TAIL}")
         assert cfg.base_url == DEFAULT_BASE_URL
         assert cfg.sandbox_host == DEFAULT_SANDBOX_HOST
 
-    def test_legacy_key_with_underscore_collision_uses_default(self) -> None:
-        # Legacy base64url random parts may contain `_`, so this key parses
-        # as region "abc123" — not in the map, so defaults win, which is
-        # correct for all legacy keys (they are all us-east).
-        cfg = resolve_config(api_key="ss_live_abc123_def456")
+    def test_legacy_key_whose_tail_starts_like_a_region_uses_default(self) -> None:
+        # A legacy key's random tail is exactly 32 chars, same as a real
+        # key's tail. Even when it happens to start with "usw_", there's no
+        # length left over for a genuine `<region>_<32-char-tail>` — so it
+        # can never be misparsed as region-tagged, regardless of what's in
+        # `_KNOWN_REGIONS`. Correct for every legacy key (they are all
+        # us-east).
+        cfg = resolve_config(api_key=f"ss_live_usw_{_TAIL[:28]}")
         assert cfg.base_url == DEFAULT_BASE_URL
         assert cfg.sandbox_host == DEFAULT_SANDBOX_HOST
 
     def test_explicit_base_url_beats_region(self) -> None:
         cfg = resolve_config(
-            api_key="ss_live_use_abc123", base_url="https://arg.example.com"
+            api_key=f"ss_live_use_{_TAIL}", base_url="https://arg.example.com"
         )
         assert cfg.base_url == "https://arg.example.com"
         assert cfg.sandbox_host == DEFAULT_SANDBOX_HOST
 
     def test_env_base_url_beats_region(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("SUPERSERVE_BASE_URL", "https://env.example.com")
-        cfg = resolve_config(api_key="ss_live_use_abc123")
+        cfg = resolve_config(api_key=f"ss_live_use_{_TAIL}")
         assert cfg.base_url == "https://env.example.com"
 
     def test_region_key_sourced_from_env_var(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setenv("SUPERSERVE_API_KEY", "ss_live_use_abc123")
+        monkeypatch.setenv("SUPERSERVE_API_KEY", f"ss_live_use_{_TAIL}")
         cfg = resolve_config()
         assert cfg.base_url == "https://api.superserve.ai"
         assert cfg.sandbox_host == "sandbox.superserve.ai"
@@ -110,10 +121,10 @@ class TestRegionFromApiKey:
     @pytest.mark.parametrize(
         ("key", "region"),
         [
-            ("ss_live_use_abc123", "use"),
-            ("ss_live_usw_abc123", "usw"),
-            ("ss_live_a_b", "a"),
-            ("ss_live_" + "a" * 17 + "_rest", "a" * 17),
+            (f"ss_live_use_{_TAIL}", "use"),
+            (f"ss_live_usw_{_TAIL}", "usw"),
+            (f"ss_live_a_{_TAIL}", "a"),
+            ("ss_live_" + "a" * 17 + "_" + _TAIL, "a" * 17),
         ],
     )
     def test_extracts_valid_region_tokens(self, key: str, region: str) -> None:
@@ -122,13 +133,16 @@ class TestRegionFromApiKey:
     @pytest.mark.parametrize(
         "key",
         [
-            "ss_live_a1B2c3D4",  # legacy: no second segment
-            "ss_live_USE_abc",  # uppercase is not a region token
-            "ss_live_us-e_abc",  # non-alphanumeric
-            "ss_live_" + "a" * 18 + "_rest",  # too long
+            f"ss_live_{_TAIL}",  # legacy: no region segment
+            f"ss_live_usw_{_TAIL[:28]}",  # legacy tail that starts like "usw_"
+            f"ss_live_USE_{_TAIL}",  # uppercase is not a region token
+            f"ss_live_us-e_{_TAIL}",  # non-alphanumeric
+            "ss_live_" + "a" * 18 + "_" + _TAIL,  # region too long
+            f"ss_live_use_{_TAIL[:31]}",  # tail one char short of 32
+            f"ss_live_use_{_TAIL}X",  # tail one char over 32
             "ss_live_use_",  # nothing after the region
-            "ss_live__abc",  # empty region
-            "ss_test_use_abc",  # wrong prefix
+            f"ss_live__{_TAIL}",  # empty region
+            "ss_test_use_" + _TAIL,  # wrong prefix
             "ss_live_",
             "",
             "not a key",

--- a/packages/python-sdk/tests/test_config.py
+++ b/packages/python-sdk/tests/test_config.py
@@ -97,6 +97,14 @@ class TestRegionDerivation:
         cfg = resolve_config(api_key="ss_live_use_abc123")
         assert cfg.base_url == "https://env.example.com"
 
+    def test_region_key_sourced_from_env_var(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SUPERSERVE_API_KEY", "ss_live_use_abc123")
+        cfg = resolve_config()
+        assert cfg.base_url == "https://api.superserve.ai"
+        assert cfg.sandbox_host == "sandbox.superserve.ai"
+
 
 class TestRegionFromApiKey:
     @pytest.mark.parametrize(

--- a/packages/sdk/src/config.ts
+++ b/packages/sdk/src/config.ts
@@ -10,6 +10,37 @@ import { AuthenticationError, ValidationError } from "./errors.js"
 const DEFAULT_BASE_URL = "https://api.superserve.ai"
 const DEFAULT_SANDBOX_HOST = "sandbox.superserve.ai"
 
+/**
+ * Known Superserve regions, keyed by the region token embedded in API keys
+ * (`ss_live_<region>_<random>`).
+ *
+ * Only regions whose DNS is live may be listed here: the SDK must never
+ * construct a hostname before that region's endpoints exist. `usw` will be
+ * added once `https://api-usw.superserve.ai` / `usw-sandbox.superserve.ai`
+ * are up.
+ *
+ * Legacy keys (`ss_live_<random>`, whose base64url random part may itself
+ * contain `_`) can coincidentally parse as having a region segment. That is
+ * harmless by design: any token not in this map falls back to the defaults,
+ * which is correct for every legacy key (they are all us-east).
+ */
+const KNOWN_REGIONS: ReadonlyMap<
+  string,
+  { baseUrl: string; sandboxHost: string }
+> = new Map([
+  [
+    "use",
+    {
+      baseUrl: "https://api.superserve.ai",
+      sandboxHost: "sandbox.superserve.ai",
+    },
+  ],
+])
+
+// Region token in `ss_live_<region>_<random>`: 1-17 lowercase alphanumeric
+// chars, followed by at least one more character of key material.
+const REGION_KEY_RE = /^ss_live_([a-z0-9]{1,17})_./
+
 export interface ResolvedConfig {
   apiKey: string
   baseUrl: string
@@ -20,6 +51,9 @@ export interface ResolvedConfig {
  * Resolve connection config from explicit options + environment variables.
  *
  * Priority: explicit option > SUPERSERVE_API_KEY / SUPERSERVE_BASE_URL env vars.
+ * Base URL priority continues: region derived from the API key via
+ * `KNOWN_REGIONS` > `DEFAULT_BASE_URL`. The sandbox host follows the same
+ * source (derived from the override URL, or taken from the region map).
  * Throws if no API key can be resolved.
  */
 export function resolveConfig(opts?: {
@@ -32,10 +66,38 @@ export function resolveConfig(opts?: {
       "Missing API key. Pass `apiKey` or set the SUPERSERVE_API_KEY environment variable.",
     )
   }
-  const baseUrl =
-    opts?.baseUrl ?? process.env.SUPERSERVE_BASE_URL ?? DEFAULT_BASE_URL
-  const sandboxHost = deriveSandboxHost(baseUrl)
-  return { apiKey, baseUrl, sandboxHost }
+  const overrideUrl = opts?.baseUrl ?? process.env.SUPERSERVE_BASE_URL
+  if (overrideUrl !== undefined) {
+    return {
+      apiKey,
+      baseUrl: overrideUrl,
+      sandboxHost: deriveSandboxHost(overrideUrl),
+    }
+  }
+  const region = regionFromApiKey(apiKey)
+  const endpoints = region !== undefined ? KNOWN_REGIONS.get(region) : undefined
+  if (endpoints !== undefined) {
+    return {
+      apiKey,
+      baseUrl: endpoints.baseUrl,
+      sandboxHost: endpoints.sandboxHost,
+    }
+  }
+  return {
+    apiKey,
+    baseUrl: DEFAULT_BASE_URL,
+    sandboxHost: DEFAULT_SANDBOX_HOST,
+  }
+}
+
+/**
+ * Extract the candidate region token from an API key, if any.
+ *
+ * Returns `undefined` for legacy keys and anything else that doesn't match
+ * `ss_live_<region>_<random>`. Never throws on weird keys.
+ */
+function regionFromApiKey(apiKey: string): string | undefined {
+  return REGION_KEY_RE.exec(apiKey)?.[1]
 }
 
 // Sandbox hosts where the proxy supports shared-host routing.

--- a/packages/sdk/src/config.ts
+++ b/packages/sdk/src/config.ts
@@ -14,10 +14,12 @@ const DEFAULT_SANDBOX_HOST = "sandbox.superserve.ai"
  * Known Superserve regions, keyed by the region token embedded in API keys
  * (`ss_live_<region>_<random>`).
  *
- * Only regions whose DNS is live may be listed here: the SDK must never
- * construct a hostname before that region's endpoints exist. `usw` will be
- * added once `https://api-usw.superserve.ai` / `usw-sandbox.superserve.ai`
- * are up.
+ * A region may be listed here only once its endpoints ACTUALLY SERVE THE
+ * API — DNS resolving is not the bar: superserve.ai has a catch-all
+ * wildcard, so every derived hostname resolves and answers with a
+ * valid-TLS 404 from the wrong infrastructure. Verify with a live /health
+ * check, not dig. `usw` will be added once `https://api-usw.superserve.ai`
+ * / `usw-sandbox.superserve.ai` serve their cell.
  *
  * Legacy keys (`ss_live_<random>`, whose base64url random part may itself
  * contain `_`) can coincidentally parse as having a region segment. That is

--- a/packages/sdk/src/config.ts
+++ b/packages/sdk/src/config.ts
@@ -21,10 +21,13 @@ const DEFAULT_SANDBOX_HOST = "sandbox.superserve.ai"
  * check, not dig. `usw` will be added once `https://api-usw.superserve.ai`
  * / `usw-sandbox.superserve.ai` serve their cell.
  *
- * Legacy keys (`ss_live_<random>`, whose base64url random part may itself
- * contain `_`) can coincidentally parse as having a region segment. That is
- * harmless by design: any token not in this map falls back to the defaults,
- * which is correct for every legacy key (they are all us-east).
+ * Legacy keys (`ss_live_<random>`) can never be misread as region-tagged:
+ * both key formats embed the same fixed-length 32-char base64url random
+ * tail (from `crypto.randomBytes(24)`), and `REGION_KEY_RE` requires that
+ * exact tail length anchored to the end of the string. A legacy key has no
+ * room left over for a region segment on top of its own 32-char tail, so no
+ * random legacy key can ever collide with a real region token — this holds
+ * regardless of how many regions `KNOWN_REGIONS` ends up containing.
  */
 const KNOWN_REGIONS: ReadonlyMap<
   string,
@@ -40,8 +43,10 @@ const KNOWN_REGIONS: ReadonlyMap<
 ])
 
 // Region token in `ss_live_<region>_<random>`: 1-17 lowercase alphanumeric
-// chars, followed by at least one more character of key material.
-const REGION_KEY_RE = /^ss_live_([a-z0-9]{1,17})_./
+// chars, then `_`, then exactly the 32-char base64url tail every key is
+// minted with — anchored to the end so a legacy key's own tail can never be
+// mistaken for `<region>_<tail>`.
+const REGION_KEY_RE = /^ss_live_([a-z0-9]{1,17})_[A-Za-z0-9_-]{32}$/
 
 export interface ResolvedConfig {
   apiKey: string
@@ -93,10 +98,10 @@ export function resolveConfig(opts?: {
 }
 
 /**
- * Extract the candidate region token from an API key, if any.
+ * Extract the region token from an API key, if any.
  *
  * Returns `undefined` for legacy keys and anything else that doesn't match
- * `ss_live_<region>_<random>`. Never throws on weird keys.
+ * `ss_live_<region>_<random-32-char-base64url>`. Never throws on weird keys.
  */
 function regionFromApiKey(apiKey: string): string | undefined {
   return REGION_KEY_RE.exec(apiKey)?.[1]

--- a/packages/sdk/tests/config.test.ts
+++ b/packages/sdk/tests/config.test.ts
@@ -88,6 +88,66 @@ describe("resolveConfig", () => {
     })
     expect(cfg.sandboxHost).toBe("sandbox.superserve.ai")
   })
+
+  it("derives endpoints from a known region key", () => {
+    const cfg = resolveConfig({ apiKey: "ss_live_use_abc123" })
+    expect(cfg.baseUrl).toBe("https://api.superserve.ai")
+    expect(cfg.sandboxHost).toBe("sandbox.superserve.ai")
+  })
+
+  it("falls back to defaults for an unknown region", () => {
+    // `usw` won't enter the known-regions map until its DNS is live.
+    const cfg = resolveConfig({ apiKey: "ss_live_usw_abc123" })
+    expect(cfg.baseUrl).toBe("https://api.superserve.ai")
+    expect(cfg.sandboxHost).toBe("sandbox.superserve.ai")
+  })
+
+  it("falls back to defaults for legacy keys", () => {
+    const cfg = resolveConfig({ apiKey: "ss_live_a1B2c3D4" })
+    expect(cfg.baseUrl).toBe("https://api.superserve.ai")
+    expect(cfg.sandboxHost).toBe("sandbox.superserve.ai")
+  })
+
+  it("falls back to defaults for a legacy key whose `_` mimics a region", () => {
+    // Legacy base64url random parts may contain `_`, so this parses as
+    // region "abc123" — not in the map, so defaults win, which is correct
+    // for all legacy keys (they are all us-east).
+    const cfg = resolveConfig({ apiKey: "ss_live_abc123_def456" })
+    expect(cfg.baseUrl).toBe("https://api.superserve.ai")
+    expect(cfg.sandboxHost).toBe("sandbox.superserve.ai")
+  })
+
+  it("never resolves a region from prototype members or weird keys", () => {
+    for (const apiKey of [
+      "ss_live_constructor_x",
+      "ss_live_USE_abc", // uppercase is not a region token
+      "ss_live_us-e_abc", // non-alphanumeric
+      `ss_live_${"a".repeat(18)}_rest`, // too long
+      "ss_live_use_", // nothing after the region
+      "ss_live__abc", // empty region
+      "ss_live_",
+      "not a key",
+    ]) {
+      const cfg = resolveConfig({ apiKey })
+      expect(cfg.baseUrl).toBe("https://api.superserve.ai")
+      expect(cfg.sandboxHost).toBe("sandbox.superserve.ai")
+    }
+  })
+
+  it("uses explicit baseUrl over region derivation", () => {
+    const cfg = resolveConfig({
+      apiKey: "ss_live_use_abc123",
+      baseUrl: "https://explicit.example.com",
+    })
+    expect(cfg.baseUrl).toBe("https://explicit.example.com")
+    expect(cfg.sandboxHost).toBe("sandbox.superserve.ai")
+  })
+
+  it("uses SUPERSERVE_BASE_URL env var over region derivation", () => {
+    vi.stubEnv("SUPERSERVE_BASE_URL", "https://env.example.com")
+    const cfg = resolveConfig({ apiKey: "ss_live_use_abc123" })
+    expect(cfg.baseUrl).toBe("https://env.example.com")
+  })
 })
 
 describe("dataPlaneTarget", () => {

--- a/packages/sdk/tests/config.test.ts
+++ b/packages/sdk/tests/config.test.ts
@@ -9,6 +9,12 @@ import {
 } from "../src/config.js"
 import { AuthenticationError, ValidationError } from "../src/errors.js"
 
+// A realistic 32-char base64url random tail, matching the length every
+// `ss_live_` key (legacy or region-tagged) is minted with. Test keys are
+// built from this so the exact-length anchor in `REGION_KEY_RE` is
+// actually exercised instead of trivially failing on a too-short fixture.
+const TAIL = "AbCdEfGhIjKlMnOpQrStUvWxYz012345"
+
 describe("resolveConfig", () => {
   let savedApiKey: string | undefined
   let savedBaseUrl: string | undefined
@@ -90,41 +96,45 @@ describe("resolveConfig", () => {
   })
 
   it("derives endpoints from a known region key", () => {
-    const cfg = resolveConfig({ apiKey: "ss_live_use_abc123" })
+    const cfg = resolveConfig({ apiKey: `ss_live_use_${TAIL}` })
     expect(cfg.baseUrl).toBe("https://api.superserve.ai")
     expect(cfg.sandboxHost).toBe("sandbox.superserve.ai")
   })
 
   it("falls back to defaults for an unknown region", () => {
     // `usw` won't enter the known-regions map until its DNS is live.
-    const cfg = resolveConfig({ apiKey: "ss_live_usw_abc123" })
+    const cfg = resolveConfig({ apiKey: `ss_live_usw_${TAIL}` })
     expect(cfg.baseUrl).toBe("https://api.superserve.ai")
     expect(cfg.sandboxHost).toBe("sandbox.superserve.ai")
   })
 
   it("falls back to defaults for legacy keys", () => {
-    const cfg = resolveConfig({ apiKey: "ss_live_a1B2c3D4" })
+    const cfg = resolveConfig({ apiKey: `ss_live_${TAIL}` })
     expect(cfg.baseUrl).toBe("https://api.superserve.ai")
     expect(cfg.sandboxHost).toBe("sandbox.superserve.ai")
   })
 
-  it("falls back to defaults for a legacy key whose `_` mimics a region", () => {
-    // Legacy base64url random parts may contain `_`, so this parses as
-    // region "abc123" — not in the map, so defaults win, which is correct
-    // for all legacy keys (they are all us-east).
-    const cfg = resolveConfig({ apiKey: "ss_live_abc123_def456" })
+  it("falls back to defaults for a legacy key whose tail starts like a region", () => {
+    // A legacy key's random tail is exactly 32 chars, same as a real key's
+    // tail. Even when it happens to start with "usw_", there's no length
+    // left over for a genuine `<region>_<32-char-tail>` — so it can never
+    // be misparsed as region-tagged, regardless of what's in
+    // `KNOWN_REGIONS`. Correct for every legacy key (they are all us-east).
+    const cfg = resolveConfig({ apiKey: `ss_live_usw_${TAIL.slice(0, 28)}` })
     expect(cfg.baseUrl).toBe("https://api.superserve.ai")
     expect(cfg.sandboxHost).toBe("sandbox.superserve.ai")
   })
 
   it("never resolves a region from prototype members or weird keys", () => {
     for (const apiKey of [
-      "ss_live_constructor_x",
-      "ss_live_USE_abc", // uppercase is not a region token
-      "ss_live_us-e_abc", // non-alphanumeric
-      `ss_live_${"a".repeat(18)}_rest`, // too long
+      `ss_live_constructor_${TAIL}`,
+      `ss_live_USE_${TAIL}`, // uppercase is not a region token
+      `ss_live_us-e_${TAIL}`, // non-alphanumeric
+      `ss_live_${"a".repeat(18)}_${TAIL}`, // region too long
+      `ss_live_use_${TAIL.slice(0, 31)}`, // tail one char short of 32
+      `ss_live_use_${TAIL}X`, // tail one char over 32
       "ss_live_use_", // nothing after the region
-      "ss_live__abc", // empty region
+      `ss_live__${TAIL}`, // empty region
       "ss_live_",
       "not a key",
     ]) {
@@ -136,7 +146,7 @@ describe("resolveConfig", () => {
 
   it("uses explicit baseUrl over region derivation", () => {
     const cfg = resolveConfig({
-      apiKey: "ss_live_use_abc123",
+      apiKey: `ss_live_use_${TAIL}`,
       baseUrl: "https://explicit.example.com",
     })
     expect(cfg.baseUrl).toBe("https://explicit.example.com")
@@ -145,12 +155,12 @@ describe("resolveConfig", () => {
 
   it("uses SUPERSERVE_BASE_URL env var over region derivation", () => {
     vi.stubEnv("SUPERSERVE_BASE_URL", "https://env.example.com")
-    const cfg = resolveConfig({ apiKey: "ss_live_use_abc123" })
+    const cfg = resolveConfig({ apiKey: `ss_live_use_${TAIL}` })
     expect(cfg.baseUrl).toBe("https://env.example.com")
   })
 
   it("derives endpoints from a region key sourced from SUPERSERVE_API_KEY", () => {
-    vi.stubEnv("SUPERSERVE_API_KEY", "ss_live_use_abc123")
+    vi.stubEnv("SUPERSERVE_API_KEY", `ss_live_use_${TAIL}`)
     const cfg = resolveConfig()
     expect(cfg.baseUrl).toBe("https://api.superserve.ai")
     expect(cfg.sandboxHost).toBe("sandbox.superserve.ai")

--- a/packages/sdk/tests/config.test.ts
+++ b/packages/sdk/tests/config.test.ts
@@ -148,6 +148,13 @@ describe("resolveConfig", () => {
     const cfg = resolveConfig({ apiKey: "ss_live_use_abc123" })
     expect(cfg.baseUrl).toBe("https://env.example.com")
   })
+
+  it("derives endpoints from a region key sourced from SUPERSERVE_API_KEY", () => {
+    vi.stubEnv("SUPERSERVE_API_KEY", "ss_live_use_abc123")
+    const cfg = resolveConfig()
+    expect(cfg.baseUrl).toBe("https://api.superserve.ai")
+    expect(cfg.sandboxHost).toBe("sandbox.superserve.ai")
+  })
 })
 
 describe("dataPlaneTarget", () => {


### PR DESCRIPTION
SDKs (TypeScript + Python) now derive the API endpoint client-side from the region token in `ss_live_<region>_<random>` API keys, via a known-regions map. This lets multi-region keys route to the right cell with zero configuration, part of the multi-region cell work.

**Technical decisions**
- Known-regions map instead of generic hostname derivation: an SDK must never construct a hostname before that region's DNS exists, so the map ships containing only live regions (`use` for now; `usw` lands once `api-usw.superserve.ai` / `usw-sandbox.superserve.ai` are up).
- Precedence, strictly: explicit `base_url`/`baseUrl` > `SUPERSERVE_BASE_URL` > region derived from the key > default. Sandbox host follows the same source.
- Legacy-key `_` collision is safe by design: legacy base64url randoms may contain `_`, so a legacy key can parse as having a "region" — any token not in the map falls back to the default endpoint, which is correct for every legacy key (all us-east). Region tokens are 1-17 lowercase alnum chars; parsing never throws.

**Testing**
- `packages/sdk`: `bun run test` (210 passed), `bun run typecheck`, `bun run lint` — all clean.
- `packages/python-sdk`: `uv run pytest` (281 passed), `uv run ruff check`, `uv run mypy` — all clean.
- New tests in both SDKs cover legacy keys, `use` keys, unknown regions, `_`-collision keys, weird/never-throw keys, and the full precedence order (plus prototype-member safety on the TS side via `Map`).