### PR TITLE
console: server-side pagination, sorting & filtering for sandboxes and templates

### DIFF
--- a/apps/console/src/app/(dashboard)/sandboxes/page.tsx
+++ b/apps/console/src/app/(dashboard)/sandboxes/page.tsx
@@ -46,7 +46,7 @@ import {
   useSandboxesPage,
 } from "@/hooks/use-sandboxes"
 import { useSelection } from "@/hooks/use-selection"
-import type { SandboxListParams, SandboxSortColumn } from "@/lib/api/types"
+import { SANDBOX_SORT_COLUMNS, type SandboxListParams } from "@/lib/api/types"
 import { SANDBOX_EVENTS } from "@/lib/posthog/events"
 
 const STATUS_TABS = [
@@ -72,14 +72,22 @@ function SandboxesPageContent() {
     setPage,
     setPageSize,
     setSearch,
-  } = useListParams({ defaultSort: "created_at" })
+  } = useListParams({
+    columns: SANDBOX_SORT_COLUMNS,
+    defaultSort: "created_at",
+  })
 
-  const statusTab = searchParams.get("status") ?? "all"
+  // URL param is user input — an unknown status falls back to "all" instead of
+  // being forwarded to the API.
+  const rawStatus = searchParams.get("status")
+  const statusTab = STATUS_TABS.some((t) => t.value === rawStatus)
+    ? (rawStatus as string)
+    : "all"
 
   const params: SandboxListParams = {
     page,
     pageSize,
-    sort: sort as SandboxSortColumn,
+    sort,
     order,
     status: statusTab === "all" ? undefined : statusTab,
     q: debouncedQ || undefined,
@@ -135,16 +143,23 @@ function SandboxesPageContent() {
     if (total > 0 && page > pageCount) setPage(pageCount)
   }, [total, page, pageCount, setPage])
 
-  // Selection is scoped to the current view — clear it when the page, filter, or
-  // search changes so a bulk action can't hit rows that scrolled off-page.
+  // Selection is scoped to the current view — clear it when anything that
+  // changes the visible row set (page, page size, sort, filter, search)
+  // changes, so a bulk action can't hit rows that scrolled off-page.
   useEffect(() => {
     clearSelection()
-  }, [page, statusTab, debouncedQ, clearSelection])
+  }, [page, pageSize, sort, order, statusTab, debouncedQ, clearSelection])
 
-  const hasFilters = statusTab !== "all" || q !== ""
+  // Uses debouncedQ (what the current data was fetched with), not q: clearing a
+  // zero-result search would otherwise flash the account-level empty state for
+  // the 300ms until the unfiltered refetch lands.
+  const hasFilters = statusTab !== "all" || debouncedQ !== ""
   // A truly empty account (no sandboxes at all) gets the create call-to-action.
   // A zero-result filter/search keeps the toolbar so the user can clear it.
-  const isEmpty = !isPending && !error && total === 0 && !hasFilters
+  // Placeholder data is a stale page shown during a params change — never treat
+  // its total as proof the account is empty.
+  const isEmpty =
+    !isPending && !error && !isPlaceholderData && total === 0 && !hasFilters
 
   return (
     <div className="flex h-full flex-col">

--- a/apps/console/src/app/(dashboard)/sandboxes/page.tsx
+++ b/apps/console/src/app/(dashboard)/sandboxes/page.tsx
@@ -15,6 +15,7 @@ export default function SandboxesPage() {
 import { CubeIcon } from "@phosphor-icons/react"
 import {
   Checkbox,
+  cn,
   Table,
   TableHead,
   TableHeader,
@@ -22,26 +23,30 @@ import {
 } from "@superserve/ui"
 import { useRouter, useSearchParams } from "next/navigation"
 import { usePostHog } from "posthog-js/react"
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useState } from "react"
 
 import { EmptyState } from "@/components/empty-state"
 import { ErrorState } from "@/components/error-state"
 import { PageHeader } from "@/components/page-header"
+import { Pagination } from "@/components/pagination"
 import { ConnectSandboxDialog } from "@/components/sandboxes/connect-sandbox-dialog"
 import { CreateSandboxDialog } from "@/components/sandboxes/create-sandbox-dialog"
 import { DeleteSandboxDialog } from "@/components/sandboxes/delete-sandbox-dialog"
 import { SandboxTableRow } from "@/components/sandboxes/sandbox-table-row"
+import { SortableTableHead } from "@/components/sortable-table-head"
 import { StickyHoverTableBody } from "@/components/sticky-hover-table"
 import { TableToolbar } from "@/components/table-toolbar"
 import { useCreateParam } from "@/hooks/use-create-param"
+import { useListParams } from "@/hooks/use-list-params"
 import {
   useBulkDeleteSandboxes,
   useDeleteSandbox,
   usePauseSandbox,
   useResumeSandbox,
-  useSandboxes,
+  useSandboxesPage,
 } from "@/hooks/use-sandboxes"
 import { useSelection } from "@/hooks/use-selection"
+import type { SandboxListParams, SandboxSortColumn } from "@/lib/api/types"
 import { SANDBOX_EVENTS } from "@/lib/posthog/events"
 
 const STATUS_TABS = [
@@ -54,22 +59,32 @@ function SandboxesPageContent() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const posthog = usePostHog()
-  const statusFilter = searchParams.get("status") ?? "all"
-  const search = searchParams.get("q") ?? ""
 
-  const setStatusFilter = (value: string) => {
-    const params = new URLSearchParams(searchParams.toString())
-    if (value === "all") params.delete("status")
-    else params.set("status", value)
-    router.replace(`?${params.toString()}`)
+  const {
+    page,
+    pageSize,
+    sort,
+    order,
+    q,
+    debouncedQ,
+    setParam,
+    toggleSort,
+    setPage,
+    setPageSize,
+    setSearch,
+  } = useListParams({ defaultSort: "created_at" })
+
+  const statusTab = searchParams.get("status") ?? "all"
+
+  const params: SandboxListParams = {
+    page,
+    pageSize,
+    sort: sort as SandboxSortColumn,
+    order,
+    status: statusTab === "all" ? undefined : statusTab,
+    q: debouncedQ || undefined,
   }
 
-  const setSearch = (value: string) => {
-    const params = new URLSearchParams(searchParams.toString())
-    if (!value) params.delete("q")
-    else params.set("q", value)
-    router.replace(`?${params.toString()}`)
-  }
   const [createOpen, setCreateOpen] = useCreateParam()
   const [connectSandboxId, setConnectSandboxId] = useState<string | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<{
@@ -87,35 +102,21 @@ function SandboxesPageContent() {
     if (!name) return
     setTemplateRef(name)
     setCreateOpen(true)
-    const params = new URLSearchParams(searchParams.toString())
-    params.delete("from_template")
-    const qs = params.toString()
+    const next = new URLSearchParams(searchParams.toString())
+    next.delete("from_template")
+    const qs = next.toString()
     router.replace(qs ? `?${qs}` : window.location.pathname)
   }, [searchParams, router, setCreateOpen])
 
-  const { data: sandboxes = [], isPending, error, refetch } = useSandboxes()
+  const { data, isPending, error, refetch, isPlaceholderData } =
+    useSandboxesPage(params)
+  const sandboxes = data?.items ?? []
+  const total = data?.total ?? 0
+
   const deleteSandbox = useDeleteSandbox()
   const bulkDelete = useBulkDeleteSandboxes()
   const pauseMutation = usePauseSandbox()
   const resumeMutation = useResumeSandbox()
-
-  const filtered = useMemo(() => {
-    return sandboxes.filter((s) => {
-      if (statusFilter !== "all" && s.status !== statusFilter) return false
-      if (search && !s.name.toLowerCase().includes(search.toLowerCase()))
-        return false
-      return true
-    })
-  }, [sandboxes, statusFilter, search])
-
-  // oxlint-disable-next-line no-map-spread -- small static array; clarity > micro-perf
-  const tabs = STATUS_TABS.map((tab) => ({
-    ...tab,
-    count:
-      tab.value === "all"
-        ? sandboxes.length
-        : sandboxes.filter((s) => s.status === tab.value).length,
-  }))
 
   const {
     selected,
@@ -124,9 +125,12 @@ function SandboxesPageContent() {
     toggleAll,
     toggleOne,
     clearSelection,
-  } = useSelection(filtered)
+  } = useSelection(sandboxes)
 
-  const isEmpty = !isPending && !error && sandboxes.length === 0
+  const hasFilters = statusTab !== "all" || q !== ""
+  // A truly empty account (no sandboxes at all) gets the create call-to-action.
+  // A zero-result filter/search keeps the toolbar so the user can clear it.
+  const isEmpty = !isPending && !error && total === 0 && !hasFilters
 
   return (
     <div className="flex h-full flex-col">
@@ -158,78 +162,114 @@ function SandboxesPageContent() {
       ) : (
         <>
           <TableToolbar
-            tabs={tabs}
-            activeTab={statusFilter}
-            onTabChange={setStatusFilter}
+            tabs={STATUS_TABS}
+            activeTab={statusTab}
+            onTabChange={(v) => setParam({ status: v === "all" ? null : v })}
             searchPlaceholder="Search sandboxes..."
-            searchValue={search}
+            searchValue={q}
             onSearchChange={setSearch}
             selectedCount={selected.size}
             onClearSelection={clearSelection}
             onDeleteSelected={() => setBulkDeleteOpen(true)}
           />
 
-          <div className="flex-1 overflow-y-auto">
-            <Table>
-              <TableHeader className="sticky top-0 z-10 bg-background/70 backdrop-blur-md">
-                <TableRow>
-                  <TableHead className="w-10 pr-0">
-                    <Checkbox
-                      checked={allSelected}
-                      indeterminate={someSelected && !allSelected}
-                      onCheckedChange={toggleAll}
-                      aria-label="Select all sandboxes"
+          <div
+            className={cn(
+              "flex-1 overflow-y-auto transition-opacity",
+              isPlaceholderData && "opacity-60",
+            )}
+          >
+            {sandboxes.length === 0 ? (
+              <EmptyState
+                icon={CubeIcon}
+                title="No sandboxes match"
+                description="Try a different search term or status filter."
+              />
+            ) : (
+              <Table>
+                <TableHeader className="sticky top-0 z-10 bg-background/70 backdrop-blur-md">
+                  <TableRow>
+                    <TableHead className="w-10 pr-0">
+                      <Checkbox
+                        checked={allSelected}
+                        indeterminate={someSelected && !allSelected}
+                        onCheckedChange={toggleAll}
+                        aria-label="Select all sandboxes"
+                      />
+                    </TableHead>
+                    <SortableTableHead
+                      column="name"
+                      label="Name"
+                      activeSort={sort}
+                      order={order}
+                      onSort={toggleSort}
+                      className="w-[30%]"
                     />
-                  </TableHead>
-                  <TableHead className="w-[30%]">Name</TableHead>
-                  <TableHead className="w-[15%]">Status</TableHead>
-                  {/* <TableHead className="w-[20%]">Snapshot</TableHead> */}
-                  <TableHead className="w-[15%]">Resources</TableHead>
-                  <TableHead className="w-28" />
-                </TableRow>
-              </TableHeader>
-              <StickyHoverTableBody>
-                {filtered.map((sandbox) => (
-                  <SandboxTableRow
-                    key={sandbox.id}
-                    sandbox={sandbox}
-                    selected={selected.has(sandbox.id)}
-                    onToggle={() => toggleOne(sandbox.id)}
-                    onConnect={() => {
-                      posthog.capture(SANDBOX_EVENTS.CONNECT_OPENED, {
-                        sandbox_id: sandbox.id,
-                      })
-                      setConnectSandboxId(sandbox.id)
-                    }}
-                    onDelete={() =>
-                      setDeleteTarget({
-                        id: sandbox.id,
-                        name: sandbox.name,
-                      })
-                    }
-                    onPause={() => {
-                      posthog.capture(SANDBOX_EVENTS.PAUSED, {
-                        sandbox_id: sandbox.id,
-                      })
-                      pauseMutation.mutate(sandbox.id)
-                    }}
-                    onResume={() => {
-                      posthog.capture(SANDBOX_EVENTS.RESUMED, {
-                        sandbox_id: sandbox.id,
-                      })
-                      resumeMutation.mutate(sandbox.id)
-                    }}
-                    onOpenTerminal={() =>
-                      posthog.capture(SANDBOX_EVENTS.TERMINAL_OPENED, {
-                        sandbox_id: sandbox.id,
-                        source: "list_menu",
-                      })
-                    }
-                  />
-                ))}
-              </StickyHoverTableBody>
-            </Table>
+                    <SortableTableHead
+                      column="status"
+                      label="Status"
+                      activeSort={sort}
+                      order={order}
+                      onSort={toggleSort}
+                      className="w-[15%]"
+                    />
+                    <TableHead className="w-[15%]">Resources</TableHead>
+                    <TableHead className="w-28" />
+                  </TableRow>
+                </TableHeader>
+                <StickyHoverTableBody>
+                  {sandboxes.map((sandbox) => (
+                    <SandboxTableRow
+                      key={sandbox.id}
+                      sandbox={sandbox}
+                      selected={selected.has(sandbox.id)}
+                      onToggle={() => toggleOne(sandbox.id)}
+                      onConnect={() => {
+                        posthog.capture(SANDBOX_EVENTS.CONNECT_OPENED, {
+                          sandbox_id: sandbox.id,
+                        })
+                        setConnectSandboxId(sandbox.id)
+                      }}
+                      onDelete={() =>
+                        setDeleteTarget({
+                          id: sandbox.id,
+                          name: sandbox.name,
+                        })
+                      }
+                      onPause={() => {
+                        posthog.capture(SANDBOX_EVENTS.PAUSED, {
+                          sandbox_id: sandbox.id,
+                        })
+                        pauseMutation.mutate(sandbox.id)
+                      }}
+                      onResume={() => {
+                        posthog.capture(SANDBOX_EVENTS.RESUMED, {
+                          sandbox_id: sandbox.id,
+                        })
+                        resumeMutation.mutate(sandbox.id)
+                      }}
+                      onOpenTerminal={() =>
+                        posthog.capture(SANDBOX_EVENTS.TERMINAL_OPENED, {
+                          sandbox_id: sandbox.id,
+                          source: "list_menu",
+                        })
+                      }
+                    />
+                  ))}
+                </StickyHoverTableBody>
+              </Table>
+            )}
           </div>
+
+          {total > 0 && (
+            <Pagination
+              page={page}
+              pageSize={pageSize}
+              total={total}
+              onPageChange={setPage}
+              onPageSizeChange={setPageSize}
+            />
+          )}
         </>
       )}
 

--- a/apps/console/src/app/(dashboard)/sandboxes/page.tsx
+++ b/apps/console/src/app/(dashboard)/sandboxes/page.tsx
@@ -127,6 +127,20 @@ function SandboxesPageContent() {
     clearSelection,
   } = useSelection(sandboxes)
 
+  const pageCount = Math.max(1, Math.ceil(total / pageSize))
+
+  // If the current page falls past the end (e.g. after deleting the last row on
+  // the last page), snap back to the last valid page.
+  useEffect(() => {
+    if (total > 0 && page > pageCount) setPage(pageCount)
+  }, [total, page, pageCount, setPage])
+
+  // Selection is scoped to the current view — clear it when the page, filter, or
+  // search changes so a bulk action can't hit rows that scrolled off-page.
+  useEffect(() => {
+    clearSelection()
+  }, [page, statusTab, debouncedQ, clearSelection])
+
   const hasFilters = statusTab !== "all" || q !== ""
   // A truly empty account (no sandboxes at all) gets the create call-to-action.
   // A zero-result filter/search keeps the toolbar so the user can clear it.

--- a/apps/console/src/app/(dashboard)/templates/page.tsx
+++ b/apps/console/src/app/(dashboard)/templates/page.tsx
@@ -25,10 +25,10 @@ import { TemplateTableRow } from "@/components/templates/template-table-row"
 import { useCreateParam } from "@/hooks/use-create-param"
 import { useListParams } from "@/hooks/use-list-params"
 import { useTemplatesPage } from "@/hooks/use-templates"
-import type {
-  TemplateListParams,
-  TemplateOwnerFilter,
-  TemplateSortColumn,
+import {
+  TEMPLATE_SORT_COLUMNS,
+  type TemplateListParams,
+  type TemplateOwnerFilter,
 } from "@/lib/api/types"
 
 const OWNER_TABS = [
@@ -61,14 +61,21 @@ function TemplatesPageContent() {
     setPage,
     setPageSize,
     setSearch,
-  } = useListParams({ defaultSort: "created_at" })
+  } = useListParams({
+    columns: TEMPLATE_SORT_COLUMNS,
+    defaultSort: "created_at",
+  })
 
-  const owner = (searchParams.get("owner") ?? "all") as TemplateOwnerFilter
+  // URL param is user input — an unknown owner falls back to "all" instead of
+  // being forwarded to the API.
+  const rawOwner = searchParams.get("owner")
+  const owner: TemplateOwnerFilter =
+    rawOwner === "team" || rawOwner === "system" ? rawOwner : "all"
 
   const params: TemplateListParams = {
     page,
     pageSize,
-    sort: sort as TemplateSortColumn,
+    sort,
     order,
     owner,
     q: debouncedQ || undefined,
@@ -86,8 +93,12 @@ function TemplatesPageContent() {
     if (total > 0 && page > pageCount) setPage(pageCount)
   }, [total, page, pageCount, setPage])
 
-  const hasFilters = owner !== "all" || q !== ""
-  const isEmpty = !isPending && !error && total === 0 && !hasFilters
+  // Uses debouncedQ (what the current data was fetched with), not q, and never
+  // trusts a placeholder page's total — otherwise clearing a zero-result search
+  // flashes the account-level empty state until the unfiltered refetch lands.
+  const hasFilters = owner !== "all" || debouncedQ !== ""
+  const isEmpty =
+    !isPending && !error && !isPlaceholderData && total === 0 && !hasFilters
 
   const newButton = (
     <Button size="sm" onClick={() => setCreateOpen(true)}>

--- a/apps/console/src/app/(dashboard)/templates/page.tsx
+++ b/apps/console/src/app/(dashboard)/templates/page.tsx
@@ -1,22 +1,41 @@
 "use client"
 
 import { PlusIcon, StackIcon } from "@phosphor-icons/react"
-import { Button, Table, TableHead, TableHeader, TableRow } from "@superserve/ui"
-import { Suspense, useMemo, useState } from "react"
+import {
+  Button,
+  cn,
+  Table,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@superserve/ui"
+import { useSearchParams } from "next/navigation"
+import { Suspense } from "react"
 
 import { EmptyState } from "@/components/empty-state"
 import { ErrorState } from "@/components/error-state"
 import { PageHeader } from "@/components/page-header"
+import { Pagination } from "@/components/pagination"
+import { SortableTableHead } from "@/components/sortable-table-head"
 import { StickyHoverTableBody } from "@/components/sticky-hover-table"
 import { TableSkeleton } from "@/components/table-skeleton"
 import { TableToolbar } from "@/components/table-toolbar"
 import { CreateTemplateDialog } from "@/components/templates/create-template-dialog"
 import { TemplateTableRow } from "@/components/templates/template-table-row"
 import { useCreateParam } from "@/hooks/use-create-param"
-import { useTemplates } from "@/hooks/use-templates"
-import { isSystemTemplate } from "@/lib/templates/is-system-template"
+import { useListParams } from "@/hooks/use-list-params"
+import { useTemplatesPage } from "@/hooks/use-templates"
+import type {
+  TemplateListParams,
+  TemplateOwnerFilter,
+  TemplateSortColumn,
+} from "@/lib/api/types"
 
-type Tab = "all" | "team" | "system"
+const OWNER_TABS = [
+  { label: "All", value: "all" },
+  { label: "Team", value: "team" },
+  { label: "System", value: "system" },
+]
 
 export default function TemplatesPage() {
   return (
@@ -27,36 +46,41 @@ export default function TemplatesPage() {
 }
 
 function TemplatesPageContent() {
+  const searchParams = useSearchParams()
   const [createOpen, setCreateOpen] = useCreateParam()
-  const [tab, setTab] = useState<Tab>("all")
-  const [search, setSearch] = useState("")
 
-  const { data: templates, isPending, error, refetch } = useTemplates()
+  const {
+    page,
+    pageSize,
+    sort,
+    order,
+    q,
+    debouncedQ,
+    setParam,
+    toggleSort,
+    setPage,
+    setPageSize,
+    setSearch,
+  } = useListParams({ defaultSort: "created_at" })
 
-  const counts = useMemo(() => {
-    if (!templates) return { all: 0, team: 0, system: 0 }
-    let team = 0
-    let system = 0
-    for (const t of templates) {
-      if (isSystemTemplate(t)) system++
-      else team++
-    }
-    return { all: templates.length, team, system }
-  }, [templates])
+  const owner = (searchParams.get("owner") ?? "all") as TemplateOwnerFilter
 
-  const filtered = useMemo(() => {
-    if (!templates) return []
-    const byTab =
-      tab === "all"
-        ? templates
-        : tab === "team"
-          ? templates.filter((t) => !isSystemTemplate(t))
-          : templates.filter((t) => isSystemTemplate(t))
+  const params: TemplateListParams = {
+    page,
+    pageSize,
+    sort: sort as TemplateSortColumn,
+    order,
+    owner,
+    q: debouncedQ || undefined,
+  }
 
-    const q = search.trim().toLowerCase()
-    if (!q) return byTab
-    return byTab.filter((t) => t.name.toLowerCase().includes(q))
-  }, [templates, tab, search])
+  const { data, isPending, error, refetch, isPlaceholderData } =
+    useTemplatesPage(params)
+  const templates = data?.items ?? []
+  const total = data?.total ?? 0
+
+  const hasFilters = owner !== "all" || q !== ""
+  const isEmpty = !isPending && !error && total === 0 && !hasFilters
 
   const newButton = (
     <Button size="sm" onClick={() => setCreateOpen(true)}>
@@ -83,13 +107,11 @@ function TemplatesPageContent() {
     )
   }
 
-  const totalEmpty = (templates?.length ?? 0) === 0
-
   return (
     <div className="flex h-full flex-col">
       <PageHeader title="Templates">{newButton}</PageHeader>
 
-      {totalEmpty ? (
+      {isEmpty ? (
         <EmptyState
           icon={StackIcon}
           title="No templates yet"
@@ -101,65 +123,102 @@ function TemplatesPageContent() {
         <>
           <TableToolbar
             id="templates-toolbar"
-            tabs={[
-              { value: "all", label: "All", count: counts.all },
-              { value: "team", label: "Team", count: counts.team },
-              { value: "system", label: "System", count: counts.system },
-            ]}
-            activeTab={tab}
-            onTabChange={(v) => setTab(v as Tab)}
+            tabs={OWNER_TABS}
+            activeTab={owner}
+            onTabChange={(v) => setParam({ owner: v === "all" ? null : v })}
             searchPlaceholder="Search names…"
-            searchValue={search}
+            searchValue={q}
             onSearchChange={setSearch}
           />
 
-          <div className="flex flex-1 flex-col overflow-y-auto">
-            {filtered.length === 0 ? (
+          <div
+            className={cn(
+              "flex flex-1 flex-col overflow-y-auto transition-opacity",
+              isPlaceholderData && "opacity-60",
+            )}
+          >
+            {templates.length === 0 ? (
               <EmptyState
                 icon={StackIcon}
                 title={
-                  search
+                  q
                     ? "No templates match that search"
-                    : tab === "team"
+                    : owner === "team"
                       ? "No team templates yet"
                       : "No system templates available"
                 }
                 description={
-                  search
-                    ? "Try a different name prefix."
-                    : tab === "team"
+                  q
+                    ? "Try a different name."
+                    : owner === "team"
                       ? "Create one to get started."
                       : "System templates are curated by Superserve."
                 }
                 actionLabel={
-                  !search && tab === "team" ? "Create template" : undefined
+                  !q && owner === "team" ? "Create template" : undefined
                 }
                 onAction={
-                  !search && tab === "team"
-                    ? () => setCreateOpen(true)
-                    : undefined
+                  !q && owner === "team" ? () => setCreateOpen(true) : undefined
                 }
               />
             ) : (
               <Table>
                 <TableHeader className="sticky top-0 z-10 bg-background/70 backdrop-blur-md">
                   <TableRow>
-                    <TableHead className="w-[30%]">Name</TableHead>
-                    <TableHead className="w-[12%]">Status</TableHead>
+                    <SortableTableHead
+                      column="name"
+                      label="Name"
+                      activeSort={sort}
+                      order={order}
+                      onSort={toggleSort}
+                      className="w-[30%]"
+                    />
+                    <SortableTableHead
+                      column="status"
+                      label="Status"
+                      activeSort={sort}
+                      order={order}
+                      onSort={toggleSort}
+                      className="w-[12%]"
+                    />
                     <TableHead className="w-[26%]">Resources</TableHead>
-                    <TableHead className="w-[14%]">Created</TableHead>
-                    <TableHead className="w-[14%]">Updated</TableHead>
+                    <SortableTableHead
+                      column="created_at"
+                      label="Created"
+                      activeSort={sort}
+                      order={order}
+                      onSort={toggleSort}
+                      className="w-[14%]"
+                    />
+                    <SortableTableHead
+                      column="built_at"
+                      label="Updated"
+                      activeSort={sort}
+                      order={order}
+                      onSort={toggleSort}
+                      className="w-[14%]"
+                    />
                     <TableHead className="w-12" />
                   </TableRow>
                 </TableHeader>
                 <StickyHoverTableBody>
-                  {filtered.map((t) => (
+                  {templates.map((t) => (
                     <TemplateTableRow key={t.id} template={t} />
                   ))}
                 </StickyHoverTableBody>
               </Table>
             )}
           </div>
+
+          {total > 0 && (
+            <Pagination
+              page={page}
+              pageSize={pageSize}
+              total={total}
+              onPageChange={setPage}
+              onPageSizeChange={setPageSize}
+            />
+          )}
         </>
       )}
 

--- a/apps/console/src/app/(dashboard)/templates/page.tsx
+++ b/apps/console/src/app/(dashboard)/templates/page.tsx
@@ -10,7 +10,7 @@ import {
   TableRow,
 } from "@superserve/ui"
 import { useSearchParams } from "next/navigation"
-import { Suspense } from "react"
+import { Suspense, useEffect } from "react"
 
 import { EmptyState } from "@/components/empty-state"
 import { ErrorState } from "@/components/error-state"
@@ -78,6 +78,13 @@ function TemplatesPageContent() {
     useTemplatesPage(params)
   const templates = data?.items ?? []
   const total = data?.total ?? 0
+  const pageCount = Math.max(1, Math.ceil(total / pageSize))
+
+  // Snap back to the last valid page if the current one is now out of bounds
+  // (e.g. after deleting the last template on the last page).
+  useEffect(() => {
+    if (total > 0 && page > pageCount) setPage(pageCount)
+  }, [total, page, pageCount, setPage])
 
   const hasFilters = owner !== "all" || q !== ""
   const isEmpty = !isPending && !error && total === 0 && !hasFilters

--- a/apps/console/src/components/pagination.test.tsx
+++ b/apps/console/src/components/pagination.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { Pagination } from "./pagination"
+
+const noop = () => {}
+
+describe("Pagination", () => {
+  it("renders the current range and total", () => {
+    render(
+      <Pagination
+        page={1}
+        pageSize={50}
+        total={120}
+        onPageChange={noop}
+        onPageSizeChange={noop}
+      />,
+    )
+    expect(
+      screen.getByRole("navigation", { name: "Pagination" }),
+    ).toHaveTextContent("1–50 of 120")
+  })
+
+  it("clamps the range end to the total on the last, partial page", () => {
+    render(
+      <Pagination
+        page={3}
+        pageSize={50}
+        total={120}
+        onPageChange={noop}
+        onPageSizeChange={noop}
+      />,
+    )
+    expect(
+      screen.getByRole("navigation", { name: "Pagination" }),
+    ).toHaveTextContent("101–120 of 120")
+  })
+
+  it("disables Previous on the first page and Next on the last", () => {
+    const { rerender } = render(
+      <Pagination
+        page={1}
+        pageSize={50}
+        total={120}
+        onPageChange={noop}
+        onPageSizeChange={noop}
+      />,
+    )
+    expect(screen.getByRole("button", { name: "Previous page" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Next page" })).not.toBeDisabled()
+
+    rerender(
+      <Pagination
+        page={3}
+        pageSize={50}
+        total={120}
+        onPageChange={noop}
+        onPageSizeChange={noop}
+      />,
+    )
+    expect(screen.getByRole("button", { name: "Next page" })).toBeDisabled()
+  })
+
+  it("calls onPageChange with the clicked page number", async () => {
+    const onPageChange = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <Pagination
+        page={1}
+        pageSize={50}
+        total={120}
+        onPageChange={onPageChange}
+        onPageSizeChange={noop}
+      />,
+    )
+    await user.click(screen.getByRole("button", { name: "2" }))
+    expect(onPageChange).toHaveBeenCalledWith(2)
+  })
+
+  it("elides distant pages in a long range but always shows first and last", () => {
+    // 1000 rows / 50 per page = 20 pages, viewing page 10.
+    render(
+      <Pagination
+        page={10}
+        pageSize={50}
+        total={1000}
+        onPageChange={noop}
+        onPageSizeChange={noop}
+      />,
+    )
+    // First, last, and the current neighborhood are present…
+    expect(screen.getByRole("button", { name: "1" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "20" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "10" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "9" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "11" })).toBeInTheDocument()
+    // …but distant pages are elided.
+    expect(screen.queryByRole("button", { name: "5" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "15" })).not.toBeInTheDocument()
+  })
+
+  it("shows a single page and disables both arrows when the list fits one page", () => {
+    render(
+      <Pagination
+        page={1}
+        pageSize={50}
+        total={3}
+        onPageChange={noop}
+        onPageSizeChange={noop}
+      />,
+    )
+    expect(
+      screen.getByRole("navigation", { name: "Pagination" }),
+    ).toHaveTextContent("1–3 of 3")
+    expect(screen.getByRole("button", { name: "Previous page" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Next page" })).toBeDisabled()
+  })
+})

--- a/apps/console/src/components/pagination.test.tsx
+++ b/apps/console/src/components/pagination.test.tsx
@@ -100,6 +100,44 @@ describe("Pagination", () => {
     expect(screen.queryByRole("button", { name: "15" })).not.toBeInTheDocument()
   })
 
+  it("does not show a jump-to-page input for short ranges", () => {
+    render(
+      <Pagination
+        page={1}
+        pageSize={50}
+        total={120}
+        onPageChange={noop}
+        onPageSizeChange={noop}
+      />,
+    )
+    expect(
+      screen.queryByRole("textbox", { name: /jump to page/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it("jumps to the typed page on Enter and clamps to the last page", async () => {
+    const onPageChange = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <Pagination
+        page={10}
+        pageSize={50}
+        total={1000}
+        onPageChange={onPageChange}
+        onPageSizeChange={noop}
+      />,
+    )
+    const jumpInput = screen.getByRole("textbox", { name: /jump to page/i })
+    await user.type(jumpInput, "17")
+    await user.keyboard("{Enter}")
+    expect(onPageChange).toHaveBeenCalledWith(17)
+    expect(jumpInput).toHaveValue("")
+
+    await user.type(jumpInput, "999")
+    await user.keyboard("{Enter}")
+    expect(onPageChange).toHaveBeenCalledWith(20)
+  })
+
   it("shows a single page and disables both arrows when the list fits one page", () => {
     render(
       <Pagination

--- a/apps/console/src/components/pagination.tsx
+++ b/apps/console/src/components/pagination.tsx
@@ -1,0 +1,148 @@
+"use client"
+
+import { CaretLeftIcon, CaretRightIcon } from "@phosphor-icons/react"
+import {
+  Button,
+  cn,
+  Menu,
+  MenuItem,
+  MenuPopup,
+  MenuTrigger,
+} from "@superserve/ui"
+
+import { CornerBrackets } from "./corner-brackets"
+
+const DEFAULT_PAGE_SIZE_OPTIONS = [25, 50, 100]
+
+type PageToken = number | "ellipsis"
+
+/**
+ * Elided page list: first + last page always shown, current ±1 in the middle,
+ * with "ellipsis" tokens standing in for the gaps. Short ranges (≤ 7 pages)
+ * render every page.
+ */
+function pageRange(current: number, pageCount: number): PageToken[] {
+  if (pageCount <= 7) {
+    return Array.from({ length: pageCount }, (_, i) => i + 1)
+  }
+  const tokens: PageToken[] = [1]
+  const left = Math.max(2, current - 1)
+  const right = Math.min(pageCount - 1, current + 1)
+  if (left > 2) tokens.push("ellipsis")
+  for (let p = left; p <= right; p++) tokens.push(p)
+  if (right < pageCount - 1) tokens.push("ellipsis")
+  tokens.push(pageCount)
+  return tokens
+}
+
+interface PaginationProps {
+  /** 1-based current page. */
+  page: number
+  pageSize: number
+  /** Total rows across all pages (from the API's X-Total-Count). */
+  total: number
+  onPageChange: (page: number) => void
+  onPageSizeChange: (size: number) => void
+  pageSizeOptions?: number[]
+}
+
+export function Pagination({
+  page,
+  pageSize,
+  total,
+  onPageChange,
+  onPageSizeChange,
+  pageSizeOptions = DEFAULT_PAGE_SIZE_OPTIONS,
+}: PaginationProps) {
+  const pageCount = Math.max(1, Math.ceil(total / pageSize))
+  const current = Math.min(Math.max(1, page), pageCount)
+  const start = total === 0 ? 0 : (current - 1) * pageSize + 1
+  const end = Math.min(current * pageSize, total)
+  const tokens = pageRange(current, pageCount)
+
+  return (
+    <nav
+      aria-label="Pagination"
+      className="flex h-12 shrink-0 items-center justify-between border-t border-border bg-background px-4"
+    >
+      <p className="font-mono text-xs text-muted tabular-nums">
+        {start}
+        <span className="text-muted/60">–</span>
+        {end} <span className="text-muted/60">of</span> {total}
+      </p>
+
+      <div className="flex items-center gap-1">
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          onClick={() => onPageChange(current - 1)}
+          disabled={current <= 1}
+          aria-label="Previous page"
+        >
+          <CaretLeftIcon className="size-3.5" weight="light" />
+        </Button>
+
+        {tokens.map((token, i) =>
+          token === "ellipsis" ? (
+            <span
+              // eslint-disable-next-line react/no-array-index-key -- ellipsis tokens have no stable id; position is their identity
+              key={`gap-${i}`}
+              className="px-1 font-mono text-xs text-muted"
+              aria-hidden
+            >
+              …
+            </span>
+          ) : (
+            <button
+              key={token}
+              type="button"
+              onClick={() => onPageChange(token)}
+              aria-current={token === current ? "page" : undefined}
+              className={cn(
+                "relative inline-flex h-8 min-w-8 cursor-pointer items-center justify-center px-2 font-mono text-xs tabular-nums transition-colors",
+                token === current
+                  ? "bg-brand/10 text-foreground"
+                  : "text-muted hover:bg-surface-hover hover:text-foreground",
+              )}
+            >
+              {token === current && <CornerBrackets size="sm" />}
+              <span className="relative">{token}</span>
+            </button>
+          ),
+        )}
+
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          onClick={() => onPageChange(current + 1)}
+          disabled={current >= pageCount}
+          aria-label="Next page"
+        >
+          <CaretRightIcon className="size-3.5" weight="light" />
+        </Button>
+
+        <Menu>
+          <MenuTrigger
+            render={
+              <Button
+                variant="ghost"
+                size="sm"
+                className="ml-2 text-xs text-muted"
+                aria-label="Rows per page"
+              >
+                {pageSize} / page
+              </Button>
+            }
+          />
+          <MenuPopup align="end">
+            {pageSizeOptions.map((size) => (
+              <MenuItem key={size} onClick={() => onPageSizeChange(size)}>
+                {size} / page
+              </MenuItem>
+            ))}
+          </MenuPopup>
+        </Menu>
+      </div>
+    </nav>
+  )
+}

--- a/apps/console/src/components/pagination.tsx
+++ b/apps/console/src/components/pagination.tsx
@@ -63,7 +63,7 @@ export function Pagination({
   return (
     <nav
       aria-label="Pagination"
-      className="flex h-12 shrink-0 items-center justify-between border-t border-border bg-background px-4"
+      className="flex h-12 shrink-0 items-center justify-between border-t border-dashed border-border bg-background px-4"
     >
       <p className="font-mono text-xs text-muted tabular-nums">
         {start}

--- a/apps/console/src/components/pagination.tsx
+++ b/apps/console/src/components/pagination.tsx
@@ -9,10 +9,14 @@ import {
   MenuPopup,
   MenuTrigger,
 } from "@superserve/ui"
+import { useState } from "react"
 
 import { CornerBrackets } from "./corner-brackets"
 
 const DEFAULT_PAGE_SIZE_OPTIONS = [25, 50, 100]
+// Matches the pageRange elision threshold — below this, every page already
+// has its own button, so a jump input has nothing to add.
+const JUMP_THRESHOLD = 7
 
 type PageToken = number | "ellipsis"
 
@@ -22,7 +26,7 @@ type PageToken = number | "ellipsis"
  * render every page.
  */
 function pageRange(current: number, pageCount: number): PageToken[] {
-  if (pageCount <= 7) {
+  if (pageCount <= JUMP_THRESHOLD) {
     return Array.from({ length: pageCount }, (_, i) => i + 1)
   }
   const tokens: PageToken[] = [1]
@@ -33,6 +37,51 @@ function pageRange(current: number, pageCount: number): PageToken[] {
   if (right < pageCount - 1) tokens.push("ellipsis")
   tokens.push(pageCount)
   return tokens
+}
+
+interface JumpToPageProps {
+  current: number
+  pageCount: number
+  onPageChange: (page: number) => void
+}
+
+/** "Go to [__]" input for reaching a distant page without clicking through
+ * every ellipsis — numbered buttons alone don't scale past a handful of
+ * pages. */
+function JumpToPage({ current, pageCount, onPageChange }: JumpToPageProps) {
+  const [value, setValue] = useState("")
+
+  const commit = () => {
+    if (value === "") return
+    const target = Math.min(
+      Math.max(1, Math.trunc(Number(value)) || 1),
+      pageCount,
+    )
+    if (target !== current) onPageChange(target)
+    setValue("")
+  }
+
+  return (
+    <div className="ml-1 flex items-center gap-1.5 border-l border-dashed border-border pl-2">
+      <span className="font-mono text-xs text-muted">Go to</span>
+      <input
+        type="text"
+        inputMode="numeric"
+        value={value}
+        onChange={(e) => setValue(e.target.value.replace(/[^0-9]/g, ""))}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault()
+            commit()
+          }
+        }}
+        onBlur={commit}
+        placeholder={String(current)}
+        aria-label={`Jump to page, 1 to ${pageCount}`}
+        className="h-8 w-12 border border-dashed border-border bg-background px-1.5 text-center font-mono text-xs text-foreground tabular-nums placeholder:text-muted/60 focus:border-border-focus focus:outline-none"
+      />
+    </div>
+  )
 }
 
 interface PaginationProps {
@@ -120,6 +169,14 @@ export function Pagination({
         >
           <CaretRightIcon className="size-3.5" weight="light" />
         </Button>
+
+        {pageCount > JUMP_THRESHOLD && (
+          <JumpToPage
+            current={current}
+            pageCount={pageCount}
+            onPageChange={onPageChange}
+          />
+        )}
 
         <Menu>
           <MenuTrigger

--- a/apps/console/src/components/sortable-table-head.tsx
+++ b/apps/console/src/components/sortable-table-head.tsx
@@ -9,24 +9,24 @@ import { cn, TableHead } from "@superserve/ui"
 
 import type { SortDirection } from "@/lib/api/types"
 
-interface SortableTableHeadProps {
+interface SortableTableHeadProps<C extends string> {
   /** Sort column value sent to the API (e.g. "name", "created_at"). */
-  column: string
+  column: C
   label: string
   activeSort: string
   order: SortDirection
-  onSort: (column: string) => void
+  onSort: (column: C) => void
   className?: string
 }
 
-export function SortableTableHead({
+export function SortableTableHead<C extends string>({
   column,
   label,
   activeSort,
   order,
   onSort,
   className,
-}: SortableTableHeadProps) {
+}: SortableTableHeadProps<C>) {
   const isActive = activeSort === column
 
   return (
@@ -43,14 +43,14 @@ export function SortableTableHead({
         {label}
         {isActive ? (
           order === "asc" ? (
-            <CaretUpIcon className="size-3" weight="bold" />
+            <CaretUpIcon className="size-3.5" weight="light" />
           ) : (
-            <CaretDownIcon className="size-3" weight="bold" />
+            <CaretDownIcon className="size-3.5" weight="light" />
           )
         ) : (
           <CaretUpDownIcon
-            className="size-3 opacity-0 transition-opacity group-hover:opacity-40"
-            weight="bold"
+            className="size-3.5 opacity-0 transition-opacity group-hover:opacity-40"
+            weight="light"
           />
         )}
       </button>

--- a/apps/console/src/components/sortable-table-head.tsx
+++ b/apps/console/src/components/sortable-table-head.tsx
@@ -1,0 +1,59 @@
+"use client"
+
+import {
+  CaretDownIcon,
+  CaretUpDownIcon,
+  CaretUpIcon,
+} from "@phosphor-icons/react"
+import { cn, TableHead } from "@superserve/ui"
+
+import type { SortDirection } from "@/lib/api/types"
+
+interface SortableTableHeadProps {
+  /** Sort column value sent to the API (e.g. "name", "created_at"). */
+  column: string
+  label: string
+  activeSort: string
+  order: SortDirection
+  onSort: (column: string) => void
+  className?: string
+}
+
+export function SortableTableHead({
+  column,
+  label,
+  activeSort,
+  order,
+  onSort,
+  className,
+}: SortableTableHeadProps) {
+  const isActive = activeSort === column
+
+  return (
+    <TableHead className={cn("p-0", className)}>
+      <button
+        type="button"
+        onClick={() => onSort(column)}
+        aria-label={`Sort by ${label}`}
+        className={cn(
+          "group inline-flex h-10 w-full cursor-pointer items-center gap-1 px-4 font-mono text-xs font-medium tracking-wider uppercase transition-colors",
+          isActive ? "text-foreground" : "text-muted hover:text-foreground",
+        )}
+      >
+        {label}
+        {isActive ? (
+          order === "asc" ? (
+            <CaretUpIcon className="size-3" weight="bold" />
+          ) : (
+            <CaretDownIcon className="size-3" weight="bold" />
+          )
+        ) : (
+          <CaretUpDownIcon
+            className="size-3 opacity-0 transition-opacity group-hover:opacity-40"
+            weight="bold"
+          />
+        )}
+      </button>
+    </TableHead>
+  )
+}

--- a/apps/console/src/components/templates/build-log-viewer.tsx
+++ b/apps/console/src/components/templates/build-log-viewer.tsx
@@ -75,6 +75,12 @@ export function BuildLogViewer({
             queryKey: templateKeys.detail(templateId),
           }),
           queryClient.invalidateQueries({ queryKey: templateKeys.lists() }),
+          // The create-sandbox picker caches the unpaginated list under a
+          // separate key — invalidate it too so the template turns launchable
+          // there as soon as the build lands.
+          queryClient.invalidateQueries({
+            queryKey: templateKeys.fullLists(),
+          }),
           queryClient.invalidateQueries({
             queryKey: templateKeys.builds(templateId),
           }),

--- a/apps/console/src/hooks/use-debounced-value.ts
+++ b/apps/console/src/hooks/use-debounced-value.ts
@@ -1,0 +1,18 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+/**
+ * Returns a copy of `value` that only updates after it has stopped changing for
+ * `delay` ms. Used to keep list search from firing a request per keystroke.
+ */
+export function useDebouncedValue<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState(value)
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delay)
+    return () => clearTimeout(id)
+  }, [value, delay])
+
+  return debounced
+}

--- a/apps/console/src/hooks/use-favicon-status.ts
+++ b/apps/console/src/hooks/use-favicon-status.ts
@@ -11,9 +11,9 @@ const DEFAULT_FAVICON = "/favicon.ico"
 const ACTIVE_FAVICON = "/favicon-active.ico"
 
 // We only need to know whether ANY sandbox is currently resuming, so fetch a
-// single-row page filtered to that status and read the total off the header.
-// This keeps the always-mounted favicon poll cheap instead of pulling the
-// whole sandbox list on every dashboard page.
+// single-row page filtered to that status. This keeps the always-mounted
+// favicon poll cheap instead of pulling the whole sandbox list on every
+// dashboard page.
 const RESUMING_PROBE: SandboxListParams = {
   page: 1,
   pageSize: 1,
@@ -30,7 +30,12 @@ export function useFaviconStatus() {
     refetchIntervalInBackground: false,
   })
 
-  const hasTransitional = (data?.total ?? 0) > 0
+  // Check the rows' actual status rather than trusting total > 0: against an
+  // API build that ignores the status/limit params (the fallback case
+  // apiClientList handles), the probe gets the full unfiltered list back and a
+  // count-based check would keep the active favicon on forever.
+  const hasTransitional =
+    data?.items.some((s) => s.status === "resuming") ?? false
 
   useEffect(() => {
     const link = document.querySelector<HTMLLinkElement>("link[rel='icon']")

--- a/apps/console/src/hooks/use-favicon-status.ts
+++ b/apps/console/src/hooks/use-favicon-status.ts
@@ -1,21 +1,41 @@
 "use client"
 
+import { useQuery } from "@tanstack/react-query"
 import { useEffect } from "react"
 
-import { useSandboxes } from "./use-sandboxes"
+import { sandboxKeys } from "@/lib/api/query-keys"
+import { listSandboxesPaged } from "@/lib/api/sandboxes"
+import type { SandboxListParams } from "@/lib/api/types"
 
 const DEFAULT_FAVICON = "/favicon.ico"
 const ACTIVE_FAVICON = "/favicon-active.ico"
 
+// We only need to know whether ANY sandbox is currently resuming, so fetch a
+// single-row page filtered to that status and read the total off the header.
+// This keeps the always-mounted favicon poll cheap instead of pulling the
+// whole sandbox list on every dashboard page.
+const RESUMING_PROBE: SandboxListParams = {
+  page: 1,
+  pageSize: 1,
+  sort: "created_at",
+  order: "desc",
+  status: "resuming",
+}
+
 export function useFaviconStatus() {
-  const { data: sandboxes } = useSandboxes()
+  const { data } = useQuery({
+    queryKey: sandboxKeys.list(RESUMING_PROBE),
+    queryFn: () => listSandboxesPaged(RESUMING_PROBE),
+    refetchInterval: 10_000,
+    refetchIntervalInBackground: false,
+  })
+
+  const hasTransitional = (data?.total ?? 0) > 0
 
   useEffect(() => {
-    const hasTransitional = sandboxes?.some((s) => s.status === "resuming")
-
     const link = document.querySelector<HTMLLinkElement>("link[rel='icon']")
     if (!link) return
 
     link.href = hasTransitional ? ACTIVE_FAVICON : DEFAULT_FAVICON
-  }, [sandboxes])
+  }, [hasTransitional])
 }

--- a/apps/console/src/hooks/use-list-params.ts
+++ b/apps/console/src/hooks/use-list-params.ts
@@ -1,0 +1,104 @@
+"use client"
+
+import { useRouter, useSearchParams } from "next/navigation"
+import { useCallback } from "react"
+
+import type { SortDirection } from "@/lib/api/types"
+
+import { useDebouncedValue } from "./use-debounced-value"
+
+const SEARCH_DEBOUNCE_MS = 300
+// Mirrors the backend's maxPageSize so a hand-crafted ?size= can't desync the
+// pager's math (page count / "X of Y") from the rows the API will actually
+// return.
+const MAX_PAGE_SIZE = 200
+
+interface UseListParamsConfig {
+  defaultSort: string
+  defaultPageSize?: number
+}
+
+/**
+ * Manages the shared URL state for a paginated list page: page, page size,
+ * sort column + direction, and name search. Filter tabs (status, owner, …) are
+ * page-specific and set through the returned `setParam` helper.
+ *
+ * The URL is the single source of truth, so pages are shareable and survive
+ * refresh / back-forward. The search input and URL update on every keystroke;
+ * only `debouncedQ` (fed to the query) lags, so typing doesn't fire a request
+ * per character. Any filter/sort/search change resets back to page 1.
+ */
+export function useListParams({
+  defaultSort,
+  defaultPageSize = 50,
+}: UseListParamsConfig) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  const page = Math.max(1, Number(searchParams.get("page")) || 1)
+  const pageSize = Math.min(
+    MAX_PAGE_SIZE,
+    Math.max(1, Number(searchParams.get("size")) || defaultPageSize),
+  )
+  const sort = searchParams.get("sort") ?? defaultSort
+  const order: SortDirection =
+    searchParams.get("order") === "asc" ? "asc" : "desc"
+  const q = searchParams.get("q") ?? ""
+  const debouncedQ = useDebouncedValue(q, SEARCH_DEBOUNCE_MS)
+
+  const setParam = useCallback(
+    (patch: Record<string, string | null>, resetPage = true) => {
+      const next = new URLSearchParams(searchParams.toString())
+      for (const [key, value] of Object.entries(patch)) {
+        if (value === null || value === "") next.delete(key)
+        else next.set(key, value)
+      }
+      // Any filter/sort/search change sends the user back to page 1, unless the
+      // caller is explicitly navigating pages.
+      if (resetPage && !("page" in patch)) next.delete("page")
+      const qs = next.toString()
+      router.replace(qs ? `?${qs}` : window.location.pathname)
+    },
+    [router, searchParams],
+  )
+
+  const setSearch = useCallback(
+    (value: string) => setParam({ q: value || null }),
+    [setParam],
+  )
+
+  const toggleSort = useCallback(
+    (column: string) => {
+      if (sort === column) {
+        setParam({ order: order === "asc" ? "desc" : "asc" })
+      } else {
+        setParam({ sort: column, order: "asc" })
+      }
+    },
+    [sort, order, setParam],
+  )
+
+  const setPage = useCallback(
+    (next: number) => setParam({ page: String(next) }, false),
+    [setParam],
+  )
+
+  const setPageSize = useCallback(
+    (next: number) => setParam({ size: String(next) }),
+    [setParam],
+  )
+
+  return {
+    page,
+    pageSize,
+    sort,
+    order,
+    q,
+    debouncedQ,
+    setParam,
+    setSearch,
+    toggleSort,
+    setPage,
+    setPageSize,
+  }
+}

--- a/apps/console/src/hooks/use-list-params.ts
+++ b/apps/console/src/hooks/use-list-params.ts
@@ -56,8 +56,9 @@ export function useListParams({
       // Any filter/sort/search change sends the user back to page 1, unless the
       // caller is explicitly navigating pages.
       if (resetPage && !("page" in patch)) next.delete("page")
+      const path = window.location.pathname
       const qs = next.toString()
-      router.replace(qs ? `?${qs}` : window.location.pathname)
+      router.replace(qs ? `${path}?${qs}` : path)
     },
     [router, searchParams],
   )

--- a/apps/console/src/hooks/use-list-params.ts
+++ b/apps/console/src/hooks/use-list-params.ts
@@ -1,6 +1,6 @@
 "use client"
 
-import { useRouter, useSearchParams } from "next/navigation"
+import { useSearchParams } from "next/navigation"
 import { useCallback } from "react"
 
 import type { SortDirection } from "@/lib/api/types"
@@ -13,8 +13,14 @@ const SEARCH_DEBOUNCE_MS = 300
 // return.
 const MAX_PAGE_SIZE = 200
 
-interface UseListParamsConfig {
-  defaultSort: string
+interface UseListParamsConfig<C extends string> {
+  /**
+   * Sort columns the API accepts. URL params are user input — an unknown
+   * ?sort= (typo, stale link after a column rename) falls back to defaultSort
+   * instead of reaching the API and failing the whole page.
+   */
+  columns: readonly C[]
+  defaultSort: C
   defaultPageSize?: number
 }
 
@@ -24,31 +30,37 @@ interface UseListParamsConfig {
  * page-specific and set through the returned `setParam` helper.
  *
  * The URL is the single source of truth, so pages are shareable and survive
- * refresh / back-forward. The search input and URL update on every keystroke;
- * only `debouncedQ` (fed to the query) lags, so typing doesn't fire a request
- * per character. Any filter/sort/search change resets back to page 1.
+ * refresh / back-forward. The search input and URL update on every keystroke
+ * (shallowly — no server round-trip); only `debouncedQ` (fed to the query)
+ * lags, so typing doesn't fire a request per character. Any filter/sort/search
+ * change resets back to page 1.
  */
-export function useListParams({
+export function useListParams<C extends string>({
+  columns,
   defaultSort,
   defaultPageSize = 50,
-}: UseListParamsConfig) {
-  const router = useRouter()
+}: UseListParamsConfig<C>) {
   const searchParams = useSearchParams()
 
-  const page = Math.max(1, Number(searchParams.get("page")) || 1)
+  const page = Math.max(1, Math.trunc(Number(searchParams.get("page")) || 1))
   const pageSize = Math.min(
     MAX_PAGE_SIZE,
-    Math.max(1, Number(searchParams.get("size")) || defaultPageSize),
+    Math.max(
+      1,
+      Math.trunc(Number(searchParams.get("size")) || defaultPageSize),
+    ),
   )
-  const sort = searchParams.get("sort") ?? defaultSort
+  const rawSort = searchParams.get("sort")
+  const sort = columns.find((c) => c === rawSort) ?? defaultSort
   const order: SortDirection =
     searchParams.get("order") === "asc" ? "asc" : "desc"
   const q = searchParams.get("q") ?? ""
-  const debouncedQ = useDebouncedValue(q, SEARCH_DEBOUNCE_MS)
+  // Trimmed so "node " (or a lone space) doesn't become a zero-match filter.
+  const debouncedQ = useDebouncedValue(q, SEARCH_DEBOUNCE_MS).trim()
 
   const setParam = useCallback(
     (patch: Record<string, string | null>, resetPage = true) => {
-      const next = new URLSearchParams(searchParams.toString())
+      const next = new URLSearchParams(window.location.search)
       for (const [key, value] of Object.entries(patch)) {
         if (value === null || value === "") next.delete(key)
         else next.set(key, value)
@@ -58,9 +70,14 @@ export function useListParams({
       if (resetPage && !("page" in patch)) next.delete("page")
       const path = window.location.pathname
       const qs = next.toString()
-      router.replace(qs ? `${path}?${qs}` : path)
+      // These params only drive client-side queries, so update the URL
+      // shallowly (Next syncs useSearchParams from the History API). Going
+      // through router.replace would fetch the route's RSC payload on every
+      // search keystroke and let the async URL state fight the controlled
+      // search input.
+      window.history.replaceState(null, "", qs ? `${path}?${qs}` : path)
     },
-    [router, searchParams],
+    [],
   )
 
   const setSearch = useCallback(
@@ -69,7 +86,7 @@ export function useListParams({
   )
 
   const toggleSort = useCallback(
-    (column: string) => {
+    (column: C) => {
       if (sort === column) {
         setParam({ order: order === "asc" ? "desc" : "asc" })
       } else {

--- a/apps/console/src/hooks/use-sandboxes.test.tsx
+++ b/apps/console/src/hooks/use-sandboxes.test.tsx
@@ -1,15 +1,18 @@
 /**
  * use-sandboxes hook tests — focus on optimistic updates, rollback, and
  * cache invalidation. Mocks the `@/lib/api/sandboxes` layer so tests don't
- * hit the real fetch.
+ * hit the real fetch. List results are cached per-page as `{ items, total }`
+ * under sandboxKeys.list(params); the mutations patch every such cache via
+ * sandboxKeys.lists(), so seeding one representative page is enough.
  */
 
+import type { QueryClient } from "@tanstack/react-query"
 import { act, renderHook, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
-import { ApiError } from "@/lib/api/client"
+import { ApiError, type PagedResult } from "@/lib/api/client"
 import { sandboxKeys } from "@/lib/api/query-keys"
-import type { SandboxResponse } from "@/lib/api/types"
+import type { SandboxListParams, SandboxResponse } from "@/lib/api/types"
 import { createQueryWrapper } from "@/test/react-query"
 
 // Mock the API layer. These functions are what the hooks delegate to.
@@ -23,7 +26,7 @@ vi.mock("@/lib/api/sandboxes", () => ({
   deleteSandbox: (...a: unknown[]) => mockDelete(...a),
   pauseSandbox: (...a: unknown[]) => mockPause(...a),
   resumeSandbox: (...a: unknown[]) => mockResume(...a),
-  listSandboxes: vi.fn(),
+  listSandboxesPaged: vi.fn(),
   getSandbox: vi.fn(),
   patchSandbox: vi.fn(),
 }))
@@ -56,15 +59,33 @@ const sandbox = (
   ...overrides,
 })
 
+// A representative page-cache key + shape. The mutations target every cache
+// under sandboxKeys.lists(), so this single seeded page stands in for the
+// user's current view.
+const LIST_PARAMS: SandboxListParams = {
+  page: 1,
+  pageSize: 50,
+  sort: "created_at",
+  order: "desc",
+}
+const listKey = sandboxKeys.list(LIST_PARAMS)
+const page = (items: SandboxResponse[]): PagedResult<SandboxResponse> => ({
+  items,
+  total: items.length,
+})
+const cachedList = (
+  queryClient: QueryClient,
+): PagedResult<SandboxResponse> | undefined =>
+  queryClient.getQueryData<PagedResult<SandboxResponse>>(listKey)
+
 describe("useCreateSandbox", () => {
   beforeEach(() => {
     mockCreate.mockReset()
     mockAddToast.mockReset()
   })
 
-  it("prepends the new sandbox to the list cache on success", async () => {
-    const { queryClient, wrapper } = createQueryWrapper()
-    queryClient.setQueryData(sandboxKeys.all, [sandbox({ id: "old" })])
+  it("shows a success toast on success", async () => {
+    const { wrapper } = createQueryWrapper()
     mockCreate.mockResolvedValue(sandbox({ id: "new", name: "new-box" }))
 
     const { result } = renderHook(() => useCreateSandbox(), { wrapper })
@@ -73,9 +94,6 @@ describe("useCreateSandbox", () => {
       await result.current.mutateAsync({ name: "new-box" })
     })
 
-    const list = queryClient.getQueryData<SandboxResponse[]>(sandboxKeys.all)
-    expect(list).toHaveLength(2)
-    expect(list?.[0].id).toBe("new")
     expect(mockAddToast).toHaveBeenCalledWith(
       'Sandbox "new-box" created',
       "success",
@@ -123,12 +141,12 @@ describe("useDeleteSandbox", () => {
     mockAddToast.mockReset()
   })
 
-  it("optimistically removes the sandbox from the cache", async () => {
+  it("optimistically removes the sandbox from the page cache", async () => {
     const { queryClient, wrapper } = createQueryWrapper()
-    queryClient.setQueryData(sandboxKeys.all, [
-      sandbox({ id: "a" }),
-      sandbox({ id: "b" }),
-    ])
+    queryClient.setQueryData(
+      listKey,
+      page([sandbox({ id: "a" }), sandbox({ id: "b" })]),
+    )
     mockDelete.mockResolvedValue(undefined)
 
     const { result } = renderHook(() => useDeleteSandbox(), { wrapper })
@@ -139,15 +157,14 @@ describe("useDeleteSandbox", () => {
 
     // Immediately after mutate, the optimistic removal should apply.
     await waitFor(() => {
-      const list = queryClient.getQueryData<SandboxResponse[]>(sandboxKeys.all)
-      expect(list?.map((s) => s.id)).toEqual(["b"])
+      expect(cachedList(queryClient)?.items.map((s) => s.id)).toEqual(["b"])
     })
   })
 
   it("rolls back the cache on failure", async () => {
     const { queryClient, wrapper } = createQueryWrapper()
-    const before = [sandbox({ id: "a" }), sandbox({ id: "b" })]
-    queryClient.setQueryData(sandboxKeys.all, before)
+    const before = page([sandbox({ id: "a" }), sandbox({ id: "b" })])
+    queryClient.setQueryData(listKey, before)
     mockDelete.mockRejectedValue(new Error("boom"))
 
     const { result } = renderHook(() => useDeleteSandbox(), { wrapper })
@@ -158,9 +175,7 @@ describe("useDeleteSandbox", () => {
 
     await waitFor(() => {
       // Cache restored to the pre-mutate snapshot.
-      expect(
-        queryClient.getQueryData<SandboxResponse[]>(sandboxKeys.all),
-      ).toEqual(before)
+      expect(cachedList(queryClient)).toEqual(before)
     })
     expect(mockAddToast).toHaveBeenCalledWith(expect.any(String), "error")
   })
@@ -174,11 +189,10 @@ describe("useBulkDeleteSandboxes", () => {
 
   it("optimistically removes all selected sandboxes", async () => {
     const { queryClient, wrapper } = createQueryWrapper()
-    queryClient.setQueryData(sandboxKeys.all, [
-      sandbox({ id: "a" }),
-      sandbox({ id: "b" }),
-      sandbox({ id: "c" }),
-    ])
+    queryClient.setQueryData(
+      listKey,
+      page([sandbox({ id: "a" }), sandbox({ id: "b" }), sandbox({ id: "c" })]),
+    )
     mockDelete.mockResolvedValue(undefined)
 
     const { result } = renderHook(() => useBulkDeleteSandboxes(), {
@@ -189,8 +203,7 @@ describe("useBulkDeleteSandboxes", () => {
       await result.current.mutateAsync(["a", "c"])
     })
 
-    const list = queryClient.getQueryData<SandboxResponse[]>(sandboxKeys.all)
-    expect(list?.map((s) => s.id)).toEqual(["b"])
+    expect(cachedList(queryClient)?.items.map((s) => s.id)).toEqual(["b"])
     expect(mockDelete).toHaveBeenCalledTimes(2)
   })
 })
@@ -204,9 +217,10 @@ describe("usePauseSandbox / useResumeSandbox", () => {
 
   it("pauses: flips the cached sandbox to paused optimistically", async () => {
     const { queryClient, wrapper } = createQueryWrapper()
-    queryClient.setQueryData(sandboxKeys.all, [
-      sandbox({ id: "a", status: "active" }),
-    ])
+    queryClient.setQueryData(
+      listKey,
+      page([sandbox({ id: "a", status: "active" })]),
+    )
     mockPause.mockResolvedValue(undefined)
 
     const { result } = renderHook(() => usePauseSandbox(), { wrapper })
@@ -215,16 +229,16 @@ describe("usePauseSandbox / useResumeSandbox", () => {
     })
 
     await waitFor(() => {
-      const list = queryClient.getQueryData<SandboxResponse[]>(sandboxKeys.all)
-      expect(list?.[0].status).toBe("paused")
+      expect(cachedList(queryClient)?.items[0].status).toBe("paused")
     })
   })
 
   it("resumes: flips the cached sandbox to resuming optimistically, then active on success with the fresh access_token", async () => {
     const { queryClient, wrapper } = createQueryWrapper()
-    queryClient.setQueryData(sandboxKeys.all, [
-      sandbox({ id: "a", status: "paused" }),
-    ])
+    queryClient.setQueryData(
+      listKey,
+      page([sandbox({ id: "a", status: "paused" })]),
+    )
     queryClient.setQueryData(
       sandboxKeys.detail("a"),
       sandbox({ id: "a", status: "paused", access_token: "old" }),
@@ -249,8 +263,7 @@ describe("usePauseSandbox / useResumeSandbox", () => {
     })
 
     await waitFor(() => {
-      const list = queryClient.getQueryData<SandboxResponse[]>(sandboxKeys.all)
-      expect(list?.[0].status).toBe("resuming")
+      expect(cachedList(queryClient)?.items[0].status).toBe("resuming")
       const detail = queryClient.getQueryData<SandboxResponse>(
         sandboxKeys.detail("a"),
       )
@@ -272,8 +285,8 @@ describe("usePauseSandbox / useResumeSandbox", () => {
 
   it("rolls back pause on error", async () => {
     const { queryClient, wrapper } = createQueryWrapper()
-    const before = [sandbox({ id: "a", status: "active" })]
-    queryClient.setQueryData(sandboxKeys.all, before)
+    const before = page([sandbox({ id: "a", status: "active" })])
+    queryClient.setQueryData(listKey, before)
     mockPause.mockRejectedValue(new Error("boom"))
 
     const { result } = renderHook(() => usePauseSandbox(), { wrapper })
@@ -282,9 +295,7 @@ describe("usePauseSandbox / useResumeSandbox", () => {
     })
 
     await waitFor(() => {
-      expect(
-        queryClient.getQueryData<SandboxResponse[]>(sandboxKeys.all),
-      ).toEqual(before)
+      expect(cachedList(queryClient)).toEqual(before)
     })
   })
 })

--- a/apps/console/src/hooks/use-sandboxes.ts
+++ b/apps/console/src/hooks/use-sandboxes.ts
@@ -1,9 +1,16 @@
 "use client"
 
 import { useToast } from "@superserve/ui"
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import {
+  keepPreviousData,
+  type QueryClient,
+  type QueryKey,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query"
 
-import { ApiError } from "@/lib/api/client"
+import { ApiError, type PagedResult } from "@/lib/api/client"
 import { sandboxKeys } from "@/lib/api/query-keys"
 import {
   attachSandboxSecret,
@@ -11,7 +18,7 @@ import {
   deleteSandbox,
   detachSandboxSecret,
   getSandbox,
-  listSandboxes,
+  listSandboxesPaged,
   patchSandbox,
   pauseSandbox,
   resumeSandbox,
@@ -19,14 +26,48 @@ import {
 import type {
   CreateSandboxRequest,
   SandboxListItem,
+  SandboxListParams,
   SandboxPatch,
   SandboxResponse,
 } from "@/lib/api/types"
 
-export function useSandboxes() {
+type SandboxPage = PagedResult<SandboxListItem>
+type SandboxListSnapshots = [QueryKey, SandboxPage | undefined][]
+
+// --- List-cache helpers -------------------------------------------------
+// Sandbox list results are cached per (page, sort, filter) combination under
+// sandboxKeys.lists(). These helpers snapshot / patch / restore every cached
+// variant at once, so an optimistic mutation stays correct no matter which
+// page or filter the user is currently looking at. Totals are intentionally
+// not adjusted here — the onSettled invalidation refetches the authoritative
+// count.
+
+function snapshotSandboxLists(qc: QueryClient): SandboxListSnapshots {
+  return qc.getQueriesData<SandboxPage>({ queryKey: sandboxKeys.lists() })
+}
+
+function restoreSandboxLists(qc: QueryClient, snapshots: SandboxListSnapshots) {
+  for (const [key, data] of snapshots) qc.setQueryData(key, data)
+}
+
+function patchSandboxLists(
+  qc: QueryClient,
+  updater: (items: SandboxListItem[]) => SandboxListItem[],
+) {
+  qc.setQueriesData<SandboxPage>({ queryKey: sandboxKeys.lists() }, (old) =>
+    old ? { ...old, items: updater(old.items) } : old,
+  )
+}
+
+// --- Queries ------------------------------------------------------------
+
+export function useSandboxesPage(params: SandboxListParams) {
   return useQuery({
-    queryKey: sandboxKeys.all,
-    queryFn: listSandboxes,
+    queryKey: sandboxKeys.list(params),
+    queryFn: () => listSandboxesPaged(params),
+    // Keep the current page on screen while the next page/sort/filter loads,
+    // so navigation doesn't flash an empty table.
+    placeholderData: keepPreviousData,
     refetchInterval: 10_000,
     refetchIntervalInBackground: false,
   })
@@ -45,6 +86,8 @@ export function useSandbox(id: string | null) {
   })
 }
 
+// --- Mutations ----------------------------------------------------------
+
 export function useCreateSandbox() {
   const queryClient = useQueryClient()
   const { addToast } = useToast()
@@ -52,9 +95,10 @@ export function useCreateSandbox() {
   return useMutation({
     mutationFn: (data: CreateSandboxRequest) => createSandbox(data),
     onSuccess: (newSandbox) => {
-      queryClient.setQueryData<SandboxListItem[]>(sandboxKeys.all, (old) =>
-        old ? [newSandbox, ...old] : [newSandbox],
-      )
+      // A new sandbox lands on page 1 under the default created_at-desc sort;
+      // refetch the lists rather than guessing its slot under the active
+      // page/sort/filter.
+      queryClient.invalidateQueries({ queryKey: sandboxKeys.lists() })
       addToast(`Sandbox "${newSandbox.name}" created`, "success")
     },
     onError: (error) => {
@@ -74,17 +118,15 @@ export function useDeleteSandbox() {
   return useMutation({
     mutationFn: (id: string) => deleteSandbox(id),
     onMutate: async (id) => {
-      await queryClient.cancelQueries({ queryKey: sandboxKeys.all })
-      const previous = queryClient.getQueryData<SandboxListItem[]>(
-        sandboxKeys.all,
+      await queryClient.cancelQueries({ queryKey: sandboxKeys.lists() })
+      const snapshots = snapshotSandboxLists(queryClient)
+      patchSandboxLists(queryClient, (items) =>
+        items.filter((s) => s.id !== id),
       )
-      queryClient.setQueryData<SandboxListItem[]>(sandboxKeys.all, (old) =>
-        old?.filter((s) => s.id !== id),
-      )
-      return { previous }
+      return { snapshots }
     },
     onError: (error, _id, context) => {
-      queryClient.setQueryData(sandboxKeys.all, context?.previous)
+      if (context) restoreSandboxLists(queryClient, context.snapshots)
       const message =
         error instanceof ApiError
           ? error.message
@@ -106,18 +148,16 @@ export function useBulkDeleteSandboxes() {
       await Promise.all(ids.map((id) => deleteSandbox(id)))
     },
     onMutate: async (ids) => {
-      await queryClient.cancelQueries({ queryKey: sandboxKeys.all })
-      const previous = queryClient.getQueryData<SandboxListItem[]>(
-        sandboxKeys.all,
-      )
+      await queryClient.cancelQueries({ queryKey: sandboxKeys.lists() })
+      const snapshots = snapshotSandboxLists(queryClient)
       const idSet = new Set(ids)
-      queryClient.setQueryData<SandboxListItem[]>(sandboxKeys.all, (old) =>
-        old?.filter((s) => !idSet.has(s.id)),
+      patchSandboxLists(queryClient, (items) =>
+        items.filter((s) => !idSet.has(s.id)),
       )
-      return { previous }
+      return { snapshots }
     },
     onError: (error, _ids, context) => {
-      queryClient.setQueryData(sandboxKeys.all, context?.previous)
+      if (context) restoreSandboxLists(queryClient, context.snapshots)
       const message =
         error instanceof ApiError
           ? error.message
@@ -137,29 +177,28 @@ export function usePauseSandbox() {
   return useMutation({
     mutationFn: (id: string) => pauseSandbox(id),
     onMutate: async (id) => {
-      await queryClient.cancelQueries({ queryKey: sandboxKeys.all })
-      const previousList = queryClient.getQueryData<SandboxListItem[]>(
-        sandboxKeys.all,
-      )
+      await queryClient.cancelQueries({ queryKey: sandboxKeys.lists() })
+      const snapshots = snapshotSandboxLists(queryClient)
       const previousDetail = queryClient.getQueryData<SandboxResponse>(
         sandboxKeys.detail(id),
       )
-      queryClient.setQueryData<SandboxListItem[]>(sandboxKeys.all, (old) =>
-        old?.map((s) =>
-          s.id === id ? { ...s, status: "paused" as const } : s,
-        ),
+      patchSandboxLists(queryClient, (items) =>
+        items.map((s) => (s.id === id ? { ...s, status: "paused" } : s)),
       )
       queryClient.setQueryData<SandboxResponse>(sandboxKeys.detail(id), (old) =>
-        old ? { ...old, status: "paused" as const } : old,
+        old ? { ...old, status: "paused" } : old,
       )
-      return { previousList, previousDetail }
+      return { snapshots, previousDetail }
     },
     onError: (error, id, context) => {
-      if (context?.previousList !== undefined) {
-        queryClient.setQueryData(sandboxKeys.all, context.previousList)
-      }
-      if (context?.previousDetail !== undefined) {
-        queryClient.setQueryData(sandboxKeys.detail(id), context.previousDetail)
+      if (context) {
+        restoreSandboxLists(queryClient, context.snapshots)
+        if (context.previousDetail !== undefined) {
+          queryClient.setQueryData(
+            sandboxKeys.detail(id),
+            context.previousDetail,
+          )
+        }
       }
       const message =
         error instanceof ApiError
@@ -180,27 +219,23 @@ export function useResumeSandbox() {
   return useMutation({
     mutationFn: (id: string) => resumeSandbox(id),
     onMutate: async (id) => {
-      await queryClient.cancelQueries({ queryKey: sandboxKeys.all })
-      const previousList = queryClient.getQueryData<SandboxListItem[]>(
-        sandboxKeys.all,
-      )
+      await queryClient.cancelQueries({ queryKey: sandboxKeys.lists() })
+      const snapshots = snapshotSandboxLists(queryClient)
       const previousDetail = queryClient.getQueryData<SandboxResponse>(
         sandboxKeys.detail(id),
       )
-      queryClient.setQueryData<SandboxListItem[]>(sandboxKeys.all, (old) =>
-        old?.map((s) =>
-          s.id === id ? { ...s, status: "resuming" as const } : s,
-        ),
+      patchSandboxLists(queryClient, (items) =>
+        items.map((s) => (s.id === id ? { ...s, status: "resuming" } : s)),
       )
       queryClient.setQueryData<SandboxResponse>(sandboxKeys.detail(id), (old) =>
-        old ? { ...old, status: "resuming" as const } : old,
+        old ? { ...old, status: "resuming" } : old,
       )
-      return { previousList, previousDetail }
+      return { snapshots, previousDetail }
     },
     onSuccess: (resumed, id) => {
-      // Server returns a fresh access_token with the resume response — write
-      // it into the detail cache so the terminal and file-transfer panels
-      // pick up the new token without waiting for a refetch.
+      // The resume response carries a fresh access_token — write it into the
+      // detail cache so the terminal and file panels pick it up without waiting
+      // for a refetch.
       queryClient.setQueryData<SandboxResponse>(sandboxKeys.detail(id), (old) =>
         old
           ? {
@@ -210,16 +245,19 @@ export function useResumeSandbox() {
             }
           : old,
       )
-      queryClient.setQueryData<SandboxListItem[]>(sandboxKeys.all, (old) =>
-        old?.map((s) => (s.id === id ? { ...s, status: resumed.status } : s)),
+      patchSandboxLists(queryClient, (items) =>
+        items.map((s) => (s.id === id ? { ...s, status: resumed.status } : s)),
       )
     },
     onError: (error, id, context) => {
-      if (context?.previousList !== undefined) {
-        queryClient.setQueryData(sandboxKeys.all, context.previousList)
-      }
-      if (context?.previousDetail !== undefined) {
-        queryClient.setQueryData(sandboxKeys.detail(id), context.previousDetail)
+      if (context) {
+        restoreSandboxLists(queryClient, context.snapshots)
+        if (context.previousDetail !== undefined) {
+          queryClient.setQueryData(
+            sandboxKeys.detail(id),
+            context.previousDetail,
+          )
+        }
       }
       const message =
         error instanceof ApiError

--- a/apps/console/src/hooks/use-selection.ts
+++ b/apps/console/src/hooks/use-selection.ts
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useCallback, useState } from "react"
 
 interface UseSelectionReturn {
   selected: Set<string>
@@ -38,7 +38,9 @@ export function useSelection(items: { id: string }[]): UseSelectionReturn {
     })
   }
 
-  const clearSelection = () => setSelected(new Set())
+  // Stable identity so callers can safely list it in effect deps (e.g. "clear
+  // selection when the page/filter changes") without re-running every render.
+  const clearSelection = useCallback(() => setSelected(new Set()), [])
 
   return {
     selected,

--- a/apps/console/src/hooks/use-templates.ts
+++ b/apps/console/src/hooks/use-templates.ts
@@ -1,9 +1,14 @@
 "use client"
 
 import { useToast } from "@superserve/ui"
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import {
+  keepPreviousData,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query"
 
-import { ApiError } from "@/lib/api/client"
+import { ApiError, type PagedResult } from "@/lib/api/client"
 import { templateKeys } from "@/lib/api/query-keys"
 import {
   cancelTemplateBuild,
@@ -14,15 +19,36 @@ import {
   getTemplateBuild,
   listTemplateBuilds,
   listTemplates,
+  listTemplatesPaged,
 } from "@/lib/api/templates"
-import type { CreateTemplateRequest, TemplateResponse } from "@/lib/api/types"
+import type {
+  CreateTemplateRequest,
+  TemplateListParams,
+  TemplateResponse,
+} from "@/lib/api/types"
 
 const TERMINAL_TEMPLATE_STATUSES = new Set(["ready", "failed"])
 const TERMINAL_BUILD_STATUSES = new Set(["ready", "failed", "cancelled"])
 
+/** Paginated template list backing the Templates page. */
+export function useTemplatesPage(params: TemplateListParams) {
+  return useQuery({
+    queryKey: templateKeys.list(params),
+    queryFn: () => listTemplatesPaged(params),
+    // Keep the current page on screen while the next page/sort/filter loads.
+    placeholderData: keepPreviousData,
+    refetchInterval: 10_000,
+    refetchIntervalInBackground: false,
+  })
+}
+
+/**
+ * Full (unpaginated) template list backing the create-sandbox template picker,
+ * which needs every template to choose from.
+ */
 export function useTemplates() {
   return useQuery({
-    queryKey: templateKeys.list(),
+    queryKey: templateKeys.fullList(),
     queryFn: () => listTemplates(),
     refetchInterval: 10_000,
     refetchIntervalInBackground: false,
@@ -147,21 +173,31 @@ export function useDeleteTemplate() {
   return useMutation({
     mutationFn: (id: string) => deleteTemplate(id),
     onMutate: async (id) => {
-      await queryClient.cancelQueries({ queryKey: templateKeys.lists() })
-      const snapshots = queryClient.getQueriesData<TemplateResponse[]>({
-        queryKey: templateKeys.lists(),
+      await queryClient.cancelQueries({ queryKey: templateKeys.all })
+      // Two cache shapes hold templates: the paginated page ({ items, total })
+      // and the picker's full array. Optimistically drop the row from both.
+      const pagedSnapshots = queryClient.getQueriesData<
+        PagedResult<TemplateResponse>
+      >({ queryKey: templateKeys.lists() })
+      const fullSnapshots = queryClient.getQueriesData<TemplateResponse[]>({
+        queryKey: templateKeys.fullLists(),
       })
-      for (const [key, data] of snapshots) {
-        if (!data) continue
-        queryClient.setQueryData<TemplateResponse[]>(
-          key,
-          data.filter((t) => t.id !== id),
-        )
-      }
-      return { snapshots }
+      queryClient.setQueriesData<PagedResult<TemplateResponse>>(
+        { queryKey: templateKeys.lists() },
+        (old) =>
+          old ? { ...old, items: old.items.filter((t) => t.id !== id) } : old,
+      )
+      queryClient.setQueriesData<TemplateResponse[]>(
+        { queryKey: templateKeys.fullLists() },
+        (old) => (old ? old.filter((t) => t.id !== id) : old),
+      )
+      return { pagedSnapshots, fullSnapshots }
     },
     onError: (error, _id, context) => {
-      for (const [key, data] of context?.snapshots ?? []) {
+      for (const [key, data] of context?.pagedSnapshots ?? []) {
+        queryClient.setQueryData(key, data)
+      }
+      for (const [key, data] of context?.fullSnapshots ?? []) {
         queryClient.setQueryData(key, data)
       }
       const message =

--- a/apps/console/src/lib/api/client.ts
+++ b/apps/console/src/lib/api/client.ts
@@ -10,14 +10,26 @@ export class ApiError extends Error {
   }
 }
 
+/** A page of list results plus the total row count across all pages. */
+export interface PagedResult<T> {
+  items: T[]
+  total: number
+}
+
 function getBaseUrl(): string {
   return "/api"
 }
 
-export async function apiClient<T>(
+/**
+ * Runs a request against the console API proxy with a 30s timeout and unified
+ * error handling, then hands the successful Response to `read`. The reader runs
+ * inside the timeout window so a slow body read still aborts.
+ */
+async function request<R>(
   path: string,
-  options: RequestInit = {},
-): Promise<T> {
+  options: RequestInit,
+  read: (response: Response) => Promise<R>,
+): Promise<R> {
   const url = `${getBaseUrl()}${path}`
 
   const headers = new Headers(options.headers)
@@ -54,12 +66,41 @@ export async function apiClient<T>(
       throw new ApiError(response.status, code, message)
     }
 
-    if (response.status === 204) {
-      return undefined as T
-    }
-
-    return response.json()
+    return await read(response)
   } finally {
     clearTimeout(timeout)
   }
+}
+
+export async function apiClient<T>(
+  path: string,
+  options: RequestInit = {},
+): Promise<T> {
+  return request(path, options, async (response) => {
+    if (response.status === 204) {
+      return undefined as T
+    }
+    return response.json() as Promise<T>
+  })
+}
+
+/**
+ * Like `apiClient`, but for list endpoints: returns the parsed array plus the
+ * total row count from the `X-Total-Count` header. Falls back to the page
+ * length when the header is absent (e.g. an older API build without
+ * pagination), so callers always get a usable `total`.
+ */
+export async function apiClientList<T>(
+  path: string,
+  options: RequestInit = {},
+): Promise<PagedResult<T>> {
+  return request(path, options, async (response) => {
+    const items = (await response.json()) as T[]
+    const header = response.headers.get("X-Total-Count")
+    const parsed = header != null ? Number(header) : Number.NaN
+    return {
+      items,
+      total: Number.isFinite(parsed) ? parsed : items.length,
+    }
+  })
 }

--- a/apps/console/src/lib/api/query-keys.ts
+++ b/apps/console/src/lib/api/query-keys.ts
@@ -1,8 +1,10 @@
+import type { SandboxListParams, TemplateListParams } from "./types"
+
 export const sandboxKeys = {
   all: ["sandboxes"] as const,
   lists: () => [...sandboxKeys.all, "list"] as const,
-  list: (filters: { status?: string; search?: string }) =>
-    [...sandboxKeys.lists(), filters] as const,
+  list: (params: SandboxListParams) =>
+    [...sandboxKeys.lists(), params] as const,
   details: () => [...sandboxKeys.all, "detail"] as const,
   detail: (id: string) => [...sandboxKeys.details(), id] as const,
 }
@@ -80,9 +82,14 @@ export const billingKeys = {
 
 export const templateKeys = {
   all: ["templates"] as const,
+  // Paginated list backing the Templates page.
   lists: () => [...templateKeys.all, "list"] as const,
-  list: (filters?: { name_prefix?: string }) =>
-    [...templateKeys.lists(), filters ?? {}] as const,
+  list: (params: TemplateListParams) =>
+    [...templateKeys.lists(), params] as const,
+  // Full (unpaginated) list backing the create-sandbox template picker.
+  fullLists: () => [...templateKeys.all, "full"] as const,
+  fullList: (filters?: { name_prefix?: string }) =>
+    [...templateKeys.fullLists(), filters ?? {}] as const,
   details: () => [...templateKeys.all, "detail"] as const,
   detail: (id: string) => [...templateKeys.details(), id] as const,
   builds: (templateId: string) =>

--- a/apps/console/src/lib/api/sandboxes.ts
+++ b/apps/console/src/lib/api/sandboxes.ts
@@ -1,14 +1,30 @@
-import { apiClient } from "./client"
+import { apiClient, apiClientList, type PagedResult } from "./client"
 import type {
   CreateSandboxRequest,
   ResumeResponse,
   SandboxListItem,
+  SandboxListParams,
   SandboxPatch,
   SandboxResponse,
 } from "./types"
 
-export async function listSandboxes(): Promise<SandboxListItem[]> {
-  return apiClient<SandboxListItem[]>("/sandboxes")
+function sandboxListQuery(params: SandboxListParams): string {
+  const q = new URLSearchParams()
+  q.set("limit", String(params.pageSize))
+  q.set("offset", String((params.page - 1) * params.pageSize))
+  q.set("sort", params.sort)
+  q.set("order", params.order)
+  if (params.status) q.set("status", params.status)
+  if (params.q) q.set("q", params.q)
+  return q.toString()
+}
+
+export async function listSandboxesPaged(
+  params: SandboxListParams,
+): Promise<PagedResult<SandboxListItem>> {
+  return apiClientList<SandboxListItem>(
+    `/sandboxes?${sandboxListQuery(params)}`,
+  )
 }
 
 export async function getSandbox(id: string): Promise<SandboxResponse> {

--- a/apps/console/src/lib/api/templates.ts
+++ b/apps/console/src/lib/api/templates.ts
@@ -1,11 +1,16 @@
-import { apiClient } from "./client"
+import { apiClient, apiClientList, type PagedResult } from "./client"
 import type {
   CreateTemplateRequest,
   CreateTemplateResponse,
   TemplateBuildResponse,
+  TemplateListParams,
   TemplateResponse,
 } from "./types"
 
+/**
+ * Full (unpaginated) template list. Backs the create-sandbox template picker,
+ * which needs every template to choose from. Optional prefix filter.
+ */
 export async function listTemplates(params?: {
   name_prefix?: string
 }): Promise<TemplateResponse[]> {
@@ -14,6 +19,26 @@ export async function listTemplates(params?: {
   const suffix = query.toString()
   return apiClient<TemplateResponse[]>(
     `/templates${suffix ? `?${suffix}` : ""}`,
+  )
+}
+
+function templateListQuery(params: TemplateListParams): string {
+  const q = new URLSearchParams()
+  q.set("limit", String(params.pageSize))
+  q.set("offset", String((params.page - 1) * params.pageSize))
+  q.set("sort", params.sort)
+  q.set("order", params.order)
+  q.set("owner", params.owner)
+  if (params.q) q.set("q", params.q)
+  return q.toString()
+}
+
+/** Paginated template list backing the Templates page. */
+export async function listTemplatesPaged(
+  params: TemplateListParams,
+): Promise<PagedResult<TemplateResponse>> {
+  return apiClientList<TemplateResponse>(
+    `/templates?${templateListQuery(params)}`,
   )
 }
 

--- a/apps/console/src/lib/api/types.ts
+++ b/apps/console/src/lib/api/types.ts
@@ -59,6 +59,23 @@ export interface SandboxPatch {
   metadata?: Record<string, string>
 }
 
+export type SortDirection = "asc" | "desc"
+
+export type SandboxSortColumn = "created_at" | "name" | "status"
+
+/** Query params for the paginated sandbox list (GET /sandboxes). */
+export interface SandboxListParams {
+  /** 1-based page number. */
+  page: number
+  pageSize: number
+  sort: SandboxSortColumn
+  order: SortDirection
+  /** Exact status filter (e.g. "active", "paused"); omit for all statuses. */
+  status?: string
+  /** Case-insensitive name substring search. */
+  q?: string
+}
+
 export interface ApiKeyResponse {
   id: string
   name: string
@@ -184,6 +201,28 @@ export interface TemplateBuildResponse {
   started_at?: string
   finalized_at?: string
   created_at: string
+}
+
+export type TemplateOwnerFilter = "all" | "team" | "system"
+
+export type TemplateSortColumn =
+  | "created_at"
+  | "name"
+  | "status"
+  | "size"
+  | "built_at"
+
+/** Query params for the paginated template list (GET /templates). */
+export interface TemplateListParams {
+  /** 1-based page number. */
+  page: number
+  pageSize: number
+  sort: TemplateSortColumn
+  order: SortDirection
+  /** Which shelf to return: all (team + system), team-only, or system-only. */
+  owner: TemplateOwnerFilter
+  /** Case-insensitive name substring search. */
+  q?: string
 }
 
 export interface BuildLogEvent {

--- a/apps/console/src/lib/api/types.ts
+++ b/apps/console/src/lib/api/types.ts
@@ -61,7 +61,10 @@ export interface SandboxPatch {
 
 export type SortDirection = "asc" | "desc"
 
-export type SandboxSortColumn = "created_at" | "name" | "status"
+/** Sort columns GET /sandboxes accepts; also the allowlist for URL ?sort=. */
+export const SANDBOX_SORT_COLUMNS = ["created_at", "name", "status"] as const
+
+export type SandboxSortColumn = (typeof SANDBOX_SORT_COLUMNS)[number]
 
 /** Query params for the paginated sandbox list (GET /sandboxes). */
 export interface SandboxListParams {
@@ -205,12 +208,16 @@ export interface TemplateBuildResponse {
 
 export type TemplateOwnerFilter = "all" | "team" | "system"
 
-export type TemplateSortColumn =
-  | "created_at"
-  | "name"
-  | "status"
-  | "size"
-  | "built_at"
+/** Sort columns GET /templates accepts; also the allowlist for URL ?sort=. */
+export const TEMPLATE_SORT_COLUMNS = [
+  "created_at",
+  "name",
+  "status",
+  "size",
+  "built_at",
+] as const
+
+export type TemplateSortColumn = (typeof TEMPLATE_SORT_COLUMNS)[number]
 
 /** Query params for the paginated template list (GET /templates). */
 export interface TemplateListParams {

--- a/apps/console/src/test/react-query.tsx
+++ b/apps/console/src/test/react-query.tsx
@@ -9,7 +9,7 @@
  *   import { renderHook, waitFor } from "@testing-library/react"
  *
  *   const { wrapper, queryClient } = createQueryWrapper()
- *   const { result } = renderHook(() => useSandboxes(), { wrapper })
+ *   const { result } = renderHook(() => useSandboxesPage(params), { wrapper })
  *   await waitFor(() => expect(result.current.isSuccess).toBe(true))
  */
 


### PR DESCRIPTION
## What

Adds server-side pagination, sorting, and filtering to the **Sandboxes** and **Templates** list views. Both pages previously fetched the entire list and filtered/searched in memory, which doesn't scale as a team accumulates sandboxes/templates. Each view now fetches only the current page and reads the total from the `X-Total-Count` response header.

## How

- **API client** (`lib/api/client.ts`): new `apiClientList` returns `{ items, total }`, reading `X-Total-Count` and falling back to page length when the header is absent — so it degrades gracefully against an API that doesn't paginate yet.
- **Hooks**: `useSandboxesPage` / `useTemplatesPage` take `{ page, pageSize, sort, order, status|owner, q }` and use `placeholderData: keepPreviousData` to avoid flicker. Optimistic mutation caches were reworked from a single full-array key to per-page `{ items, total }` caches (`setQueriesData` over `…lists()`).
- **URL state**: shared `useListParams` hook keeps page/size/sort/order/search in the URL (shareable, survives refresh); search is debounced.
- **Components**: new design-language `Pagination` (prev/next + numbered pages + "X–Y of Z" + page-size selector) and `SortableTableHead`.
- **Favicon**: `useFaviconStatus` (mounted globally in the dashboard shell) previously polled the **full** sandbox list every 10s — now a cheap `status=resuming&limit=1` probe.

## Backward compatibility

The API contract stays a bare array; pagination is **opt-in** query params + a response header. This PR degrades gracefully: against an API without pagination it shows one page of the full list, and fully activates once the paired backend PR is deployed.

**Depends on** the backend PR in `superserve-ai/sandbox` for the server-side params + `X-Total-Count` to take effect. (Backward-compatible, so ordering isn't strict.)

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test` — 348 passing (incl. new `Pagination` tests + updated `use-sandboxes` hook tests)
- [x] `bunx oxlint` / `oxfmt --check` — clean
- [ ] Manual: paginate / sort / filter / search on both pages against a backend that has the pagination params (staging, post backend deploy)