### PR TITLE
console: multi-cell support — team directory fan-out, per-cell writes, usw team creation

### DIFF
--- a/apps/console/src/app/(dashboard)/settings/page.tsx
+++ b/apps/console/src/app/(dashboard)/settings/page.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from "react"
 
 import { GoogleIcon, Spinner } from "@/components/icons"
 import { PageHeader } from "@/components/page-header"
+import { TeamsSection } from "@/components/settings/teams-section"
 import { useBillingSettings } from "@/hooks/use-billing-usage"
 import { useUser } from "@/hooks/use-user"
 import { SETTINGS_EVENTS } from "@/lib/posthog/events"
@@ -219,6 +220,9 @@ export default function SettingsPage() {
         </div>
 
         <Separator />
+
+        {/* Renders nothing unless a second cell (region) is configured */}
+        <TeamsSection />
 
         {billingSettings?.enabled && (
           <>

--- a/apps/console/src/app/api/[...path]/route.test.ts
+++ b/apps/console/src/app/api/[...path]/route.test.ts
@@ -14,6 +14,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 // Mocks declared BEFORE the module under test is imported.
 vi.mock("@/lib/api/proxy-auth", () => ({
+  getApiBaseUrlForUser: vi.fn(),
   getAuthApiKeyForUser: vi.fn(),
 }))
 vi.mock("@/lib/supabase/server", () => ({
@@ -24,10 +25,13 @@ vi.mock("@/lib/supabase/server", () => ({
 const fetchSpy = vi.fn()
 vi.stubGlobal("fetch", fetchSpy)
 
-// SANDBOX_API_URL is pre-stubbed in src/test/setup.ts before the route
-// module is imported (route reads it at module load).
+// SANDBOX_API_URL is pre-stubbed in src/test/setup.ts; the route resolves
+// the upstream per request via the cell registry / proxy-auth.
 
-import { getAuthApiKeyForUser } from "@/lib/api/proxy-auth"
+import {
+  getApiBaseUrlForUser,
+  getAuthApiKeyForUser,
+} from "@/lib/api/proxy-auth"
 import { createServerClient } from "@/lib/supabase/server"
 
 import { DELETE, GET, POST, PUT } from "./route"
@@ -59,6 +63,10 @@ describe("api proxy /api/[...path]", () => {
     } as never)
     vi.mocked(getAuthApiKeyForUser).mockReset()
     vi.mocked(getAuthApiKeyForUser).mockResolvedValue("ss_live_test_key")
+    vi.mocked(getApiBaseUrlForUser).mockReset()
+    vi.mocked(getApiBaseUrlForUser).mockResolvedValue(
+      "https://api.test.superserve.ai",
+    )
   })
 
   it("returns 404 for a path outside the allowed prefixes", async () => {
@@ -119,6 +127,16 @@ describe("api proxy /api/[...path]", () => {
     expect(url).toBe(
       "https://api.test.superserve.ai/sandboxes?status=active&q=foo",
     )
+  })
+
+  it("forwards to the team's home cell base URL", async () => {
+    vi.mocked(getApiBaseUrlForUser).mockResolvedValue(
+      "https://api-usw.test.superserve.ai",
+    )
+    fetchSpy.mockResolvedValue(new Response("[]", { status: 200 }))
+    await GET(req("GET", ["sandboxes"]), params(["sandboxes"]))
+    const [url] = fetchSpy.mock.calls[0]
+    expect(url).toBe("https://api-usw.test.superserve.ai/sandboxes")
   })
 
   it("skips X-API-Key injection on /v1/auth/ paths and preserves Authorization", async () => {

--- a/apps/console/src/app/api/[...path]/route.ts
+++ b/apps/console/src/app/api/[...path]/route.ts
@@ -1,10 +1,11 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-import { getAuthApiKeyForUser } from "@/lib/api/proxy-auth"
+import {
+  getApiBaseUrlForUser,
+  getAuthApiKeyForUser,
+} from "@/lib/api/proxy-auth"
+import { cellFor, DEFAULT_REGION } from "@/lib/cells"
 import { createServerClient } from "@/lib/supabase/server"
-
-const SANDBOX_API_URL =
-  process.env.SANDBOX_API_URL ?? "https://api.superserve.ai"
 
 const ALLOWED_PREFIXES = [
   "sandboxes",
@@ -56,15 +57,16 @@ async function proxyRequest(
     return NextResponse.json({ error: "Not found" }, { status: 404 })
   }
 
-  const url = new URL(`${SANDBOX_API_URL}/${joinedPath}`)
-  url.search = request.nextUrl.search
-
   const headers = new Headers()
   for (const [key, value] of request.headers.entries()) {
     if (FORWARD_REQUEST_HEADERS.has(key.toLowerCase())) {
       headers.set(key, value)
     }
   }
+
+  // Paths that carry their own auth (no key injection) go to the default
+  // cell; authenticated requests go to the user's team's home cell.
+  let apiBaseUrl = cellFor(DEFAULT_REGION).apiBaseUrl
 
   // Inject server-side API key for authenticated requests
   if (!shouldSkipKeyInjection(joinedPath)) {
@@ -74,14 +76,18 @@ async function proxyRequest(
     } = await supabase.auth.getUser()
     const apiKey = await getAuthApiKeyForUser(user)
 
-    if (!apiKey) {
+    if (!apiKey || !user) {
       return NextResponse.json(
         { error: { code: "unauthorized", message: "Not authenticated" } },
         { status: 401 },
       )
     }
     headers.set("X-API-Key", apiKey)
+    apiBaseUrl = await getApiBaseUrlForUser(user)
   }
+
+  const url = new URL(`${apiBaseUrl}/${joinedPath}`)
+  url.search = request.nextUrl.search
 
   const body =
     request.method !== "GET" && request.method !== "HEAD"

--- a/apps/console/src/app/api/team-management/[[...path]]/route.test.ts
+++ b/apps/console/src/app/api/team-management/[[...path]]/route.test.ts
@@ -8,6 +8,7 @@ vi.mock("@/lib/admin/permissions", () => ({
   canViewOtherUsersAccount: vi.fn(),
 }))
 vi.mock("@/lib/api/proxy-auth", () => ({
+  getApiBaseUrlForUser: vi.fn(),
   getAuthApiKeyForUser: vi.fn(),
   getTeamIdForUser: vi.fn(),
 }))
@@ -16,7 +17,11 @@ const fetchSpy = vi.fn()
 vi.stubGlobal("fetch", fetchSpy)
 
 import { canViewOtherUsersAccount } from "@/lib/admin/permissions"
-import { getAuthApiKeyForUser, getTeamIdForUser } from "@/lib/api/proxy-auth"
+import {
+  getApiBaseUrlForUser,
+  getAuthApiKeyForUser,
+  getTeamIdForUser,
+} from "@/lib/api/proxy-auth"
 import { createServerClient } from "@/lib/supabase/server"
 
 import { DELETE, GET, POST } from "./route"
@@ -56,6 +61,9 @@ describe("api proxy /api/team-management", () => {
     vi.mocked(canViewOtherUsersAccount).mockReturnValue(true)
     vi.mocked(getTeamIdForUser).mockResolvedValue("team-1")
     vi.mocked(getAuthApiKeyForUser).mockResolvedValue("ss_live_test_key")
+    vi.mocked(getApiBaseUrlForUser).mockResolvedValue(
+      "https://api.test.superserve.ai",
+    )
     fetchSpy.mockImplementation(() =>
       Promise.resolve(
         new Response(JSON.stringify({ members: [] }), {

--- a/apps/console/src/app/api/team-management/[[...path]]/route.ts
+++ b/apps/console/src/app/api/team-management/[[...path]]/route.ts
@@ -1,11 +1,12 @@
 import { type NextRequest, NextResponse } from "next/server"
 
 import { canViewOtherUsersAccount } from "@/lib/admin/permissions"
-import { getAuthApiKeyForUser, getTeamIdForUser } from "@/lib/api/proxy-auth"
+import {
+  getApiBaseUrlForUser,
+  getAuthApiKeyForUser,
+  getTeamIdForUser,
+} from "@/lib/api/proxy-auth"
 import { createServerClient } from "@/lib/supabase/server"
-
-const SANDBOX_API_URL =
-  process.env.SANDBOX_API_URL ?? "https://api.superserve.ai"
 
 const FORWARD_REQUEST_HEADERS = new Set([
   "accept",
@@ -84,7 +85,9 @@ async function proxyTeamManagementRequest(
     )
   }
 
-  const url = new URL(`${SANDBOX_API_URL}${targetPath}`)
+  // Team management lives in the team's home cell's control plane.
+  const apiBaseUrl = await getApiBaseUrlForUser(user)
+  const url = new URL(`${apiBaseUrl}${targetPath}`)
   if (request.method === "GET" || request.method === "HEAD") {
     url.search = request.nextUrl.search
   }

--- a/apps/console/src/components/settings/teams-section.tsx
+++ b/apps/console/src/components/settings/teams-section.tsx
@@ -1,0 +1,126 @@
+"use client"
+
+import {
+  Button,
+  Field,
+  Input,
+  Select,
+  SelectItem,
+  SelectPopup,
+  SelectTrigger,
+  SelectValue,
+  Separator,
+  useToast,
+} from "@superserve/ui"
+import { useState } from "react"
+
+import { useCreateTeam, useTeams } from "@/hooks/use-teams"
+
+const REGION_LABELS: Record<string, string> = {
+  use: "US East",
+  usw: "US West",
+}
+
+function regionLabel(region: string): string {
+  return REGION_LABELS[region] ?? region
+}
+
+/**
+ * Team directory + create-team form. Only rendered when more than one cell
+ * is configured — the single-cell console has no team creation surface, and
+ * that must stay true until a second region exists to choose from.
+ */
+export function TeamsSection() {
+  const { data } = useTeams()
+  const createTeam = useCreateTeam()
+  const { addToast } = useToast()
+
+  const [name, setName] = useState("")
+  const [region, setRegion] = useState("use")
+
+  if (!data || data.regions.length <= 1) return null
+
+  const handleCreate = () => {
+    createTeam.mutate(
+      { name, region },
+      {
+        onSuccess: (team) => {
+          setName("")
+          addToast(
+            `Team ${team.name} created in ${regionLabel(team.region)}`,
+            "success",
+          )
+        },
+        onError: (error) => {
+          addToast(error.message || "Failed to create team", "error")
+        },
+      },
+    )
+  }
+
+  return (
+    <>
+      <div className="grid grid-cols-[240px_1fr] gap-12 px-8 py-8">
+        <div>
+          <h2 className="text-base font-medium text-foreground">Teams</h2>
+          <p className="mt-1 text-xs text-muted">
+            Your teams and the region each is homed in.
+          </p>
+        </div>
+        <div className="max-w-md space-y-5">
+          <div className="border border-dashed border-border">
+            {data.teams.map((team) => (
+              <div
+                key={`${team.region}:${team.id}`}
+                className="flex items-center justify-between border-b border-dashed border-border px-4 py-3 last:border-b-0"
+              >
+                <span className="text-sm text-foreground">{team.name}</span>
+                <span className="font-mono text-xs text-muted uppercase">
+                  {regionLabel(team.region)}
+                </span>
+              </div>
+            ))}
+            {data.teams.length === 0 && (
+              <p className="px-4 py-3 text-xs text-muted">No teams yet.</p>
+            )}
+          </div>
+          <Field label="New Team Name">
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="my-team"
+            />
+          </Field>
+          <Field label="Region">
+            <Select
+              value={region}
+              onValueChange={(v) => setRegion(v as string)}
+            >
+              <SelectTrigger aria-label="Team region">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectPopup>
+                {data.regions.map((r) => (
+                  <SelectItem key={r} value={r}>
+                    {regionLabel(r)}
+                  </SelectItem>
+                ))}
+              </SelectPopup>
+            </Select>
+          </Field>
+          <div>
+            <Button
+              onClick={handleCreate}
+              disabled={!name.trim() || createTeam.isPending}
+              size="sm"
+            >
+              {createTeam.isPending ? "Creating..." : "Create Team"}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <Separator />
+    </>
+  )
+}

--- a/apps/console/src/hooks/use-teams.ts
+++ b/apps/console/src/hooks/use-teams.ts
@@ -1,0 +1,25 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+
+import { teamKeys } from "@/lib/api/query-keys"
+import { createTeamAction, listTeamsAction } from "@/lib/api/teams-actions"
+
+export function useTeams() {
+  return useQuery({
+    queryKey: teamKeys.directory(),
+    queryFn: listTeamsAction,
+    staleTime: 5 * 60_000,
+  })
+}
+
+export function useCreateTeam() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ name, region }: { name: string; region: string }) =>
+      createTeamAction(name, region),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: teamKeys.all })
+    },
+  })
+}

--- a/apps/console/src/lib/api/activity-actions.ts
+++ b/apps/console/src/lib/api/activity-actions.ts
@@ -1,17 +1,15 @@
 "use server"
 
-import { createAdminClient } from "@/lib/supabase/admin"
+import {
+  listTeamMembershipsForUser,
+  type TeamMembership,
+} from "@/lib/api/team-directory"
+import { cellFor } from "@/lib/cells"
 import { createServerClient } from "@/lib/supabase/server"
 
-async function getTeamId(userId: string): Promise<string | null> {
-  const admin = createAdminClient()
-  const { data } = await admin
-    .from("team_member")
-    .select("team_id")
-    .eq("profile_id", userId)
-    .limit(1)
-    .single()
-  return data?.team_id ?? null
+async function getTeam(userId: string): Promise<TeamMembership | null> {
+  const memberships = await listTeamMembershipsForUser(userId).catch(() => [])
+  return memberships[0] ?? null
 }
 
 export async function listActivityBySandboxAction(
@@ -24,17 +22,17 @@ export async function listActivityBySandboxAction(
   } = await supabase.auth.getUser()
   if (!user) throw new Error("Not authenticated")
 
-  const teamId = await getTeamId(user.id)
-  if (!teamId) return []
+  const team = await getTeam(user.id)
+  if (!team) return []
 
-  const admin = createAdminClient()
+  const admin = cellFor(team.region).createAdminClient()
   const { data, error } = await admin
     .from("activity")
     .select(
       "id, sandbox_id, category, action, status, sandbox_name, secret_id, secret_name, duration_ms, error, metadata, created_at",
     )
     .eq("sandbox_id", sandboxId)
-    .eq("team_id", teamId)
+    .eq("team_id", team.teamId)
     .order("created_at", { ascending: false })
     .limit(limit)
 
@@ -63,16 +61,16 @@ export async function listActivityAction(limit = 100) {
   } = await supabase.auth.getUser()
   if (!user) throw new Error("Not authenticated")
 
-  const teamId = await getTeamId(user.id)
-  if (!teamId) return []
+  const team = await getTeam(user.id)
+  if (!team) return []
 
-  const admin = createAdminClient()
+  const admin = cellFor(team.region).createAdminClient()
   const { data, error } = await admin
     .from("activity")
     .select(
       "id, sandbox_id, category, action, status, sandbox_name, secret_id, secret_name, duration_ms, error, metadata, created_at",
     )
-    .eq("team_id", teamId)
+    .eq("team_id", team.teamId)
     .order("created_at", { ascending: false })
     .limit(limit)
 

--- a/apps/console/src/lib/api/api-keys-actions.cell.test.ts
+++ b/apps/console/src/lib/api/api-keys-actions.cell.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("@/lib/supabase/server", () => ({
+  createServerClient: async () => ({
+    auth: {
+      getUser: async () => ({
+        data: { user: { id: "u1", email: "pavitra@superserve.ai" } },
+      }),
+    },
+  }),
+}))
+
+let insertedApiKeyRow: Record<string, unknown> | null = null
+
+// Default cell: the user's profile exists, but their team lives elsewhere.
+const useClient = {
+  from: vi.fn((table: string) => {
+    if (table === "profile") {
+      return {
+        select: () => ({
+          eq: () => ({
+            single: async () => ({ data: { id: "u1" }, error: null }),
+          }),
+        }),
+      }
+    }
+    if (table === "team_member") {
+      return {
+        select: () => ({ eq: async () => ({ data: [], error: null }) }),
+      }
+    }
+    throw new Error(`unexpected table ${table} in use cell`)
+  }),
+}
+
+// usw cell: holds the membership, the team row, and receives the key insert.
+const uswClient = {
+  from: vi.fn((table: string) => {
+    if (table === "team_member") {
+      return {
+        select: () => ({
+          eq: async () => ({ data: [{ team_id: "team-west" }], error: null }),
+        }),
+      }
+    }
+    if (table === "team") {
+      return {
+        select: () => ({
+          eq: () => ({
+            single: async () => ({
+              data: { home_region: "usw" },
+              error: null,
+            }),
+          }),
+        }),
+      }
+    }
+    if (table === "api_key") {
+      return {
+        insert: (row: Record<string, unknown>) => {
+          insertedApiKeyRow = row
+          return {
+            select: () => ({
+              single: async () => ({
+                data: { id: "k1", name: "test", created_at: "2026-07-01" },
+                error: null,
+              }),
+            }),
+          }
+        },
+      }
+    }
+    throw new Error(`unexpected table ${table} in usw cell`)
+  }),
+}
+
+vi.mock("@/lib/cells", () => ({
+  DEFAULT_REGION: "use",
+  configuredRegions: () => ["use", "usw"],
+  cellFor: (region: string) => ({
+    region,
+    apiBaseUrl: `https://api-${region}.test`,
+    createAdminClient: () => (region === "usw" ? uswClient : useClient),
+  }),
+}))
+
+import { createApiKeyAction } from "./api-keys-actions"
+
+describe("createApiKeyAction cell targeting", () => {
+  it("writes the key row to the team's home cell", async () => {
+    const res = await createApiKeyAction("test")
+
+    expect(res.key).toMatch(/^ss_live_usw_/)
+    expect(insertedApiKeyRow).toMatchObject({
+      team_id: "team-west",
+      name: "test",
+      created_by: "u1",
+    })
+    // The default cell only saw the profile check and membership fan-out.
+    const useTables = useClient.from.mock.calls.map(([table]) => table)
+    expect(useTables).not.toContain("api_key")
+  })
+})

--- a/apps/console/src/lib/api/api-keys-actions.cell.test.ts
+++ b/apps/console/src/lib/api/api-keys-actions.cell.test.ts
@@ -10,6 +10,7 @@ vi.mock("@/lib/supabase/server", () => ({
   }),
 }))
 
+let uswProfileChecked = false
 let insertedApiKeyRow: Record<string, unknown> | null = null
 
 // Default cell: the user's profile exists, but their team lives elsewhere.
@@ -55,6 +56,18 @@ const uswClient = {
         }),
       }
     }
+    if (table === "profile") {
+      // ensureProfile now runs in the team's cell before the key insert —
+      // report the profile as present so the write path proceeds.
+      uswProfileChecked = true
+      return {
+        select: () => ({
+          eq: () => ({
+            single: async () => ({ data: { id: "u1" }, error: null }),
+          }),
+        }),
+      }
+    }
     if (table === "api_key") {
       return {
         insert: (row: Record<string, unknown>) => {
@@ -91,6 +104,7 @@ describe("createApiKeyAction cell targeting", () => {
     const res = await createApiKeyAction("test")
 
     expect(res.key).toMatch(/^ss_live_usw_/)
+    expect(uswProfileChecked).toBe(true)
     expect(insertedApiKeyRow).toMatchObject({
       team_id: "team-west",
       name: "test",

--- a/apps/console/src/lib/api/api-keys-actions.cell.test.ts
+++ b/apps/console/src/lib/api/api-keys-actions.cell.test.ts
@@ -25,6 +25,13 @@ const useClient = {
         }),
       }
     }
+    if (table === "team_memberships") {
+      return {
+        select: () => ({
+          eq: async () => ({ data: [], error: null }),
+        }),
+      }
+    }
     if (table === "team_member") {
       return {
         select: () => ({ eq: async () => ({ data: [], error: null }) }),
@@ -37,6 +44,13 @@ const useClient = {
 // usw cell: holds the membership, the team row, and receives the key insert.
 const uswClient = {
   from: vi.fn((table: string) => {
+    if (table === "team_memberships") {
+      return {
+        select: () => ({
+          eq: async () => ({ data: [], error: null }),
+        }),
+      }
+    }
     if (table === "team_member") {
       return {
         select: () => ({

--- a/apps/console/src/lib/api/api-keys-actions.create.test.ts
+++ b/apps/console/src/lib/api/api-keys-actions.create.test.ts
@@ -40,7 +40,12 @@ vi.mock("@/lib/supabase/admin", () => ({
         case "profile":
           return chain({ data: { id: "a1" }, error: null })
         case "team_member":
-          return chain({ data: { team_id: "team-1" }, error: null })
+          // The membership fan-out awaits the filter directly (no single()).
+          return {
+            select: () => ({
+              eq: async () => ({ data: [{ team_id: "team-1" }], error: null }),
+            }),
+          }
         case "team":
           return chain(homeRegionResult)
         case "api_key": {

--- a/apps/console/src/lib/api/api-keys-actions.create.test.ts
+++ b/apps/console/src/lib/api/api-keys-actions.create.test.ts
@@ -39,6 +39,8 @@ vi.mock("@/lib/supabase/admin", () => ({
       switch (table) {
         case "profile":
           return chain({ data: { id: "a1" }, error: null })
+        case "team_memberships":
+          return chain({ data: [], error: null })
         case "team_member":
           // The membership fan-out awaits the filter directly (no single()).
           return {

--- a/apps/console/src/lib/api/api-keys-actions.ts
+++ b/apps/console/src/lib/api/api-keys-actions.ts
@@ -50,11 +50,17 @@ function hashKey(key: string): string {
 }
 
 /**
- * Ensure a profile row exists for the authenticated user in the default
- * cell. The Go backend schema requires profile(id) to match auth.users(id).
+ * Ensure a profile row exists for the authenticated user in the given cell.
+ * The Go backend schema requires profile(id) to match auth.users(id), and
+ * profile rows are per-cell — a row must exist in whichever cell a write
+ * references it from.
  */
-async function ensureProfile(userId: string, email: string): Promise<void> {
-  const admin = cellFor(DEFAULT_REGION).createAdminClient()
+async function ensureProfile(
+  region: string,
+  userId: string,
+  email: string,
+): Promise<void> {
+  const admin = cellFor(region).createAdminClient()
   const { data: existing } = await admin
     .from("profile")
     .select("id")
@@ -84,7 +90,7 @@ async function getOrCreateTeamForUser(
   email: string,
 ): Promise<TeamMembership> {
   // Ensure profile exists first (FK target for team_member and api_key)
-  await ensureProfile(userId, email)
+  await ensureProfile(DEFAULT_REGION, userId, email)
 
   // Try to find existing team membership in any configured cell
   const memberships = await listTeamMembershipsForUser(userId)
@@ -159,7 +165,11 @@ export async function createApiKeyAction(name: string) {
   const keyPrefix = `${rawKey.slice(0, `ss_live_${region}_`.length + 8)}...`
 
   // The key row must live in the team's cell — that's the database the
-  // team's control plane authenticates against.
+  // team's control plane authenticates against. The creator's profile row
+  // (created_by FK target) must exist in that same cell: today only
+  // createTeamAction guarantees it, and a membership provisioned any other
+  // way (seed, admin tooling, migration) would otherwise FK-violate here.
+  await ensureProfile(team.region, user.id, user.email ?? user.id)
   const admin = cellFor(team.region).createAdminClient()
   const { data, error } = await admin
     .from("api_key")

--- a/apps/console/src/lib/api/api-keys-actions.ts
+++ b/apps/console/src/lib/api/api-keys-actions.ts
@@ -35,8 +35,12 @@ async function getTeamHomeRegion(team: TeamMembership): Promise<string> {
     .select("home_region")
     .eq("id", team.teamId)
     .single()
+  // Fall back to the cell the team was discovered in, not DEFAULT_REGION:
+  // a transient read failure for a usw team must not mint a use-prefixed
+  // key that the edge would route to the wrong cell. team.region is always
+  // a configured region, so it is a safe routing prefix.
   if (error || !data?.home_region || !REGION_CODES.has(data.home_region)) {
-    return DEFAULT_REGION
+    return team.region
   }
   return data.home_region as string
 }

--- a/apps/console/src/lib/api/api-keys-actions.ts
+++ b/apps/console/src/lib/api/api-keys-actions.ts
@@ -2,7 +2,11 @@
 
 import crypto from "node:crypto"
 
-import { createAdminClient } from "@/lib/supabase/admin"
+import {
+  listTeamMembershipsForUser,
+  type TeamMembership,
+} from "@/lib/api/team-directory"
+import { cellFor, DEFAULT_REGION } from "@/lib/cells"
 import { createServerClient } from "@/lib/supabase/server"
 
 // Region codes embedded in new API keys (ss_live_<region>_...). Must stay in
@@ -12,7 +16,6 @@ import { createServerClient } from "@/lib/supabase/server"
 // without a region segment keep working: the control plane hashes the whole
 // string, so the format is opaque to auth.
 const REGION_CODES = new Set(["use", "usw"])
-const DEFAULT_REGION = "use"
 
 function generateRawKey(region: string): string {
   const bytes = crypto.randomBytes(24)
@@ -25,12 +28,12 @@ function generateRawKey(region: string): string {
  * home_region migration hasn't been applied yet or the value is unknown, so
  * key creation never breaks on schema skew.
  */
-async function getTeamHomeRegion(teamId: string): Promise<string> {
-  const admin = createAdminClient()
+async function getTeamHomeRegion(team: TeamMembership): Promise<string> {
+  const admin = cellFor(team.region).createAdminClient()
   const { data, error } = await admin
     .from("team")
     .select("home_region")
-    .eq("id", teamId)
+    .eq("id", team.teamId)
     .single()
   if (error || !data?.home_region || !REGION_CODES.has(data.home_region)) {
     return DEFAULT_REGION
@@ -43,11 +46,11 @@ function hashKey(key: string): string {
 }
 
 /**
- * Ensure a profile row exists for the authenticated user.
- * The Go backend schema requires profile(id) to match auth.users(id).
+ * Ensure a profile row exists for the authenticated user in the default
+ * cell. The Go backend schema requires profile(id) to match auth.users(id).
  */
 async function ensureProfile(userId: string, email: string): Promise<void> {
-  const admin = createAdminClient()
+  const admin = cellFor(DEFAULT_REGION).createAdminClient()
   const { data: existing } = await admin
     .from("profile")
     .select("id")
@@ -68,29 +71,23 @@ async function ensureProfile(userId: string, email: string): Promise<void> {
 }
 
 /**
- * Look up the user's team via team_member. If no team exists,
- * auto-create one (named after their email) and add them as owner.
+ * Look up the user's team across configured cells. If no team exists,
+ * auto-create one (named after their email) in the default cell and add
+ * them as owner.
  */
 async function getOrCreateTeamForUser(
   userId: string,
   email: string,
-): Promise<string> {
-  const admin = createAdminClient()
-
+): Promise<TeamMembership> {
   // Ensure profile exists first (FK target for team_member and api_key)
   await ensureProfile(userId, email)
 
-  // Try to find existing team membership
-  const { data: membership } = await admin
-    .from("team_member")
-    .select("team_id")
-    .eq("profile_id", userId)
-    .limit(1)
-    .single()
+  // Try to find existing team membership in any configured cell
+  const memberships = await listTeamMembershipsForUser(userId)
+  if (memberships[0]) return memberships[0]
 
-  if (membership?.team_id) return membership.team_id
-
-  // No team — create one and add user as owner
+  // No team — create one in the default cell and add user as owner
+  const admin = cellFor(DEFAULT_REGION).createAdminClient()
   const { data: team, error: teamErr } = await admin
     .from("team")
     .insert({ name: email })
@@ -108,7 +105,7 @@ async function getOrCreateTeamForUser(
   if (memberErr)
     throw new Error(`Failed to add team member: ${memberErr.message}`)
 
-  return team.id as string
+  return { teamId: team.id as string, region: DEFAULT_REGION }
 }
 
 export async function listApiKeysAction() {
@@ -118,13 +115,13 @@ export async function listApiKeysAction() {
   } = await supabase.auth.getUser()
   if (!user) throw new Error("Not authenticated")
 
-  const teamId = await getOrCreateTeamForUser(user.id, user.email ?? user.id)
+  const team = await getOrCreateTeamForUser(user.id, user.email ?? user.id)
 
-  const admin = createAdminClient()
+  const admin = cellFor(team.region).createAdminClient()
   const { data, error } = await admin
     .from("api_key")
     .select("id, name, key_hash, created_at, last_used_at")
-    .eq("team_id", teamId)
+    .eq("team_id", team.teamId)
     .is("revoked_at", null)
     .neq("name", "__console_proxy__")
     .order("created_at", { ascending: false })
@@ -147,9 +144,9 @@ export async function createApiKeyAction(name: string) {
   } = await supabase.auth.getUser()
   if (!user) throw new Error("Not authenticated")
 
-  const teamId = await getOrCreateTeamForUser(user.id, user.email ?? user.id)
+  const team = await getOrCreateTeamForUser(user.id, user.email ?? user.id)
 
-  const region = await getTeamHomeRegion(teamId)
+  const region = await getTeamHomeRegion(team)
   const rawKey = generateRawKey(region)
   const keyHash = hashKey(rawKey)
   // ss_live_<region>_ plus the first 8 random chars, e.g. "ss_live_use_AbCdEfGh..."
@@ -157,11 +154,13 @@ export async function createApiKeyAction(name: string) {
   // different length still shows exactly 8 random chars.
   const keyPrefix = `${rawKey.slice(0, `ss_live_${region}_`.length + 8)}...`
 
-  const admin = createAdminClient()
+  // The key row must live in the team's cell — that's the database the
+  // team's control plane authenticates against.
+  const admin = cellFor(team.region).createAdminClient()
   const { data, error } = await admin
     .from("api_key")
     .insert({
-      team_id: teamId,
+      team_id: team.teamId,
       key_hash: keyHash,
       name,
       scopes: [],
@@ -188,14 +187,14 @@ export async function revokeApiKeyAction(id: string) {
   } = await supabase.auth.getUser()
   if (!user) throw new Error("Not authenticated")
 
-  const teamId = await getOrCreateTeamForUser(user.id, user.email ?? user.id)
+  const team = await getOrCreateTeamForUser(user.id, user.email ?? user.id)
 
-  const admin = createAdminClient()
+  const admin = cellFor(team.region).createAdminClient()
   const { error } = await admin
     .from("api_key")
     .update({ revoked_at: new Date().toISOString() })
     .eq("id", id)
-    .eq("team_id", teamId)
+    .eq("team_id", team.teamId)
 
   if (error) throw new Error(error.message)
 }

--- a/apps/console/src/lib/api/billing-actions.test.ts
+++ b/apps/console/src/lib/api/billing-actions.test.ts
@@ -154,6 +154,10 @@ describe("billing actions", () => {
       return featureFlagResult(false)
     })
     from.mockImplementation((table: string) => {
+      if (table === "team_memberships")
+        return {
+          select: () => ({ eq: async () => ({ data: [], error: null }) }),
+        }
       if (table === "team_member") return singleTeamResult()
       if (table === "team_pricing_plan") return teamPricingPlanQuery()
       if (table === "pricing_plan") return pricingPlanQuery()

--- a/apps/console/src/lib/api/billing-actions.ts
+++ b/apps/console/src/lib/api/billing-actions.ts
@@ -3,7 +3,7 @@
 import type { SupabaseClient } from "@supabase/supabase-js"
 
 import {
-  listTeamMembershipsForUser,
+  listTeamMembershipsForUserDetailed,
   type TeamMembership,
 } from "@/lib/api/team-directory"
 import { cellFor } from "@/lib/cells"
@@ -54,7 +54,19 @@ export interface BillingSettingsResponse {
 }
 
 async function getTeam(userId: string): Promise<TeamMembership | null> {
-  const memberships = await listTeamMembershipsForUser(userId)
+  const { memberships, degradedRegions } =
+    await listTeamMembershipsForUserDetailed(userId)
+
+  // Fail closed on a partial directory read: with a cell unreachable,
+  // "exactly one membership" may just mean the other team's cell is down —
+  // billing must never show a different team's numbers because a sibling
+  // region blinked.
+  if (degradedRegions.length > 0) {
+    throw new Error(
+      "Billing is temporarily unavailable while part of the team directory is unreachable — retry shortly",
+    )
+  }
+
   if (!memberships.length) return null
 
   const uniqueTeams = new Map(memberships.map((m) => [m.teamId, m]))

--- a/apps/console/src/lib/api/billing-actions.ts
+++ b/apps/console/src/lib/api/billing-actions.ts
@@ -1,6 +1,12 @@
 "use server"
 
-import { createAdminClient } from "@/lib/supabase/admin"
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+import {
+  listTeamMembershipsForUser,
+  type TeamMembership,
+} from "@/lib/api/team-directory"
+import { cellFor } from "@/lib/cells"
 import { createServerClient } from "@/lib/supabase/server"
 
 const MAX_USAGE_RANGE_MS = 90 * 24 * 60 * 60 * 1000
@@ -47,27 +53,15 @@ export interface BillingSettingsResponse {
   pricing?: BillingPricing
 }
 
-async function getTeamId(userId: string): Promise<string | null> {
-  const admin = createAdminClient()
-  const { data, error } = await admin
-    .from("team_member")
-    .select("team_id")
-    .eq("profile_id", userId)
+async function getTeam(userId: string): Promise<TeamMembership | null> {
+  const memberships = await listTeamMembershipsForUser(userId)
+  if (!memberships.length) return null
 
-  if (error) throw new Error(error.message)
-  if (!data?.length) return null
-
-  const teamIds = [
-    ...new Set(
-      data
-        .map((row) => row.team_id)
-        .filter((teamId): teamId is string => typeof teamId === "string"),
-    ),
-  ]
-  if (teamIds.length !== 1) {
+  const uniqueTeams = new Map(memberships.map((m) => [m.teamId, m]))
+  if (uniqueTeams.size !== 1) {
     throw new Error("Select a team before viewing billing usage")
   }
-  return teamIds[0]
+  return [...uniqueTeams.values()][0]
 }
 
 function normalizePeriod(periodStart: string, periodEnd: string) {
@@ -93,10 +87,10 @@ function normalizePeriod(periodStart: string, periodEnd: string) {
 }
 
 async function getFeatureEnabled(
+  admin: SupabaseClient,
   teamId: string,
   flagKey: string,
 ): Promise<boolean> {
-  const admin = createAdminClient()
   const { data: enabled, error } = await admin.rpc("feature_enabled", {
     flag_key: flagKey,
     flag_team_id: teamId,
@@ -130,8 +124,10 @@ function compareNullableStringsDesc(left: unknown, right: unknown): number {
   return rightString.localeCompare(leftString)
 }
 
-async function getTeamPricingPlanKey(teamId: string): Promise<string> {
-  const admin = createAdminClient()
+async function getTeamPricingPlanKey(
+  admin: SupabaseClient,
+  teamId: string,
+): Promise<string> {
   const now = new Date().toISOString()
   const { data: assignments, error: assignmentError } = await admin
     .from("team_pricing_plan")
@@ -167,9 +163,9 @@ async function getTeamPricingPlanKey(teamId: string): Promise<string> {
 }
 
 async function getBillingPricingForPlan(
+  admin: SupabaseClient,
   planKey: string,
 ): Promise<BillingPricing> {
-  const admin = createAdminClient()
   const now = new Date().toISOString()
   const { data: rates, error } = await admin
     .from("pricing_rate")
@@ -236,9 +232,12 @@ async function getBillingPricingForPlan(
   }
 }
 
-async function getTeamBillingPricing(teamId: string): Promise<BillingPricing> {
-  const planKey = await getTeamPricingPlanKey(teamId)
-  return getBillingPricingForPlan(planKey)
+async function getTeamBillingPricing(
+  admin: SupabaseClient,
+  teamId: string,
+): Promise<BillingPricing> {
+  const planKey = await getTeamPricingPlanKey(admin, teamId)
+  return getBillingPricingForPlan(admin, planKey)
 }
 
 export async function getBillingUsageAction(
@@ -253,8 +252,8 @@ export async function getBillingUsageAction(
   } = await supabase.auth.getUser()
   if (!user) throw new Error("Not authenticated")
 
-  const teamId = await getTeamId(user.id)
-  if (!teamId) {
+  const team = await getTeam(user.id)
+  if (!team) {
     return {
       enabled: false,
       billing_mode: "disabled",
@@ -264,7 +263,15 @@ export async function getBillingUsageAction(
     }
   }
 
-  const dashboardEnabled = await getFeatureEnabled(teamId, USAGE_DASHBOARD_FLAG)
+  // All billing data lives in the team's home cell.
+  const admin = cellFor(team.region).createAdminClient()
+  const teamId = team.teamId
+
+  const dashboardEnabled = await getFeatureEnabled(
+    admin,
+    teamId,
+    USAGE_DASHBOARD_FLAG,
+  )
   if (!dashboardEnabled) {
     return {
       enabled: false,
@@ -276,8 +283,8 @@ export async function getBillingUsageAction(
   }
 
   const [metricsWriteEnabled, billingExportEnabled] = await Promise.all([
-    getFeatureEnabled(teamId, BILLING_METRICS_WRITE_FLAG),
-    getFeatureEnabled(teamId, BILLING_EXPORT_FLAG),
+    getFeatureEnabled(admin, teamId, BILLING_METRICS_WRITE_FLAG),
+    getFeatureEnabled(admin, teamId, BILLING_EXPORT_FLAG),
   ])
   if (!metricsWriteEnabled) {
     return {
@@ -292,9 +299,8 @@ export async function getBillingUsageAction(
   const billingMode: BillingUsageMode = billingExportEnabled
     ? "active"
     : "shadow"
-  const pricing = await getTeamBillingPricing(teamId)
+  const pricing = await getTeamBillingPricing(admin, teamId)
 
-  const admin = createAdminClient()
   const { data, error } = await admin
     .from("team_billing_usage_hourly")
     .select(
@@ -337,16 +343,18 @@ export async function getBillingSettingsAction(): Promise<BillingSettingsRespons
   } = await supabase.auth.getUser()
   if (!user) throw new Error("Not authenticated")
 
-  const teamId = await getTeamId(user.id)
-  if (!teamId) {
+  const team = await getTeam(user.id)
+  if (!team) {
     return {
       enabled: false,
       billing_mode: "disabled",
     }
   }
 
+  const admin = cellFor(team.region).createAdminClient()
   const billingExportEnabled = await getFeatureEnabled(
-    teamId,
+    admin,
+    team.teamId,
     BILLING_EXPORT_FLAG,
   )
 
@@ -360,6 +368,6 @@ export async function getBillingSettingsAction(): Promise<BillingSettingsRespons
   return {
     enabled: true,
     billing_mode: "active",
-    pricing: await getTeamBillingPricing(teamId),
+    pricing: await getTeamBillingPricing(admin, team.teamId),
   }
 }

--- a/apps/console/src/lib/api/proxy-auth.test.ts
+++ b/apps/console/src/lib/api/proxy-auth.test.ts
@@ -1,5 +1,5 @@
 /**
- * proxy-auth — pure helpers.
+ * proxy-auth — pure helpers and cell targeting.
  *
  * These are the security-critical primitives used by every authenticated
  * request through the API proxy. Tests focus on:
@@ -7,6 +7,7 @@
  *  - Different users → different keys
  *  - CONSOLE_PROXY_SECRET length guard
  *  - hashKey stability
+ *  - Proxy key row / upstream URL resolving to the team's home cell
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
@@ -21,7 +22,51 @@ vi.mock("@/lib/supabase/server", () => ({
   createServerClient: vi.fn(),
 }))
 
-import { deriveRawKey, getProxySecret, hashKey } from "./proxy-auth"
+// The user's team lives in the usw cell — used by the cell-targeting tests.
+vi.mock("@/lib/api/team-directory", () => ({
+  listTeamMembershipsForUser: vi.fn(async () => [
+    { teamId: "team-west", region: "usw" },
+  ]),
+}))
+
+const uswApiKeyUpserts: Array<Record<string, unknown>> = []
+vi.mock("@/lib/cells", () => ({
+  DEFAULT_REGION: "use",
+  configuredRegions: () => ["use", "usw"],
+  cellFor: (region: string) => ({
+    region,
+    apiBaseUrl: `https://api-${region}.test`,
+    createAdminClient: () =>
+      region === "usw"
+        ? {
+            // Captures the proxy key upsert.
+            from: (table: string) => ({
+              upsert: async (row: Record<string, unknown>) => {
+                uswApiKeyUpserts.push({ table, ...row })
+                return { error: null }
+              },
+            }),
+          }
+        : {
+            // ensureProfile only reads: the profile already exists.
+            from: () => ({
+              select: () => ({
+                eq: () => ({
+                  single: async () => ({ data: { id: "u1" }, error: null }),
+                }),
+              }),
+            }),
+          },
+  }),
+}))
+
+import {
+  deriveRawKey,
+  getApiBaseUrlForUser,
+  getAuthApiKeyForUser,
+  getProxySecret,
+  hashKey,
+} from "./proxy-auth"
 
 const ORIGINAL_SECRET = process.env.CONSOLE_PROXY_SECRET
 
@@ -95,5 +140,31 @@ describe("proxy-auth.hashKey", () => {
 
   it("produces different hashes for different inputs", () => {
     expect(hashKey("a")).not.toBe(hashKey("b"))
+  })
+})
+
+describe("proxy-auth cell targeting", () => {
+  const user = { id: "cell-user", email: "pavitra@superserve.ai" }
+
+  it("ensures the proxy key row in the team's home cell", async () => {
+    const key = await getAuthApiKeyForUser(user as never)
+
+    expect(key).toMatch(/^ss_live_/)
+    expect(uswApiKeyUpserts).toEqual([
+      {
+        table: "api_key",
+        team_id: "team-west",
+        key_hash: hashKey(key as string),
+        name: "__console_proxy__",
+        scopes: [],
+        created_by: "cell-user",
+      },
+    ])
+  })
+
+  it("resolves the proxy upstream to the team's home cell API", async () => {
+    expect(await getApiBaseUrlForUser(user as never)).toBe(
+      "https://api-usw.test",
+    )
   })
 })

--- a/apps/console/src/lib/api/proxy-auth.ts
+++ b/apps/console/src/lib/api/proxy-auth.ts
@@ -3,7 +3,11 @@ import crypto from "node:crypto"
 import type { User } from "@supabase/supabase-js"
 
 import { getProxySecret, hashKey } from "@/lib/api/proxy-secret"
-import { createAdminClient } from "@/lib/supabase/admin"
+import {
+  listTeamMembershipsForUser,
+  type TeamMembership,
+} from "@/lib/api/team-directory"
+import { cellFor, DEFAULT_REGION } from "@/lib/cells"
 import { createServerClient } from "@/lib/supabase/server"
 
 export { getProxySecret, hashKey } from "@/lib/api/proxy-secret"
@@ -25,11 +29,12 @@ export function deriveRawKey(userId: string): string {
 // This is not a secret cache — losing it only costs one extra idempotent
 // INSERT. Safe across instances because the DB write is idempotent.
 const ensuredUsers = new Set<string>()
-// team_id is stable per user and not a secret; safe to cache in-process.
-const teamIdCache = new Map<string, string>()
+// The team (and its home cell) is stable per user and not a secret; safe to
+// cache in-process.
+const teamCache = new Map<string, TeamMembership>()
 
 async function ensureProfile(userId: string, email: string): Promise<void> {
-  const admin = createAdminClient()
+  const admin = cellFor(DEFAULT_REGION).createAdminClient()
   const { data: existing } = await admin
     .from("profile")
     .select("id")
@@ -48,26 +53,22 @@ async function ensureProfile(userId: string, email: string): Promise<void> {
   }
 }
 
-async function getTeamForUser(userId: string, email: string): Promise<string> {
-  const cached = teamIdCache.get(userId)
+async function getTeamForUser(
+  userId: string,
+  email: string,
+): Promise<TeamMembership> {
+  const cached = teamCache.get(userId)
   if (cached) return cached
-
-  const admin = createAdminClient()
 
   await ensureProfile(userId, email)
 
-  const { data: membership } = await admin
-    .from("team_member")
-    .select("team_id")
-    .eq("profile_id", userId)
-    .limit(1)
-    .single()
-
-  if (membership?.team_id) {
-    teamIdCache.set(userId, membership.team_id as string)
-    return membership.team_id as string
+  const membership = (await listTeamMembershipsForUser(userId))[0]
+  if (membership) {
+    teamCache.set(userId, membership)
+    return membership
   }
 
+  const admin = cellFor(DEFAULT_REGION).createAdminClient()
   const { data: team, error: teamErr } = await admin
     .from("team")
     .insert({ name: email })
@@ -85,18 +86,31 @@ async function getTeamForUser(userId: string, email: string): Promise<string> {
   if (memberErr)
     throw new Error(`Failed to add team member: ${memberErr.message}`)
 
-  teamIdCache.set(userId, team.id as string)
-  return team.id as string
+  const created = { teamId: team.id as string, region: DEFAULT_REGION }
+  teamCache.set(userId, created)
+  return created
 }
 
 export async function getTeamIdForUser(user: User): Promise<string> {
-  return getTeamForUser(user.id, user.email ?? user.id)
+  const { teamId } = await getTeamForUser(user.id, user.email ?? user.id)
+  return teamId
 }
 
 /**
- * Ensure the derived proxy key's hash exists in the api_key table.
- * Idempotent: does an INSERT ... ON CONFLICT (key_hash) DO NOTHING, so
- * concurrent callers across multiple instances cannot stomp each other.
+ * Base URL of the control-plane API serving the user's team. Proxied
+ * requests must go to the team's home cell — that's the only control plane
+ * whose database holds the proxy key row.
+ */
+export async function getApiBaseUrlForUser(user: User): Promise<string> {
+  const { region } = await getTeamForUser(user.id, user.email ?? user.id)
+  return cellFor(region).apiBaseUrl
+}
+
+/**
+ * Ensure the derived proxy key's hash exists in the api_key table of the
+ * team's home cell. Idempotent: does an INSERT ... ON CONFLICT (key_hash)
+ * DO NOTHING, so concurrent callers across multiple instances cannot stomp
+ * each other.
  */
 async function ensureProxyKeyRow(
   userId: string,
@@ -105,12 +119,12 @@ async function ensureProxyKeyRow(
 ): Promise<void> {
   if (ensuredUsers.has(userId)) return
 
-  const teamId = await getTeamForUser(userId, email)
-  const admin = createAdminClient()
+  const team = await getTeamForUser(userId, email)
+  const admin = cellFor(team.region).createAdminClient()
 
   const { error } = await admin.from("api_key").upsert(
     {
-      team_id: teamId,
+      team_id: team.teamId,
       key_hash: keyHash,
       name: PROXY_KEY_NAME,
       scopes: [],

--- a/apps/console/src/lib/api/proxy-auth.ts
+++ b/apps/console/src/lib/api/proxy-auth.ts
@@ -25,13 +25,38 @@ export function deriveRawKey(userId: string): string {
   return `ss_live_${mac.toString("base64url")}`
 }
 
-// Tracks which users have had their api_key row ensured in this process.
-// This is not a secret cache — losing it only costs one extra idempotent
-// INSERT. Safe across instances because the DB write is idempotent.
-const ensuredUsers = new Set<string>()
-// The team (and its home cell) is stable per user and not a secret; safe to
-// cache in-process.
-const teamCache = new Map<string, TeamMembership>()
+// Authorization state is cached with a short TTL, never indefinitely: a
+// user removed from a team (or moved between cells) must lose proxy access
+// within a bounded window, not at the next process recycle. The TTL bounds
+// staleness to one minute; every entry costs one membership read per user
+// per minute to refresh, which is noise.
+const AUTHZ_CACHE_TTL_MS = 60_000
+
+interface Expiring<T> {
+  value: T
+  expires: number
+}
+
+function getFresh<T>(map: Map<string, Expiring<T>>, key: string): T | null {
+  const entry = map.get(key)
+  if (!entry) return null
+  if (Date.now() > entry.expires) {
+    map.delete(key)
+    return null
+  }
+  return entry.value
+}
+
+function setFresh<T>(map: Map<string, Expiring<T>>, key: string, value: T) {
+  map.set(key, { value, expires: Date.now() + AUTHZ_CACHE_TTL_MS })
+}
+
+// Users whose api_key row was ensured recently — re-ensuring is one
+// idempotent upsert, so the TTL also heals a server-side key-row deletion.
+const ensuredUsers = new Map<string, Expiring<true>>()
+// The user's team + home cell. Stable in practice, but it IS authorization
+// state, hence the TTL.
+const teamCache = new Map<string, Expiring<TeamMembership>>()
 
 async function ensureProfile(userId: string, email: string): Promise<void> {
   const admin = cellFor(DEFAULT_REGION).createAdminClient()
@@ -57,14 +82,14 @@ async function getTeamForUser(
   userId: string,
   email: string,
 ): Promise<TeamMembership> {
-  const cached = teamCache.get(userId)
+  const cached = getFresh(teamCache, userId)
   if (cached) return cached
 
   await ensureProfile(userId, email)
 
   const membership = (await listTeamMembershipsForUser(userId))[0]
   if (membership) {
-    teamCache.set(userId, membership)
+    setFresh(teamCache, userId, membership)
     return membership
   }
 
@@ -87,7 +112,7 @@ async function getTeamForUser(
     throw new Error(`Failed to add team member: ${memberErr.message}`)
 
   const created = { teamId: team.id as string, region: DEFAULT_REGION }
-  teamCache.set(userId, created)
+  setFresh(teamCache, userId, created)
   return created
 }
 
@@ -117,7 +142,7 @@ async function ensureProxyKeyRow(
   email: string,
   keyHash: string,
 ): Promise<void> {
-  if (ensuredUsers.has(userId)) return
+  if (getFresh(ensuredUsers, userId)) return
 
   const team = await getTeamForUser(userId, email)
   const admin = cellFor(team.region).createAdminClient()
@@ -135,7 +160,7 @@ async function ensureProxyKeyRow(
 
   if (error) throw new Error(`Failed to ensure proxy key: ${error.message}`)
 
-  ensuredUsers.add(userId)
+  setFresh(ensuredUsers, userId, true)
 }
 
 export async function getAuthApiKeyForUser(

--- a/apps/console/src/lib/api/query-keys.ts
+++ b/apps/console/src/lib/api/query-keys.ts
@@ -102,3 +102,8 @@ export const quotaKeys = {
   all: ["quota"] as const,
   usage: () => [...quotaKeys.all, "usage"] as const,
 }
+
+export const teamKeys = {
+  all: ["teams"] as const,
+  directory: () => [...teamKeys.all, "directory"] as const,
+}

--- a/apps/console/src/lib/api/quota-actions.ts
+++ b/apps/console/src/lib/api/quota-actions.ts
@@ -1,7 +1,7 @@
 "use server"
 
 import {
-  listTeamMembershipsForUser,
+  listTeamMembershipsForUserDetailed,
   type TeamMembership,
 } from "@/lib/api/team-directory"
 import { cellFor } from "@/lib/cells"
@@ -14,7 +14,13 @@ export interface QuotaUsageResponse {
 }
 
 async function getTeam(userId: string): Promise<TeamMembership | null> {
-  const memberships = await listTeamMembershipsForUser(userId)
+  const { memberships, degradedRegions } =
+    await listTeamMembershipsForUserDetailed(userId)
+
+  // A partial directory read makes the membership shape untrustworthy — the
+  // banner renders nothing rather than showing a possibly-wrong team's quota.
+  if (degradedRegions.length > 0) return null
+
   if (!memberships.length) return null
 
   const uniqueTeams = new Map(memberships.map((m) => [m.teamId, m]))

--- a/apps/console/src/lib/api/quota-actions.ts
+++ b/apps/console/src/lib/api/quota-actions.ts
@@ -1,6 +1,10 @@
 "use server"
 
-import { createAdminClient } from "@/lib/supabase/admin"
+import {
+  listTeamMembershipsForUser,
+  type TeamMembership,
+} from "@/lib/api/team-directory"
+import { cellFor } from "@/lib/cells"
 import { createServerClient } from "@/lib/supabase/server"
 
 export interface QuotaUsageResponse {
@@ -9,29 +13,17 @@ export interface QuotaUsageResponse {
   pct: number
 }
 
-async function getTeamId(userId: string): Promise<string | null> {
-  const admin = createAdminClient()
-  const { data, error } = await admin
-    .from("team_member")
-    .select("team_id")
-    .eq("profile_id", userId)
+async function getTeam(userId: string): Promise<TeamMembership | null> {
+  const memberships = await listTeamMembershipsForUser(userId)
+  if (!memberships.length) return null
 
-  if (error) throw new Error(error.message)
-  if (!data?.length) return null
-
-  const teamIds = [
-    ...new Set(
-      data
-        .map((row) => row.team_id)
-        .filter((teamId): teamId is string => typeof teamId === "string"),
-    ),
-  ]
+  const uniqueTeams = new Map(memberships.map((m) => [m.teamId, m]))
   // Ambient poller with no team-selector: an ambiguous (multi-team) membership
   // renders nothing rather than throwing on every poll (which would spam logs).
-  if (teamIds.length !== 1) {
+  if (uniqueTeams.size !== 1) {
     return null
   }
-  return teamIds[0]
+  return [...uniqueTeams.values()][0]
 }
 
 // Current team's sandbox usage for the in-product quota banner; null when the
@@ -45,14 +37,14 @@ export async function getQuotaUsageAction(): Promise<QuotaUsageResponse | null> 
   if (authError) throw authError
   if (!user) throw new Error("Not authenticated")
 
-  const teamId = await getTeamId(user.id)
-  if (!teamId) return null
+  const team = await getTeam(user.id)
+  if (!team) return null
 
-  const admin = createAdminClient()
+  const admin = cellFor(team.region).createAdminClient()
   const { data, error } = await admin
     .from("team")
     .select("active_sandbox_count, max_sandboxes")
-    .eq("id", teamId)
+    .eq("id", team.teamId)
     .single()
   if (error) throw new Error(error.message)
 

--- a/apps/console/src/lib/api/snapshots-actions.ts
+++ b/apps/console/src/lib/api/snapshots-actions.ts
@@ -1,17 +1,15 @@
 "use server"
 
-import { createAdminClient } from "@/lib/supabase/admin"
+import {
+  listTeamMembershipsForUser,
+  type TeamMembership,
+} from "@/lib/api/team-directory"
+import { cellFor } from "@/lib/cells"
 import { createServerClient } from "@/lib/supabase/server"
 
-async function getTeamId(userId: string): Promise<string | null> {
-  const admin = createAdminClient()
-  const { data } = await admin
-    .from("team_member")
-    .select("team_id")
-    .eq("profile_id", userId)
-    .limit(1)
-    .single()
-  return data?.team_id ?? null
+async function getTeam(userId: string): Promise<TeamMembership | null> {
+  const memberships = await listTeamMembershipsForUser(userId).catch(() => [])
+  return memberships[0] ?? null
 }
 
 export async function listSnapshotsBySandboxAction(sandboxId: string) {
@@ -21,17 +19,17 @@ export async function listSnapshotsBySandboxAction(sandboxId: string) {
   } = await supabase.auth.getUser()
   if (!user) throw new Error("Not authenticated")
 
-  const teamId = await getTeamId(user.id)
-  if (!teamId) return []
+  const team = await getTeam(user.id)
+  if (!team) return []
 
-  const admin = createAdminClient()
+  const admin = cellFor(team.region).createAdminClient()
   const { data, error } = await admin
     .from("snapshot")
     .select(
       "id, sandbox_id, team_id, name, size_bytes, saved, trigger, created_at",
     )
     .eq("sandbox_id", sandboxId)
-    .eq("team_id", teamId)
+    .eq("team_id", team.teamId)
     .order("created_at", { ascending: false })
 
   if (error) throw new Error(error.message)
@@ -54,16 +52,16 @@ export async function listSnapshotsAction() {
   } = await supabase.auth.getUser()
   if (!user) throw new Error("Not authenticated")
 
-  const teamId = await getTeamId(user.id)
-  if (!teamId) return []
+  const team = await getTeam(user.id)
+  if (!team) return []
 
-  const admin = createAdminClient()
+  const admin = cellFor(team.region).createAdminClient()
   const { data, error } = await admin
     .from("snapshot")
     .select(
       "id, sandbox_id, team_id, name, size_bytes, saved, trigger, created_at",
     )
-    .eq("team_id", teamId)
+    .eq("team_id", team.teamId)
     .order("created_at", { ascending: false })
 
   if (error) throw new Error(error.message)

--- a/apps/console/src/lib/api/team-directory.test.ts
+++ b/apps/console/src/lib/api/team-directory.test.ts
@@ -39,7 +39,11 @@ vi.mock("@/lib/cells", () => ({
   }),
 }))
 
-import { listTeamMembershipsForUser, listTeamsForUser } from "./team-directory"
+import {
+  listTeamMembershipsForUser,
+  listTeamMembershipsForUserDetailed,
+  listTeamsForUser,
+} from "./team-directory"
 
 describe("team directory fan-out", () => {
   beforeEach(() => {
@@ -162,5 +166,40 @@ describe("cell failure isolation", () => {
 
     expect(teams).toEqual([{ id: "team-1", name: "Alpha", region: "use" }])
     errSpy.mockRestore()
+  })
+})
+
+describe("degradation visibility", () => {
+  beforeEach(() => {
+    regions = ["use", "usw"]
+    cellClients = {}
+  })
+
+  it("reports which secondary cells were dropped", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    cellClients.use = cellClient([{ team_id: "team-1" }])
+    cellClients.usw = {
+      from: vi.fn(() => ({
+        select: () => ({
+          eq: async () => ({ data: null, error: { message: "usw down" } }),
+        }),
+      })),
+    } as unknown as ReturnType<typeof cellClient>
+
+    const { memberships, degradedRegions } =
+      await listTeamMembershipsForUserDetailed("u1")
+
+    expect(memberships).toEqual([{ teamId: "team-1", region: "use" }])
+    expect(degradedRegions).toEqual(["usw"])
+    errSpy.mockRestore()
+  })
+
+  it("reports no degradation when every cell answers", async () => {
+    cellClients.use = cellClient([{ team_id: "team-1" }])
+    cellClients.usw = cellClient([])
+
+    const { degradedRegions } = await listTeamMembershipsForUserDetailed("u1")
+
+    expect(degradedRegions).toEqual([])
   })
 })

--- a/apps/console/src/lib/api/team-directory.test.ts
+++ b/apps/console/src/lib/api/team-directory.test.ts
@@ -8,8 +8,16 @@ let cellClients: Record<string, ReturnType<typeof cellClient>> = {}
 function cellClient(
   memberships: Array<{ team_id: string }>,
   teams: Array<{ id: string; name: string }> = [],
+  rbac: Array<{ team_id: string; status: string }> = [],
 ) {
   const from = vi.fn((table: string) => {
+    if (table === "team_memberships") {
+      return {
+        select: () => ({
+          eq: async () => ({ data: rbac, error: null }),
+        }),
+      }
+    }
     if (table === "team_member") {
       return {
         select: () => ({
@@ -57,7 +65,8 @@ describe("team directory fan-out", () => {
     const memberships = await listTeamMembershipsForUser("u1")
 
     expect(memberships).toEqual([{ teamId: "team-1", region: "use" }])
-    expect(cellClients.use.from).toHaveBeenCalledTimes(1)
+    // RBAC + legacy membership queries — still a single cell touched.
+    expect(cellClients.use.from).toHaveBeenCalledTimes(2)
   })
 
   it("merges memberships across cells, tagged with each cell's region", async () => {
@@ -111,8 +120,8 @@ describe("team directory fan-out", () => {
     const teams = await listTeamsForUser("u1")
 
     expect(teams).toEqual([{ id: "team-1", name: "east team", region: "use" }])
-    // Only the membership query hit the empty cell.
-    expect(cellClients.usw.from).toHaveBeenCalledTimes(1)
+    // Only the membership queries hit the empty cell — no team lookup.
+    expect(cellClients.usw.from).toHaveBeenCalledTimes(2)
   })
 })
 
@@ -201,5 +210,42 @@ describe("degradation visibility", () => {
     const { degradedRegions } = await listTeamMembershipsForUserDetailed("u1")
 
     expect(degradedRegions).toEqual([])
+  })
+})
+
+describe("RBAC-authoritative membership", () => {
+  beforeEach(() => {
+    regions = ["use"]
+    cellClients = {}
+  })
+
+  it("denies a member whose RBAC membership is inactive, even with a legacy row", async () => {
+    cellClients.use = cellClient(
+      [{ team_id: "team-1" }],
+      [],
+      [{ team_id: "team-1", status: "inactive" }],
+    )
+
+    expect(await listTeamMembershipsForUser("u1")).toEqual([])
+  })
+
+  it("keeps a pure-legacy member with no RBAC row at all", async () => {
+    cellClients.use = cellClient([{ team_id: "team-1" }], [], [])
+
+    expect(await listTeamMembershipsForUser("u1")).toEqual([
+      { teamId: "team-1", region: "use" },
+    ])
+  })
+
+  it("accepts an active RBAC membership without a legacy row", async () => {
+    cellClients.use = cellClient(
+      [],
+      [],
+      [{ team_id: "team-2", status: "active" }],
+    )
+
+    expect(await listTeamMembershipsForUser("u1")).toEqual([
+      { teamId: "team-2", region: "use" },
+    ])
   })
 })

--- a/apps/console/src/lib/api/team-directory.test.ts
+++ b/apps/console/src/lib/api/team-directory.test.ts
@@ -111,3 +111,56 @@ describe("team directory fan-out", () => {
     expect(cellClients.usw.from).toHaveBeenCalledTimes(1)
   })
 })
+
+describe("cell failure isolation", () => {
+  beforeEach(() => {
+    regions = ["use", "usw"]
+    cellClients = {}
+  })
+
+  // Shape-compatible with cellClient but every query fails; cast because the
+  // success type pins error to null.
+  function failingClient(message: string) {
+    const from = vi.fn(() => ({
+      select: () => ({
+        eq: async () => ({ data: null, error: { message } }),
+      }),
+    }))
+    return { from } as unknown as ReturnType<typeof cellClient>
+  }
+
+  it("serves the remaining cells when a secondary cell fails", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    cellClients.use = cellClient([{ team_id: "team-1" }])
+    cellClients.usw = failingClient("usw pooler unreachable")
+
+    const memberships = await listTeamMembershipsForUser("u1")
+
+    expect(memberships).toEqual([{ teamId: "team-1", region: "use" }])
+    expect(errSpy).toHaveBeenCalledOnce()
+    errSpy.mockRestore()
+  })
+
+  it("still throws when the default cell fails", async () => {
+    cellClients.use = failingClient("primary down")
+    cellClients.usw = cellClient([{ team_id: "team-9" }])
+
+    await expect(listTeamMembershipsForUser("u1")).rejects.toThrow(
+      "primary down",
+    )
+  })
+
+  it("isolates a secondary-cell failure in the team directory too", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    cellClients.use = cellClient(
+      [{ team_id: "team-1" }],
+      [{ id: "team-1", name: "Alpha" }],
+    )
+    cellClients.usw = failingClient("usw down")
+
+    const teams = await listTeamsForUser("u1")
+
+    expect(teams).toEqual([{ id: "team-1", name: "Alpha", region: "use" }])
+    errSpy.mockRestore()
+  })
+})

--- a/apps/console/src/lib/api/team-directory.test.ts
+++ b/apps/console/src/lib/api/team-directory.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+// Per-test knobs read lazily by the cells mock.
+let regions: string[] = ["use"]
+let cellClients: Record<string, ReturnType<typeof cellClient>> = {}
+
+// Minimal per-cell client: team_member memberships and team name lookups.
+function cellClient(
+  memberships: Array<{ team_id: string }>,
+  teams: Array<{ id: string; name: string }> = [],
+) {
+  const from = vi.fn((table: string) => {
+    if (table === "team_member") {
+      return {
+        select: () => ({
+          eq: async () => ({ data: memberships, error: null }),
+        }),
+      }
+    }
+    if (table === "team") {
+      return {
+        select: () => ({
+          in: async () => ({ data: teams, error: null }),
+        }),
+      }
+    }
+    throw new Error(`unexpected table ${table}`)
+  })
+  return { from }
+}
+
+vi.mock("@/lib/cells", () => ({
+  DEFAULT_REGION: "use",
+  configuredRegions: () => regions,
+  cellFor: (region: string) => ({
+    region,
+    apiBaseUrl: `https://api-${region}.test`,
+    createAdminClient: () => cellClients[region],
+  }),
+}))
+
+import { listTeamMembershipsForUser, listTeamsForUser } from "./team-directory"
+
+describe("team directory fan-out", () => {
+  beforeEach(() => {
+    regions = ["use"]
+    cellClients = {}
+  })
+
+  it("reduces to the single default-cell query when only use is configured", async () => {
+    cellClients.use = cellClient([{ team_id: "team-1" }])
+
+    const memberships = await listTeamMembershipsForUser("u1")
+
+    expect(memberships).toEqual([{ teamId: "team-1", region: "use" }])
+    expect(cellClients.use.from).toHaveBeenCalledTimes(1)
+  })
+
+  it("merges memberships across cells, tagged with each cell's region", async () => {
+    regions = ["use", "usw"]
+    cellClients.use = cellClient([{ team_id: "team-1" }])
+    cellClients.usw = cellClient([{ team_id: "team-west" }])
+
+    const memberships = await listTeamMembershipsForUser("u1")
+
+    expect(memberships).toEqual([
+      { teamId: "team-1", region: "use" },
+      { teamId: "team-west", region: "usw" },
+    ])
+  })
+
+  it("returns an empty list when the user has no memberships anywhere", async () => {
+    regions = ["use", "usw"]
+    cellClients.use = cellClient([])
+    cellClients.usw = cellClient([])
+
+    expect(await listTeamMembershipsForUser("u1")).toEqual([])
+  })
+
+  it("lists teams with names from each cell for the directory", async () => {
+    regions = ["use", "usw"]
+    cellClients.use = cellClient(
+      [{ team_id: "team-1" }],
+      [{ id: "team-1", name: "east team" }],
+    )
+    cellClients.usw = cellClient(
+      [{ team_id: "team-west" }],
+      [{ id: "team-west", name: "west team" }],
+    )
+
+    const teams = await listTeamsForUser("u1")
+
+    expect(teams).toEqual([
+      { id: "team-1", name: "east team", region: "use" },
+      { id: "team-west", name: "west team", region: "usw" },
+    ])
+  })
+
+  it("skips the team lookup in cells without memberships", async () => {
+    regions = ["use", "usw"]
+    cellClients.use = cellClient(
+      [{ team_id: "team-1" }],
+      [{ id: "team-1", name: "east team" }],
+    )
+    cellClients.usw = cellClient([])
+
+    const teams = await listTeamsForUser("u1")
+
+    expect(teams).toEqual([{ id: "team-1", name: "east team", region: "use" }])
+    // Only the membership query hit the empty cell.
+    expect(cellClients.usw.from).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/console/src/lib/api/team-directory.ts
+++ b/apps/console/src/lib/api/team-directory.ts
@@ -23,35 +23,45 @@ export interface TeamDirectoryEntry {
  */
 async function acrossCells<T>(
   lookup: (region: string) => Promise<T[]>,
-): Promise<T[]> {
+): Promise<{ items: T[]; degradedRegions: string[] }> {
   const regions = configuredRegions()
   const settled = await Promise.allSettled(regions.map(lookup))
 
-  const merged: T[] = []
+  const items: T[] = []
+  const degradedRegions: string[] = []
   settled.forEach((result, i) => {
     const region = regions[i]
     if (result.status === "fulfilled") {
-      merged.push(...result.value)
+      items.push(...result.value)
       return
     }
     if (region === DEFAULT_REGION) throw result.reason
+    degradedRegions.push(region)
     console.error(
       `team directory: cell ${region} lookup failed, serving without it:`,
       result.reason,
     )
   })
-  return merged
+  return { items, degradedRegions }
+}
+
+export interface MembershipDirectory {
+  memberships: TeamMembership[]
+  // Secondary cells whose lookup failed and whose memberships are therefore
+  // missing from the list. Callers that infer anything from the SHAPE of the
+  // membership set (e.g. "exactly one team") must treat a degraded read as
+  // ambiguous rather than authoritative.
+  degradedRegions: string[]
 }
 
 /**
- * The user's team memberships across every configured cell, tagged with the
- * cell's region. With a single configured cell this is exactly the one
- * team_member query the console has always made.
+ * Membership lookup that also reports which cells could not be read. Use
+ * this wherever "how many teams does this user have" changes behavior.
  */
-export async function listTeamMembershipsForUser(
+export async function listTeamMembershipsForUserDetailed(
   userId: string,
-): Promise<TeamMembership[]> {
-  return acrossCells(async (region) => {
+): Promise<MembershipDirectory> {
+  const { items, degradedRegions } = await acrossCells(async (region) => {
     const admin = cellFor(region).createAdminClient()
     const { data, error } = await admin
       .from("team_member")
@@ -65,6 +75,19 @@ export async function listTeamMembershipsForUser(
       .filter((teamId): teamId is string => typeof teamId === "string")
       .map((teamId) => ({ teamId, region }))
   })
+  return { memberships: items, degradedRegions }
+}
+
+/**
+ * The user's team memberships across every configured cell, tagged with the
+ * cell's region. With a single configured cell this is exactly the one
+ * team_member query the console has always made.
+ */
+export async function listTeamMembershipsForUser(
+  userId: string,
+): Promise<TeamMembership[]> {
+  const { memberships } = await listTeamMembershipsForUserDetailed(userId)
+  return memberships
 }
 
 /**
@@ -74,7 +97,7 @@ export async function listTeamMembershipsForUser(
 export async function listTeamsForUser(
   userId: string,
 ): Promise<TeamDirectoryEntry[]> {
-  return acrossCells(async (region) => {
+  const { items } = await acrossCells(async (region) => {
     const admin = cellFor(region).createAdminClient()
     const { data: memberships, error } = await admin
       .from("team_member")
@@ -105,4 +128,5 @@ export async function listTeamsForUser(
       region,
     }))
   })
+  return items
 }

--- a/apps/console/src/lib/api/team-directory.ts
+++ b/apps/console/src/lib/api/team-directory.ts
@@ -1,3 +1,5 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+
 import { cellFor, configuredRegions, DEFAULT_REGION } from "@/lib/cells"
 
 export interface TeamMembership {
@@ -63,19 +65,52 @@ export async function listTeamMembershipsForUserDetailed(
 ): Promise<MembershipDirectory> {
   const { items, degradedRegions } = await acrossCells(async (region) => {
     const admin = cellFor(region).createAdminClient()
-    const { data, error } = await admin
-      .from("team_member")
-      .select("team_id")
-      .eq("profile_id", userId)
-
-    if (error) throw new Error(error.message)
-
-    return (data ?? [])
-      .map((row) => row.team_id)
-      .filter((teamId): teamId is string => typeof teamId === "string")
-      .map((teamId) => ({ teamId, region }))
+    return membershipTeamIdsInCell(admin, userId).then((teamIds) =>
+      teamIds.map((teamId) => ({ teamId, region })),
+    )
   })
   return { memberships: items, degradedRegions }
+}
+
+/**
+ * Team ids the user is authorized for in one cell. RBAC `team_memberships`
+ * is authoritative whenever a row exists — only `status = 'active'` passes,
+ * so a user deactivated through the backend user-management endpoints loses
+ * console access too (the console's service-role reads bypass backend RBAC,
+ * so this lookup is the console's authorization boundary). Legacy
+ * `team_member` rows count only for members with no RBAC row at all: those
+ * are pre-RBAC memberships that were never migrated (10 exist in prod as of
+ * 2026-07), and treating the legacy table as a discovery hint — never as an
+ * override — keeps them working without letting it resurrect revoked access.
+ */
+async function membershipTeamIdsInCell(
+  admin: SupabaseClient,
+  userId: string,
+): Promise<string[]> {
+  const [rbac, legacy] = await Promise.all([
+    admin
+      .from("team_memberships")
+      .select("team_id, status")
+      .eq("user_id", userId),
+    admin.from("team_member").select("team_id").eq("profile_id", userId),
+  ])
+  if (rbac.error) throw new Error(rbac.error.message)
+  if (legacy.error) throw new Error(legacy.error.message)
+
+  const rbacRows = (rbac.data ?? []).filter(
+    (row): row is { team_id: string; status: string } =>
+      typeof row.team_id === "string",
+  )
+  const rbacByTeam = new Map(rbacRows.map((row) => [row.team_id, row.status]))
+
+  const allowed = new Set<string>(
+    rbacRows.filter((row) => row.status === "active").map((row) => row.team_id),
+  )
+  for (const row of legacy.data ?? []) {
+    if (typeof row.team_id !== "string") continue
+    if (!rbacByTeam.has(row.team_id)) allowed.add(row.team_id)
+  }
+  return [...allowed]
 }
 
 /**
@@ -99,20 +134,9 @@ export async function listTeamsForUser(
 ): Promise<TeamDirectoryEntry[]> {
   const { items } = await acrossCells(async (region) => {
     const admin = cellFor(region).createAdminClient()
-    const { data: memberships, error } = await admin
-      .from("team_member")
-      .select("team_id")
-      .eq("profile_id", userId)
-
-    if (error) throw new Error(error.message)
-
-    const teamIds = [
-      ...new Set(
-        (memberships ?? [])
-          .map((row) => row.team_id)
-          .filter((teamId): teamId is string => typeof teamId === "string"),
-      ),
-    ]
+    // Same authorization boundary as the membership lookup — a deactivated
+    // member must not see the team in the directory either.
+    const teamIds = await membershipTeamIdsInCell(admin, userId)
     if (!teamIds.length) return []
 
     const { data: teams, error: teamErr } = await admin

--- a/apps/console/src/lib/api/team-directory.ts
+++ b/apps/console/src/lib/api/team-directory.ts
@@ -1,4 +1,4 @@
-import { cellFor, configuredRegions } from "@/lib/cells"
+import { cellFor, configuredRegions, DEFAULT_REGION } from "@/lib/cells"
 
 export interface TeamMembership {
   teamId: string
@@ -12,31 +12,59 @@ export interface TeamDirectoryEntry {
 }
 
 /**
+ * Run a per-cell lookup across every configured cell in parallel, merged in
+ * region order (default cell first).
+ *
+ * Failure isolation follows the cell architecture: an outage in a secondary
+ * cell must not take the console down for everyone else, so non-default
+ * cells degrade to an empty result (logged). The default cell still throws —
+ * that keeps single-cell behavior identical to the pre-cells console, and a
+ * hard failure there means the console is broken anyway.
+ */
+async function acrossCells<T>(
+  lookup: (region: string) => Promise<T[]>,
+): Promise<T[]> {
+  const regions = configuredRegions()
+  const settled = await Promise.allSettled(regions.map(lookup))
+
+  const merged: T[] = []
+  settled.forEach((result, i) => {
+    const region = regions[i]
+    if (result.status === "fulfilled") {
+      merged.push(...result.value)
+      return
+    }
+    if (region === DEFAULT_REGION) throw result.reason
+    console.error(
+      `team directory: cell ${region} lookup failed, serving without it:`,
+      result.reason,
+    )
+  })
+  return merged
+}
+
+/**
  * The user's team memberships across every configured cell, tagged with the
- * cell's region. Cells are queried in parallel and merged in region order
- * (default cell first), so with a single configured cell this is exactly the
- * one team_member query the console has always made.
+ * cell's region. With a single configured cell this is exactly the one
+ * team_member query the console has always made.
  */
 export async function listTeamMembershipsForUser(
   userId: string,
 ): Promise<TeamMembership[]> {
-  const perCell = await Promise.all(
-    configuredRegions().map(async (region) => {
-      const admin = cellFor(region).createAdminClient()
-      const { data, error } = await admin
-        .from("team_member")
-        .select("team_id")
-        .eq("profile_id", userId)
+  return acrossCells(async (region) => {
+    const admin = cellFor(region).createAdminClient()
+    const { data, error } = await admin
+      .from("team_member")
+      .select("team_id")
+      .eq("profile_id", userId)
 
-      if (error) throw new Error(error.message)
+    if (error) throw new Error(error.message)
 
-      return (data ?? [])
-        .map((row) => row.team_id)
-        .filter((teamId): teamId is string => typeof teamId === "string")
-        .map((teamId) => ({ teamId, region }))
-    }),
-  )
-  return perCell.flat()
+    return (data ?? [])
+      .map((row) => row.team_id)
+      .filter((teamId): teamId is string => typeof teamId === "string")
+      .map((teamId) => ({ teamId, region }))
+  })
 }
 
 /**
@@ -46,38 +74,35 @@ export async function listTeamMembershipsForUser(
 export async function listTeamsForUser(
   userId: string,
 ): Promise<TeamDirectoryEntry[]> {
-  const perCell = await Promise.all(
-    configuredRegions().map(async (region) => {
-      const admin = cellFor(region).createAdminClient()
-      const { data: memberships, error } = await admin
-        .from("team_member")
-        .select("team_id")
-        .eq("profile_id", userId)
+  return acrossCells(async (region) => {
+    const admin = cellFor(region).createAdminClient()
+    const { data: memberships, error } = await admin
+      .from("team_member")
+      .select("team_id")
+      .eq("profile_id", userId)
 
-      if (error) throw new Error(error.message)
+    if (error) throw new Error(error.message)
 
-      const teamIds = [
-        ...new Set(
-          (memberships ?? [])
-            .map((row) => row.team_id)
-            .filter((teamId): teamId is string => typeof teamId === "string"),
-        ),
-      ]
-      if (!teamIds.length) return []
+    const teamIds = [
+      ...new Set(
+        (memberships ?? [])
+          .map((row) => row.team_id)
+          .filter((teamId): teamId is string => typeof teamId === "string"),
+      ),
+    ]
+    if (!teamIds.length) return []
 
-      const { data: teams, error: teamErr } = await admin
-        .from("team")
-        .select("id, name")
-        .in("id", teamIds)
+    const { data: teams, error: teamErr } = await admin
+      .from("team")
+      .select("id, name")
+      .in("id", teamIds)
 
-      if (teamErr) throw new Error(teamErr.message)
+    if (teamErr) throw new Error(teamErr.message)
 
-      return (teams ?? []).map((t) => ({
-        id: t.id as string,
-        name: t.name as string,
-        region,
-      }))
-    }),
-  )
-  return perCell.flat()
+    return (teams ?? []).map((t) => ({
+      id: t.id as string,
+      name: t.name as string,
+      region,
+    }))
+  })
 }

--- a/apps/console/src/lib/api/team-directory.ts
+++ b/apps/console/src/lib/api/team-directory.ts
@@ -1,0 +1,83 @@
+import { cellFor, configuredRegions } from "@/lib/cells"
+
+export interface TeamMembership {
+  teamId: string
+  region: string
+}
+
+export interface TeamDirectoryEntry {
+  id: string
+  name: string
+  region: string
+}
+
+/**
+ * The user's team memberships across every configured cell, tagged with the
+ * cell's region. Cells are queried in parallel and merged in region order
+ * (default cell first), so with a single configured cell this is exactly the
+ * one team_member query the console has always made.
+ */
+export async function listTeamMembershipsForUser(
+  userId: string,
+): Promise<TeamMembership[]> {
+  const perCell = await Promise.all(
+    configuredRegions().map(async (region) => {
+      const admin = cellFor(region).createAdminClient()
+      const { data, error } = await admin
+        .from("team_member")
+        .select("team_id")
+        .eq("profile_id", userId)
+
+      if (error) throw new Error(error.message)
+
+      return (data ?? [])
+        .map((row) => row.team_id)
+        .filter((teamId): teamId is string => typeof teamId === "string")
+        .map((teamId) => ({ teamId, region }))
+    }),
+  )
+  return perCell.flat()
+}
+
+/**
+ * The user's teams across every configured cell, for directory UI. Same
+ * fan-out as the membership lookup, plus a name lookup in each cell.
+ */
+export async function listTeamsForUser(
+  userId: string,
+): Promise<TeamDirectoryEntry[]> {
+  const perCell = await Promise.all(
+    configuredRegions().map(async (region) => {
+      const admin = cellFor(region).createAdminClient()
+      const { data: memberships, error } = await admin
+        .from("team_member")
+        .select("team_id")
+        .eq("profile_id", userId)
+
+      if (error) throw new Error(error.message)
+
+      const teamIds = [
+        ...new Set(
+          (memberships ?? [])
+            .map((row) => row.team_id)
+            .filter((teamId): teamId is string => typeof teamId === "string"),
+        ),
+      ]
+      if (!teamIds.length) return []
+
+      const { data: teams, error: teamErr } = await admin
+        .from("team")
+        .select("id, name")
+        .in("id", teamIds)
+
+      if (teamErr) throw new Error(teamErr.message)
+
+      return (teams ?? []).map((t) => ({
+        id: t.id as string,
+        name: t.name as string,
+        region,
+      }))
+    }),
+  )
+  return perCell.flat()
+}

--- a/apps/console/src/lib/api/teams-actions.test.ts
+++ b/apps/console/src/lib/api/teams-actions.test.ts
@@ -12,6 +12,7 @@ vi.mock("@/lib/supabase/server", () => ({
 
 // Per-test knobs read lazily by the cells mock.
 let regions: string[] = ["use", "usw"]
+let allowedRegions: string[] | null = null
 let cellClients: Record<string, ReturnType<typeof recordingCellClient>> = {}
 
 // Records every write per table so tests can assert the full create chain
@@ -74,6 +75,7 @@ function recordingCellClient() {
 vi.mock("@/lib/cells", () => ({
   DEFAULT_REGION: "use",
   configuredRegions: () => regions,
+  creatableRegions: () => allowedRegions ?? regions,
   cellFor: (region: string) => {
     if (!regions.includes(region)) {
       throw new Error(`Region ${region} is not configured`)
@@ -86,11 +88,16 @@ vi.mock("@/lib/cells", () => ({
   },
 }))
 
-import { createTeamAction } from "./teams-actions"
+vi.mock("@/lib/api/team-directory", () => ({
+  listTeamsForUser: async () => [],
+}))
+
+import { createTeamAction, listTeamsAction } from "./teams-actions"
 
 describe("createTeamAction", () => {
   beforeEach(() => {
     regions = ["use", "usw"]
+    allowedRegions = null
     cellClients = {
       use: recordingCellClient(),
       usw: recordingCellClient(),
@@ -139,7 +146,7 @@ describe("createTeamAction", () => {
   it("rejects a region that is not configured", async () => {
     regions = ["use"]
     await expect(createTeamAction("west pilot", "usw")).rejects.toThrow(
-      "Region usw is not configured",
+      "Region usw is not available",
     )
   })
 
@@ -147,5 +154,24 @@ describe("createTeamAction", () => {
     await expect(createTeamAction("   ")).rejects.toThrow(
       "Team name is required",
     )
+  })
+})
+
+describe("multi-cell allowlist enforcement", () => {
+  beforeEach(() => {
+    regions = ["use", "usw"]
+  })
+
+  it("rejects creating in a configured region the user is not allowed into", async () => {
+    allowedRegions = ["use"]
+    await expect(createTeamAction("Pilot", "usw")).rejects.toThrow(
+      "Region usw is not available",
+    )
+  })
+
+  it("returns only the user's creatable regions from the directory action", async () => {
+    allowedRegions = ["use"]
+    const { regions: visible } = await listTeamsAction()
+    expect(visible).toEqual(["use"])
   })
 })

--- a/apps/console/src/lib/api/teams-actions.test.ts
+++ b/apps/console/src/lib/api/teams-actions.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/lib/supabase/server", () => ({
+  createServerClient: async () => ({
+    auth: {
+      getUser: async () => ({
+        data: { user: { id: "u1", email: "pavitra@superserve.ai" } },
+      }),
+    },
+  }),
+}))
+
+// Per-test knobs read lazily by the cells mock.
+let regions: string[] = ["use", "usw"]
+let cellClients: Record<string, ReturnType<typeof recordingCellClient>> = {}
+
+// Records every write per table so tests can assert the full create chain
+// landed in one cell and nowhere else.
+function recordingCellClient() {
+  const writes: Record<string, Array<Record<string, unknown>>> = {}
+  const record = (table: string, row: Record<string, unknown>) => {
+    writes[table] = [...(writes[table] ?? []), row]
+  }
+  const from = vi.fn((table: string) => {
+    switch (table) {
+      case "profile":
+        return {
+          upsert: async (row: Record<string, unknown>) => {
+            record(table, row)
+            return { error: null }
+          },
+        }
+      case "team":
+        return {
+          insert: (row: Record<string, unknown>) => {
+            record(table, row)
+            return {
+              select: () => ({
+                single: async () => ({
+                  data: { id: "team-new", name: row.name },
+                  error: null,
+                }),
+              }),
+            }
+          },
+        }
+      case "team_member":
+      case "team_memberships":
+      case "user_role_assignments":
+        return {
+          insert: async (row: Record<string, unknown>) => {
+            record(table, row)
+            return { error: null }
+          },
+        }
+      case "roles":
+        return {
+          select: () => ({
+            eq: () => ({
+              single: async () => ({
+                data: { id: "role-owner" },
+                error: null,
+              }),
+            }),
+          }),
+        }
+      default:
+        throw new Error(`unexpected table ${table}`)
+    }
+  })
+  return { from, writes }
+}
+
+vi.mock("@/lib/cells", () => ({
+  DEFAULT_REGION: "use",
+  configuredRegions: () => regions,
+  cellFor: (region: string) => {
+    if (!regions.includes(region)) {
+      throw new Error(`Region ${region} is not configured`)
+    }
+    return {
+      region,
+      apiBaseUrl: `https://api-${region}.test`,
+      createAdminClient: () => cellClients[region],
+    }
+  },
+}))
+
+import { createTeamAction } from "./teams-actions"
+
+describe("createTeamAction", () => {
+  beforeEach(() => {
+    regions = ["use", "usw"]
+    cellClients = {
+      use: recordingCellClient(),
+      usw: recordingCellClient(),
+    }
+  })
+
+  it("writes the full RBAC chain into the target cell", async () => {
+    const team = await createTeamAction("west pilot", "usw")
+
+    expect(team).toEqual({ id: "team-new", name: "west pilot", region: "usw" })
+
+    const writes = cellClients.usw.writes
+    expect(writes.profile).toEqual([
+      { id: "u1", email: "pavitra@superserve.ai" },
+    ])
+    expect(writes.team).toEqual([{ name: "west pilot", home_region: "usw" }])
+    expect(writes.team_member).toEqual([
+      { team_id: "team-new", profile_id: "u1", role: "owner" },
+    ])
+    expect(writes.team_memberships).toEqual([
+      { team_id: "team-new", user_id: "u1", status: "active" },
+    ])
+    expect(writes.user_role_assignments).toEqual([
+      {
+        user_id: "u1",
+        role_id: "role-owner",
+        scope_type: "team",
+        team_id: "team-new",
+      },
+    ])
+
+    // Nothing leaked into the default cell.
+    expect(cellClients.use.from).not.toHaveBeenCalled()
+  })
+
+  it("defaults to the default region when none is given", async () => {
+    const team = await createTeamAction("east team")
+
+    expect(team.region).toBe("use")
+    expect(cellClients.use.writes.team).toEqual([
+      { name: "east team", home_region: "use" },
+    ])
+    expect(cellClients.usw.from).not.toHaveBeenCalled()
+  })
+
+  it("rejects a region that is not configured", async () => {
+    regions = ["use"]
+    await expect(createTeamAction("west pilot", "usw")).rejects.toThrow(
+      "Region usw is not configured",
+    )
+  })
+
+  it("rejects an empty team name", async () => {
+    await expect(createTeamAction("   ")).rejects.toThrow(
+      "Team name is required",
+    )
+  })
+})

--- a/apps/console/src/lib/api/teams-actions.test.ts
+++ b/apps/console/src/lib/api/teams-actions.test.ts
@@ -53,6 +53,11 @@ function recordingCellClient() {
             record(table, row)
             return { error: null }
           },
+          // The directory's RBAC-authoritative lookup also selects from
+          // team_memberships; empty = legacy-discovery path.
+          select: () => ({
+            eq: async () => ({ data: [], error: null }),
+          }),
         }
       case "roles":
         return {

--- a/apps/console/src/lib/api/teams-actions.ts
+++ b/apps/console/src/lib/api/teams-actions.ts
@@ -1,0 +1,132 @@
+"use server"
+
+import { listTeamsForUser } from "@/lib/api/team-directory"
+import { cellFor, configuredRegions, DEFAULT_REGION } from "@/lib/cells"
+import { createServerClient } from "@/lib/supabase/server"
+
+// Role granted to a team's creator. Seeded by the control-plane RBAC
+// migration in every cell; looked up by name so the id can differ per cell.
+const TEAM_OWNER_ROLE = "team_owner"
+
+export interface TeamSummary {
+  id: string
+  name: string
+  region: string
+}
+
+export interface TeamDirectoryResponse {
+  teams: TeamSummary[]
+  // Regions teams can be created in. Length 1 unless a second cell is
+  // configured, which is what gates the region select in the UI.
+  regions: string[]
+}
+
+export async function listTeamsAction(): Promise<TeamDirectoryResponse> {
+  const supabase = await createServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) throw new Error("Not authenticated")
+
+  const teams = await listTeamsForUser(user.id)
+  return { teams, regions: configuredRegions() }
+}
+
+/**
+ * Create a team homed in the given cell. Everything the control plane needs
+ * to authorize the creator is written in that cell: profile (auth is global
+ * but profile rows are per-cell), team with home_region, the legacy
+ * team_member row the console's own lookups read, and the RBAC chain
+ * (active membership + team_owner assignment) — without which the control
+ * plane rejects every request for the team.
+ */
+export async function createTeamAction(
+  name: string,
+  region?: string,
+): Promise<TeamSummary> {
+  const supabase = await createServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) throw new Error("Not authenticated")
+
+  const trimmed = name.trim()
+  if (!trimmed) throw new Error("Team name is required")
+
+  const targetRegion = region ?? DEFAULT_REGION
+  if (!configuredRegions().includes(targetRegion)) {
+    throw new Error(`Region ${targetRegion} is not configured`)
+  }
+
+  const admin = cellFor(targetRegion).createAdminClient()
+
+  // The user may have never touched this cell before; upsert so a concurrent
+  // create can't fail on the unique id.
+  const { error: profileErr } = await admin
+    .from("profile")
+    .upsert(
+      { id: user.id, email: user.email ?? user.id },
+      { onConflict: "id", ignoreDuplicates: true },
+    )
+  if (profileErr) {
+    throw new Error(`Failed to create profile: ${profileErr.message}`)
+  }
+
+  const { data: team, error: teamErr } = await admin
+    .from("team")
+    .insert({ name: trimmed, home_region: targetRegion })
+    .select("id, name")
+    .single()
+  if (teamErr) throw new Error(`Failed to create team: ${teamErr.message}`)
+
+  const { error: memberErr } = await admin.from("team_member").insert({
+    team_id: team.id,
+    profile_id: user.id,
+    role: "owner",
+  })
+  if (memberErr) {
+    throw new Error(`Failed to add team member: ${memberErr.message}`)
+  }
+
+  // Membership must exist (and be active) before the role assignment — the
+  // control-plane schema enforces that ordering with a trigger.
+  const { error: membershipErr } = await admin.from("team_memberships").insert({
+    team_id: team.id,
+    user_id: user.id,
+    status: "active",
+  })
+  if (membershipErr) {
+    throw new Error(
+      `Failed to create team membership: ${membershipErr.message}`,
+    )
+  }
+
+  const { data: role, error: roleErr } = await admin
+    .from("roles")
+    .select("id")
+    .eq("name", TEAM_OWNER_ROLE)
+    .single()
+  if (roleErr || !role) {
+    throw new Error(
+      `Failed to look up ${TEAM_OWNER_ROLE} role: ${roleErr?.message ?? "not found"}`,
+    )
+  }
+
+  const { error: assignErr } = await admin
+    .from("user_role_assignments")
+    .insert({
+      user_id: user.id,
+      role_id: role.id,
+      scope_type: "team",
+      team_id: team.id,
+    })
+  if (assignErr) {
+    throw new Error(`Failed to assign ${TEAM_OWNER_ROLE}: ${assignErr.message}`)
+  }
+
+  return {
+    id: team.id as string,
+    name: team.name as string,
+    region: targetRegion,
+  }
+}

--- a/apps/console/src/lib/api/teams-actions.ts
+++ b/apps/console/src/lib/api/teams-actions.ts
@@ -1,7 +1,7 @@
 "use server"
 
 import { listTeamsForUser } from "@/lib/api/team-directory"
-import { cellFor, configuredRegions, DEFAULT_REGION } from "@/lib/cells"
+import { cellFor, creatableRegions, DEFAULT_REGION } from "@/lib/cells"
 import { createServerClient } from "@/lib/supabase/server"
 
 // Role granted to a team's creator. Seeded by the control-plane RBAC
@@ -16,8 +16,9 @@ export interface TeamSummary {
 
 export interface TeamDirectoryResponse {
   teams: TeamSummary[]
-  // Regions teams can be created in. Length 1 unless a second cell is
-  // configured, which is what gates the region select in the UI.
+  // Regions THIS USER may create teams in. Length 1 unless a second cell is
+  // configured AND the user is on the multi-cell UI allowlist — which is
+  // what gates the region select in the UI.
   regions: string[]
 }
 
@@ -29,7 +30,7 @@ export async function listTeamsAction(): Promise<TeamDirectoryResponse> {
   if (!user) throw new Error("Not authenticated")
 
   const teams = await listTeamsForUser(user.id)
-  return { teams, regions: configuredRegions() }
+  return { teams, regions: creatableRegions(user.email) }
 }
 
 /**
@@ -53,9 +54,11 @@ export async function createTeamAction(
   const trimmed = name.trim()
   if (!trimmed) throw new Error("Team name is required")
 
+  // Server-side enforcement, not just UI hiding: non-default regions
+  // require the multi-cell allowlist (internal-first rollout).
   const targetRegion = region ?? DEFAULT_REGION
-  if (!configuredRegions().includes(targetRegion)) {
-    throw new Error(`Region ${targetRegion} is not configured`)
+  if (!creatableRegions(user.email).includes(targetRegion)) {
+    throw new Error(`Region ${targetRegion} is not available`)
   }
 
   const admin = cellFor(targetRegion).createAdminClient()

--- a/apps/console/src/lib/api/teams-actions.ts
+++ b/apps/console/src/lib/api/teams-actions.ts
@@ -82,49 +82,84 @@ export async function createTeamAction(
     .single()
   if (teamErr) throw new Error(`Failed to create team: ${teamErr.message}`)
 
-  const { error: memberErr } = await admin.from("team_member").insert({
-    team_id: team.id,
-    profile_id: user.id,
-    role: "owner",
-  })
-  if (memberErr) {
-    throw new Error(`Failed to add team member: ${memberErr.message}`)
-  }
-
-  // Membership must exist (and be active) before the role assignment — the
-  // control-plane schema enforces that ordering with a trigger.
-  const { error: membershipErr } = await admin.from("team_memberships").insert({
-    team_id: team.id,
-    user_id: user.id,
-    status: "active",
-  })
-  if (membershipErr) {
-    throw new Error(
-      `Failed to create team membership: ${membershipErr.message}`,
-    )
-  }
-
-  const { data: role, error: roleErr } = await admin
-    .from("roles")
-    .select("id")
-    .eq("name", TEAM_OWNER_ROLE)
-    .single()
-  if (roleErr || !role) {
-    throw new Error(
-      `Failed to look up ${TEAM_OWNER_ROLE} role: ${roleErr?.message ?? "not found"}`,
-    )
-  }
-
-  const { error: assignErr } = await admin
-    .from("user_role_assignments")
-    .insert({
-      user_id: user.id,
-      role_id: role.id,
-      scope_type: "team",
+  // Postgrest calls aren't a transaction, so a failure mid-chain would leave
+  // a team the console can list but the control plane rejects (no RBAC
+  // chain). Compensate by unwinding what was written; a per-cell RPC that
+  // does the whole chain in one transaction is the durable replacement.
+  try {
+    const { error: memberErr } = await admin.from("team_member").insert({
       team_id: team.id,
+      profile_id: user.id,
+      role: "owner",
     })
-  if (assignErr) {
-    throw new Error(`Failed to assign ${TEAM_OWNER_ROLE}: ${assignErr.message}`)
+    if (memberErr) {
+      throw new Error(`Failed to add team member: ${memberErr.message}`)
+    }
+
+    // Membership must exist (and be active) before the role assignment — the
+    // control-plane schema enforces that ordering with a trigger.
+    const { error: membershipErr } = await admin
+      .from("team_memberships")
+      .insert({
+        team_id: team.id,
+        user_id: user.id,
+        status: "active",
+      })
+    if (membershipErr) {
+      throw new Error(
+        `Failed to create team membership: ${membershipErr.message}`,
+      )
+    }
+
+    const { data: role, error: roleErr } = await admin
+      .from("roles")
+      .select("id")
+      .eq("name", TEAM_OWNER_ROLE)
+      .single()
+    if (roleErr || !role) {
+      throw new Error(
+        `Failed to look up ${TEAM_OWNER_ROLE} role: ${roleErr?.message ?? "not found"}`,
+      )
+    }
+
+    const { error: assignErr } = await admin
+      .from("user_role_assignments")
+      .insert({
+        user_id: user.id,
+        role_id: role.id,
+        scope_type: "team",
+        team_id: team.id,
+      })
+    if (assignErr) {
+      throw new Error(
+        `Failed to assign ${TEAM_OWNER_ROLE}: ${assignErr.message}`,
+      )
+    }
+  } catch (chainErr) {
+    // Best-effort unwind in reverse dependency order, so a mid-chain failure
+    // can't leave a team the console lists but the control plane rejects.
+    // Failures here are logged and the original error is surfaced with the
+    // team id for manual repair.
+    for (const [table, column] of [
+      ["user_role_assignments", "team_id"],
+      ["team_memberships", "team_id"],
+      ["team_member", "team_id"],
+      ["team", "id"],
+    ] as const) {
+      const { error: unwindErr } = await admin
+        .from(table)
+        .delete()
+        .eq(column, team.id)
+      if (unwindErr) {
+        console.error(
+          `create-team unwind: failed to delete from ${table} for team ${team.id}: ${unwindErr.message}`,
+        )
+      }
+    }
+    throw new Error(
+      `${chainErr instanceof Error ? chainErr.message : String(chainErr)} (team ${team.id})`,
+      { cause: chainErr },
+    )
   }
 
   return {

--- a/apps/console/src/lib/cells.test.ts
+++ b/apps/console/src/lib/cells.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const mockCreateClient = vi.fn()
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: (...args: unknown[]) => mockCreateClient(...args),
+}))
+
+const mockCreateAdminClient = vi.fn()
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => mockCreateAdminClient(),
+}))
+
+import { cellFor, configuredRegions, DEFAULT_REGION } from "./cells"
+
+const ORIGINAL_ENV = {
+  SANDBOX_API_URL: process.env.SANDBOX_API_URL,
+  SANDBOX_API_URL_USWEST: process.env.SANDBOX_API_URL_USWEST,
+  SUPABASE_USWEST_URL: process.env.SUPABASE_USWEST_URL,
+  SUPABASE_USWEST_SERVICE_ROLE_KEY:
+    process.env.SUPABASE_USWEST_SERVICE_ROLE_KEY,
+}
+
+function restoreEnv() {
+  for (const [name, value] of Object.entries(ORIGINAL_ENV)) {
+    if (value === undefined) delete process.env[name]
+    else process.env[name] = value
+  }
+}
+
+describe("cells registry env gating", () => {
+  beforeEach(() => {
+    delete process.env.SUPABASE_USWEST_URL
+    delete process.env.SUPABASE_USWEST_SERVICE_ROLE_KEY
+    delete process.env.SANDBOX_API_URL_USWEST
+  })
+
+  afterEach(() => {
+    restoreEnv()
+    vi.clearAllMocks()
+  })
+
+  it("offers only the default region when usw env vars are absent", () => {
+    expect(configuredRegions()).toEqual([DEFAULT_REGION])
+    expect(() => cellFor("usw")).toThrow("Region usw is not configured")
+  })
+
+  it("stays dormant when the usw env is only partially configured", () => {
+    process.env.SUPABASE_USWEST_URL = "https://usw.supabase.co"
+    expect(configuredRegions()).toEqual(["use"])
+
+    delete process.env.SUPABASE_USWEST_URL
+    process.env.SUPABASE_USWEST_SERVICE_ROLE_KEY = "usw-service-role-key"
+    expect(configuredRegions()).toEqual(["use"])
+  })
+
+  it("keeps the default cell on the existing admin client and API URL", () => {
+    const adminClient = { cell: "use" }
+    mockCreateAdminClient.mockReturnValue(adminClient)
+
+    const cell = cellFor("use")
+    // setup.ts stubs SANDBOX_API_URL for every test.
+    expect(cell.apiBaseUrl).toBe("https://api.test.superserve.ai")
+    expect(cell.createAdminClient()).toBe(adminClient)
+    expect(mockCreateClient).not.toHaveBeenCalled()
+  })
+
+  it("falls back to the production API URL when SANDBOX_API_URL is unset", () => {
+    delete process.env.SANDBOX_API_URL
+    expect(cellFor("use").apiBaseUrl).toBe("https://api.superserve.ai")
+  })
+
+  it("offers usw once its Supabase env vars are set", () => {
+    process.env.SUPABASE_USWEST_URL = "https://usw.supabase.co"
+    process.env.SUPABASE_USWEST_SERVICE_ROLE_KEY = "usw-service-role-key"
+
+    expect(configuredRegions()).toEqual(["use", "usw"])
+    expect(cellFor("usw").apiBaseUrl).toBe("https://api-usw.superserve.ai")
+  })
+
+  it("uses SANDBOX_API_URL_USWEST for the usw API when set", () => {
+    process.env.SUPABASE_USWEST_URL = "https://usw.supabase.co"
+    process.env.SUPABASE_USWEST_SERVICE_ROLE_KEY = "usw-service-role-key"
+    process.env.SANDBOX_API_URL_USWEST = "https://api-usw.test.superserve.ai"
+
+    expect(cellFor("usw").apiBaseUrl).toBe("https://api-usw.test.superserve.ai")
+  })
+
+  it("builds the usw admin client from the usw env vars", () => {
+    process.env.SUPABASE_USWEST_URL = "https://usw.supabase.co"
+    process.env.SUPABASE_USWEST_SERVICE_ROLE_KEY = "usw-service-role-key"
+    mockCreateClient.mockReturnValue({})
+
+    cellFor("usw").createAdminClient()
+
+    expect(mockCreateClient).toHaveBeenCalledWith(
+      "https://usw.supabase.co",
+      "usw-service-role-key",
+      { auth: { autoRefreshToken: false, persistSession: false } },
+    )
+    expect(mockCreateAdminClient).not.toHaveBeenCalled()
+  })
+})

--- a/apps/console/src/lib/cells.test.ts
+++ b/apps/console/src/lib/cells.test.ts
@@ -100,3 +100,26 @@ describe("cells registry env gating", () => {
     expect(mockCreateAdminClient).not.toHaveBeenCalled()
   })
 })
+
+describe("admin client reuse", () => {
+  beforeEach(() => {
+    mockCreateClient.mockClear()
+    mockCreateClient.mockImplementation(() => ({}))
+    process.env.SUPABASE_USWEST_URL = "https://usw.supabase.test"
+  })
+
+  it("returns the same usw client across calls", () => {
+    process.env.SUPABASE_USWEST_SERVICE_ROLE_KEY = "svc-key-reuse"
+    cellFor("usw").createAdminClient()
+    cellFor("usw").createAdminClient()
+    expect(mockCreateClient).toHaveBeenCalledTimes(1)
+  })
+
+  it("builds a fresh client when the credentials change", () => {
+    process.env.SUPABASE_USWEST_SERVICE_ROLE_KEY = "svc-key-a"
+    cellFor("usw").createAdminClient()
+    process.env.SUPABASE_USWEST_SERVICE_ROLE_KEY = "svc-key-b"
+    cellFor("usw").createAdminClient()
+    expect(mockCreateClient).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/console/src/lib/cells.test.ts
+++ b/apps/console/src/lib/cells.test.ts
@@ -10,7 +10,12 @@ vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: () => mockCreateAdminClient(),
 }))
 
-import { cellFor, configuredRegions, DEFAULT_REGION } from "./cells"
+import {
+  cellFor,
+  configuredRegions,
+  creatableRegions,
+  DEFAULT_REGION,
+} from "./cells"
 
 const ORIGINAL_ENV = {
   SANDBOX_API_URL: process.env.SANDBOX_API_URL,
@@ -121,5 +126,34 @@ describe("admin client reuse", () => {
     process.env.SUPABASE_USWEST_SERVICE_ROLE_KEY = "svc-key-b"
     cellFor("usw").createAdminClient()
     expect(mockCreateClient).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe("multi-cell UI allowlist", () => {
+  beforeEach(() => {
+    process.env.SUPABASE_USWEST_URL = "https://usw.supabase.test"
+    process.env.SUPABASE_USWEST_SERVICE_ROLE_KEY = "svc-key"
+    delete process.env.MULTI_CELL_UI_ALLOWLIST
+  })
+
+  it("offers only the default region without an allowlist, even with usw live", () => {
+    expect(creatableRegions("dev@superserve.ai")).toEqual(["use"])
+  })
+
+  it("matches @domain entries case-insensitively", () => {
+    process.env.MULTI_CELL_UI_ALLOWLIST = "@superserve.ai"
+    expect(creatableRegions("Dev@Superserve.AI")).toEqual(["use", "usw"])
+    expect(creatableRegions("someone@customer.com")).toEqual(["use"])
+  })
+
+  it("matches exact-email entries and ignores list whitespace", () => {
+    process.env.MULTI_CELL_UI_ALLOWLIST = " pilot@acme.com , @superserve.ai "
+    expect(creatableRegions("pilot@acme.com")).toEqual(["use", "usw"])
+    expect(creatableRegions("other@acme.com")).toEqual(["use"])
+  })
+
+  it("denies undefined emails", () => {
+    process.env.MULTI_CELL_UI_ALLOWLIST = "@superserve.ai"
+    expect(creatableRegions(undefined)).toEqual(["use"])
   })
 })

--- a/apps/console/src/lib/cells.ts
+++ b/apps/console/src/lib/cells.ts
@@ -29,6 +29,24 @@ function defaultCell(): Cell {
   }
 }
 
+// One client per credential set, reused across calls — a fresh client per
+// call would bypass HTTP agent reuse and risk socket exhaustion under load.
+// Keyed by url+key (not a singleton) so tests that swap env, and future key
+// rotations, get a matching client instead of a stale one.
+const clientCache = new Map<string, SupabaseClient>()
+
+function cachedClient(url: string, serviceRoleKey: string): SupabaseClient {
+  const cacheKey = `${url}\n${serviceRoleKey}`
+  let client = clientCache.get(cacheKey)
+  if (!client) {
+    client = createClient(url, serviceRoleKey, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    })
+    clientCache.set(cacheKey, client)
+  }
+  return client
+}
+
 function uswCell(): Cell | null {
   const url = process.env.SUPABASE_USWEST_URL
   const serviceRoleKey = process.env.SUPABASE_USWEST_SERVICE_ROLE_KEY
@@ -38,10 +56,7 @@ function uswCell(): Cell | null {
     region: "usw",
     apiBaseUrl:
       process.env.SANDBOX_API_URL_USWEST ?? "https://api-usw.superserve.ai",
-    createAdminClient: () =>
-      createClient(url, serviceRoleKey, {
-        auth: { autoRefreshToken: false, persistSession: false },
-      }),
+    createAdminClient: () => cachedClient(url, serviceRoleKey),
   }
 }
 

--- a/apps/console/src/lib/cells.ts
+++ b/apps/console/src/lib/cells.ts
@@ -76,3 +76,31 @@ export function cellFor(region: string): Cell {
   if (!cell) throw new Error(`Region ${region} is not configured`)
   return cell
 }
+
+// Multi-cell UI allowlist. Region choice (and later the team switcher,
+// SS-162) rolls out person-by-person, independent of which cells are
+// configured: MULTI_CELL_UI_ALLOWLIST is a comma-separated list of email
+// addresses and/or @domain entries (e.g. "@superserve.ai,pilot@acme.com").
+// Absent or unmatched, users see only the default region even when other
+// cells are live — so wiring a cell's env vars alone exposes nothing.
+export function multiCellUiEnabled(email: string | undefined): boolean {
+  const allowlist = process.env.MULTI_CELL_UI_ALLOWLIST
+  if (!allowlist || !email) return false
+  const normalized = email.toLowerCase()
+  return allowlist
+    .split(",")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean)
+    .some((entry) =>
+      entry.startsWith("@") ? normalized.endsWith(entry) : normalized === entry,
+    )
+}
+
+// Regions the given user may create teams in: everyone gets the default
+// cell; other configured cells require the allowlist.
+export function creatableRegions(email: string | undefined): string[] {
+  const regions = configuredRegions()
+  return multiCellUiEnabled(email)
+    ? regions
+    : regions.filter((r) => r === DEFAULT_REGION)
+}

--- a/apps/console/src/lib/cells.ts
+++ b/apps/console/src/lib/cells.ts
@@ -1,0 +1,63 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js"
+
+import { createAdminClient } from "@/lib/supabase/admin"
+
+// Cell registry. Each region ("cell") runs a full stack: its own Supabase
+// project for team-scoped data and its own control-plane API. Auth stays on
+// the global Supabase project, so this registry only covers admin (service
+// role) access and API routing.
+//
+// A cell is offered only when its env vars are present. Without the
+// SUPABASE_USWEST_* vars the registry collapses to the single default cell
+// and every code path behaves exactly like the single-cell console.
+
+export const DEFAULT_REGION = "use"
+
+export interface Cell {
+  region: string
+  apiBaseUrl: string
+  createAdminClient(): SupabaseClient
+}
+
+// The default cell reuses the existing admin client and SANDBOX_API_URL so
+// nothing changes for code paths that only ever touch "use".
+function defaultCell(): Cell {
+  return {
+    region: DEFAULT_REGION,
+    apiBaseUrl: process.env.SANDBOX_API_URL ?? "https://api.superserve.ai",
+    createAdminClient,
+  }
+}
+
+function uswCell(): Cell | null {
+  const url = process.env.SUPABASE_USWEST_URL
+  const serviceRoleKey = process.env.SUPABASE_USWEST_SERVICE_ROLE_KEY
+  if (!url || !serviceRoleKey) return null
+
+  return {
+    region: "usw",
+    apiBaseUrl:
+      process.env.SANDBOX_API_URL_USWEST ?? "https://api-usw.superserve.ai",
+    createAdminClient: () =>
+      createClient(url, serviceRoleKey, {
+        auth: { autoRefreshToken: false, persistSession: false },
+      }),
+  }
+}
+
+// Env is read per call (not at module load) so a cell can be enabled without
+// touching code, and tests can toggle configuration.
+function configuredCells(): Cell[] {
+  const usw = uswCell()
+  return usw ? [defaultCell(), usw] : [defaultCell()]
+}
+
+export function configuredRegions(): string[] {
+  return configuredCells().map((cell) => cell.region)
+}
+
+export function cellFor(region: string): Cell {
+  const cell = configuredCells().find((c) => c.region === region)
+  if (!cell) throw new Error(`Region ${region} is not configured`)
+  return cell
+}


### PR DESCRIPTION
The console now supports teams homed in different regions ("cells"), including creating new teams in the usw cell. A cell registry maps region → {Supabase admin client, control-plane API base URL}; team lookups fan out across configured cells, and everything that operates on a team (API key minting, proxy key rows, the API proxy upstream, activity/snapshots/quota/billing queries) targets that team's home cell. Part of multi-region cells this is the console piece that unblocks the west-cell pilot.

## Technical decisions

- **Env-gated dormancy.** The usw cell exists only when `SUPABASE_USWEST_URL` + `SUPABASE_USWEST_SERVICE_ROLE_KEY` are set (`SANDBOX_API_URL_USWEST` optional, defaults to `https://api-usw.superserve.ai`). Absent those, `configuredRegions` is `["use"]`, the region select and the whole Teams settings section render nothing, and every query reduces to today's single-cell path. Env is read per call, not at module load, so enabling a cell is config-only.
- **Fan-out, not a directory service.** At 2 cells, membership lookup is a parallel query per cell merged in region order (default cell first). A central team directory isn't worth it yet; the seam (`team-directory.ts`) is where one would slot in.
- **RBAC chain written in the target cell.** Creating a team in a cell writes profile (upsert — auth is global, profile rows are per-cell), team with `home_region`, the legacy `team_member` row (console lookups still read it), then `team_memberships` (active) before the `team_owner` assignment (`roles` looked up by name; the control-plane trigger enforces that ordering). Without the chain the control plane 403s the team.
- **Key rows land in the team's cell.** Both user-minted keys and `__console_proxy__` rows are written via the registry to the team's home cell, and the browser proxy (`/api/[...path]`, team-management) forwards to that cell's API base URL — the only control plane whose DB holds the key hash. Key format (region prefix from `home_region`, #253) is unchanged.
- **Conservative active-team semantics.** There's still no team switcher; per-action multi-team behavior is preserved (billing throws, quota banner hides, first membership wins elsewhere), now applied across the merged cross-cell membership set. The implicit auto-create path (first login) still creates in the default cell and does not write the RBAC chain — matching today's prod behavior. Follow-ups: a real team switcher for users with teams in multiple cells, and RBAC-chain writes on the auto-create path once the control plane requires it in `use`.
- **Teams settings section is itself gated** behind >1 configured region: the single-cell console has no team-creation surface today, and dormant-until-configured means keeping it that way.

## Testing

- New vitest coverage: registry env gating (absent usw env → only `use`, partial env stays dormant, URL/key wiring), directory merge across a mocked second cell, create-team chain lands entirely in the target cell (and nothing in the default cell), API key insert and proxy key upsert target the team's cell, proxy routes forward to the resolved cell base URL.
- `bun run test` (console): 47 files, 370 tests passing; `bun run typecheck` clean; `bunx oxlint` / `oxfmt` clean on `apps/console`.