### PR TITLE
sdk: auto_delete_seconds on create, patchable auto-delete and timeout on update

### DIFF
--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -3,7 +3,7 @@ name: Publish MCP Server
 # Tag-triggered (mcp-v0.1.0 -> 0.1.0). Publishes @superserve/mcp to npm (Trusted
 # Publishing + provenance), then registers server.json in the MCP Registry.
 # Prereqs: npm Trusted Publisher configured for @superserve/mcp; @superserve/sdk
-# >= 0.7.7 published; mcp.superserve.ai live; public repo (OIDC + provenance).
+# >= 0.7.8 published; mcp.superserve.ai live; public repo (OIDC + provenance).
 
 on:
   push:
@@ -48,7 +48,7 @@ jobs:
         working-directory: packages/mcp
         run: |
           set -euo pipefail
-          MIN_SDK_VERSION="0.7.7"
+          MIN_SDK_VERSION="0.7.8"
           SDK_VERSION="$(npm view @superserve/sdk version)"
           test -n "$SDK_VERSION"
           if [ "$(printf '%s\n%s\n' "$MIN_SDK_VERSION" "$SDK_VERSION" | sort -V | head -n1)" != "$MIN_SDK_VERSION" ]; then

--- a/apps/console/src/components/sandboxes/create-sandbox-dialog.test.ts
+++ b/apps/console/src/components/sandboxes/create-sandbox-dialog.test.ts
@@ -14,6 +14,7 @@ import { buildCreateSandboxRequest } from "./create-sandbox-dialog"
 const emptyState = {
   name: "",
   timeout: "",
+  autoDelete: "",
   allowRules: [] as string[],
   denyRules: [] as string[],
   secretEntries: [] as { key: string; secret: string }[],
@@ -43,6 +44,60 @@ describe("buildCreateSandboxRequest", () => {
       timeout: "300",
     })
     expect(req.timeout_seconds).toBe(300)
+  })
+
+  it("includes auto_delete_seconds as a number when present", () => {
+    const req = buildCreateSandboxRequest({
+      ...emptyState,
+      name: "x",
+      autoDelete: "3600",
+    })
+    expect(req.auto_delete_seconds).toBe(3600)
+  })
+
+  it("accepts auto_delete_seconds of 0 (delete on pause)", () => {
+    const req = buildCreateSandboxRequest({
+      ...emptyState,
+      name: "x",
+      autoDelete: "0",
+    })
+    expect(req.auto_delete_seconds).toBe(0)
+  })
+
+  it("throws on a non-finite window ('1e309' → Infinity → null)", () => {
+    expect(() =>
+      buildCreateSandboxRequest({
+        ...emptyState,
+        name: "x",
+        autoDelete: "1e309",
+      }),
+    ).toThrow(/whole number/)
+  })
+
+  it("throws on a fractional window", () => {
+    expect(() =>
+      buildCreateSandboxRequest({
+        ...emptyState,
+        name: "x",
+        autoDelete: "1.5",
+      }),
+    ).toThrow(/whole number/)
+  })
+
+  it("throws on an out-of-range window", () => {
+    expect(() =>
+      buildCreateSandboxRequest({
+        ...emptyState,
+        name: "x",
+        autoDelete: "2592001",
+      }),
+    ).toThrow(/whole number/)
+  })
+
+  it("throws when timeout is below its minimum of 1", () => {
+    expect(() =>
+      buildCreateSandboxRequest({ ...emptyState, name: "x", timeout: "0" }),
+    ).toThrow(/whole number/)
   })
 
   it("omits network when all rules are empty strings", () => {
@@ -146,6 +201,7 @@ describe("buildCreateSandboxRequest", () => {
     const req = buildCreateSandboxRequest({
       name: "full",
       timeout: "600",
+      autoDelete: "3600",
       allowRules: ["api.example.com"],
       denyRules: ["malicious.test"],
       secretEntries: [{ key: "GITHUB_TOKEN", secret: "github_pat" }],
@@ -155,6 +211,7 @@ describe("buildCreateSandboxRequest", () => {
     expect(req).toEqual({
       name: "full",
       timeout_seconds: 600,
+      auto_delete_seconds: 3600,
       network: {
         allow_out: ["api.example.com"],
         deny_out: ["malicious.test"],

--- a/apps/console/src/components/sandboxes/create-sandbox-dialog.tsx
+++ b/apps/console/src/components/sandboxes/create-sandbox-dialog.tsx
@@ -19,6 +19,7 @@ import {
   Field,
   HighlightedCode,
   Input,
+  useToast,
 } from "@superserve/ui"
 import { AnimatePresence, LayoutGroup, motion } from "motion/react"
 import { usePostHog } from "posthog-js/react"
@@ -241,6 +242,7 @@ function CopyButton({ text }: { text: string }) {
 interface FormState {
   name: string
   timeout: string
+  autoDelete: string
   allowRules: string[]
   denyRules: string[]
   secretEntries: SecretBindingEntry[]
@@ -249,15 +251,48 @@ interface FormState {
   templateRef?: string
 }
 
+/** Max auto-pause timeout (7 days) and auto-delete window (30 days), matching
+ *  the control-plane API caps. */
+export const MAX_TIMEOUT_SECONDS = 604800
+export const MAX_AUTO_DELETE_SECONDS = 2592000
+
+/**
+ * Coerce a form string to a whole-second lifecycle window, or throw if the
+ * value is one a `type="number"` field can still emit past its min/max — the
+ * dialog submits from a click handler, not a validated form, so fractional,
+ * out-of-range, and non-finite inputs (e.g. `Number("1e309")` → `Infinity`,
+ * which `JSON.stringify` turns into `null` and the API reads as "disable")
+ * reach here. Returns undefined for an empty (unset) field.
+ */
+export function parseWindowSeconds(
+  raw: string,
+  label: string,
+  min: number,
+  max: number,
+): number | undefined {
+  if (raw.trim() === "") return undefined
+  const n = Number(raw)
+  if (!Number.isSafeInteger(n) || n < min || n > max) {
+    throw new Error(
+      `${label} must be a whole number between ${min} and ${max}.`,
+    )
+  }
+  return n
+}
+
 /**
  * Build the CreateSandboxRequest payload from the dialog's form state.
  *
  * Exported for unit testing. Keeps the network/env/metadata branches in
  * one place so we can assert shape without driving the full dialog UI.
  *
+ * Throws if `timeout` or `autoDelete` hold an invalid number (see
+ * {@link parseWindowSeconds}); the dialog surfaces the message as a toast.
+ *
  * Rules:
  *  - `name` is trimmed.
- *  - `timeout` is only included when set (coerced to number).
+ *  - `timeout` / `autoDelete` are only included when set, validated to a
+ *    whole number in range.
  *  - `network` is only included when at least one allow or deny rule is
  *    non-empty. Within it, `allow_out` / `deny_out` are each only included
  *    when that specific list has entries.
@@ -293,10 +328,28 @@ export function buildCreateSandboxRequest(
     if (k) metadata[k] = entry.value.trim()
   }
 
+  const timeoutSeconds = parseWindowSeconds(
+    state.timeout,
+    "Timeout",
+    1,
+    MAX_TIMEOUT_SECONDS,
+  )
+  const autoDeleteSeconds = parseWindowSeconds(
+    state.autoDelete,
+    "Auto-delete",
+    0,
+    MAX_AUTO_DELETE_SECONDS,
+  )
+
   return {
     name: state.name.trim(),
     ...(state.templateRef ? { from_template: state.templateRef } : {}),
-    ...(state.timeout ? { timeout_seconds: Number(state.timeout) } : {}),
+    ...(timeoutSeconds !== undefined
+      ? { timeout_seconds: timeoutSeconds }
+      : {}),
+    ...(autoDeleteSeconds !== undefined
+      ? { auto_delete_seconds: autoDeleteSeconds }
+      : {}),
     ...(hasNetwork
       ? {
           network: {
@@ -337,6 +390,7 @@ export function CreateSandboxDialog({
   const setOpen = onOpenChange ?? setInternalOpen
   const [name, setName] = useState("")
   const [timeout, setTimeout] = useState("")
+  const [autoDelete, setAutoDelete] = useState("")
   const [allowRules, setAllowRules] = useState<string[]>([])
   const [denyRules, setDenyRules] = useState<string[]>([])
   const [secretEntries, setSecretEntries] = useState<SecretBindingEntry[]>([])
@@ -397,10 +451,12 @@ export function CreateSandboxDialog({
   }, [templateOptions, templateRef])
 
   const createMutation = useCreateSandbox()
+  const { addToast } = useToast()
 
   const handleReset = () => {
     setName("")
     setTimeout("")
+    setAutoDelete("")
     setAllowRules([])
     setDenyRules([])
     setSecretEntries([])
@@ -412,19 +468,27 @@ export function CreateSandboxDialog({
   }
 
   const handleCreate = () => {
-    const payload = buildCreateSandboxRequest({
-      name,
-      timeout,
-      allowRules,
-      denyRules,
-      secretEntries,
-      envEntries,
-      metadataEntries,
-      templateRef: templateRef || undefined,
-    })
+    let payload: CreateSandboxRequest
+    try {
+      payload = buildCreateSandboxRequest({
+        name,
+        timeout,
+        autoDelete,
+        allowRules,
+        denyRules,
+        secretEntries,
+        envEntries,
+        metadataEntries,
+        templateRef: templateRef || undefined,
+      })
+    } catch (e) {
+      addToast(e instanceof Error ? e.message : "Invalid input", "error")
+      return
+    }
 
     posthog.capture(SANDBOX_EVENTS.CREATED, {
       has_timeout: !!timeout,
+      has_auto_delete: !!autoDelete,
       has_network_rules: !!payload.network,
       allow_rule_count: payload.network?.allow_out?.length ?? 0,
       deny_rule_count: payload.network?.deny_out?.length ?? 0,
@@ -591,9 +655,23 @@ export function CreateSandboxDialog({
                           type="number"
                           placeholder="No timeout"
                           min={1}
-                          max={604800}
+                          max={MAX_TIMEOUT_SECONDS}
                           value={timeout}
                           onChange={(e) => setTimeout(e.target.value)}
+                        />
+                      </Field>
+
+                      <Field
+                        label="Auto-delete"
+                        description="Delete after this many seconds of continuous pause. 0 = delete as soon as it pauses; blank = keep forever. Max 2592000 (30 days)."
+                      >
+                        <Input
+                          type="number"
+                          placeholder="Keep forever"
+                          min={0}
+                          max={MAX_AUTO_DELETE_SECONDS}
+                          value={autoDelete}
+                          onChange={(e) => setAutoDelete(e.target.value)}
                         />
                       </Field>
 

--- a/apps/console/src/components/sandboxes/sandbox-info-grid.tsx
+++ b/apps/console/src/components/sandboxes/sandbox-info-grid.tsx
@@ -12,17 +12,20 @@ import { useState } from "react"
 
 import { usePatchSandbox } from "@/hooks/use-sandboxes"
 import type { SandboxResponse } from "@/lib/api/types"
-import { formatDate } from "@/lib/format"
+import { formatDate, formatTime, formatTimeout } from "@/lib/format"
 
 interface SandboxInfoGridProps {
   sandbox: SandboxResponse
 }
 
-function formatTimeout(seconds: number): string {
-  if (seconds < 60) return `${seconds}s`
-  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`
-  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h`
-  return `${Math.floor(seconds / 86400)}d`
+/** Human label for a sandbox's auto-delete state. */
+function formatAutoDelete(sandbox: SandboxResponse): string {
+  if (sandbox.auto_delete_at) {
+    return formatTime(new Date(sandbox.auto_delete_at)).absolute
+  }
+  if (sandbox.auto_delete_seconds == null) return "None"
+  if (sandbox.auto_delete_seconds === 0) return "On pause"
+  return `${formatTimeout(sandbox.auto_delete_seconds)} after pause`
 }
 
 export function NetworkSection({ sandbox }: { sandbox: SandboxResponse }) {
@@ -348,7 +351,7 @@ export function MetadataSection({ sandbox }: { sandbox: SandboxResponse }) {
 export function SandboxInfoGrid({ sandbox }: SandboxInfoGridProps) {
   return (
     <div className="border-b border-border">
-      <div className="grid grid-cols-4">
+      <div className="grid grid-cols-5">
         <div className="border-r border-border px-4 py-4">
           <p className="text-xs text-muted">Resources</p>
           <p className="mt-2 text-sm text-foreground/80 tabular-nums">
@@ -361,6 +364,12 @@ export function SandboxInfoGrid({ sandbox }: SandboxInfoGridProps) {
             {sandbox.timeout_seconds
               ? formatTimeout(sandbox.timeout_seconds)
               : "None"}
+          </p>
+        </div>
+        <div className="border-r border-border px-4 py-4">
+          <p className="text-xs text-muted">Auto-delete</p>
+          <p className="mt-2 font-mono text-sm text-foreground/80">
+            {formatAutoDelete(sandbox)}
           </p>
         </div>
         <div className="border-r border-border px-4 py-4">

--- a/apps/console/src/components/sandboxes/sandbox-resource-bar.tsx
+++ b/apps/console/src/components/sandboxes/sandbox-resource-bar.tsx
@@ -1,17 +1,10 @@
 "use client"
 
 import type { SandboxResponse } from "@/lib/api/types"
-import { formatTime } from "@/lib/format"
+import { formatTime, formatTimeout } from "@/lib/format"
 
 interface SandboxResourceBarProps {
   sandbox: SandboxResponse
-}
-
-function formatTimeout(seconds: number): string {
-  if (seconds < 60) return `${seconds}s`
-  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`
-  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h`
-  return `${Math.floor(seconds / 86400)}d`
 }
 
 function formatMemory(mib: number): string {

--- a/apps/console/src/lib/api/types.ts
+++ b/apps/console/src/lib/api/types.ts
@@ -13,6 +13,9 @@ export interface SandboxListItem {
   memory_mib: number
   snapshot_id?: string
   timeout_seconds?: number
+  auto_delete_seconds?: number
+  /** Deletion deadline; present only while paused with auto_delete_seconds set. */
+  auto_delete_at?: string
   network?: NetworkConfig
   metadata: Record<string, string>
   created_at: string
@@ -46,6 +49,8 @@ export interface CreateSandboxRequest {
   from_template?: string
   from_snapshot?: string
   timeout_seconds?: number
+  /** Delete the sandbox once continuously paused for this many seconds. */
+  auto_delete_seconds?: number
   env_vars?: Record<string, string>
   /** env-var name → secret name. The agent sees a proxy token under env_key;
    *  the in-host daemon swaps it for the real value at egress. */
@@ -57,6 +62,10 @@ export interface CreateSandboxRequest {
 export interface SandboxPatch {
   network?: NetworkConfig
   metadata?: Record<string, string>
+  /** A number (re)arms the window; null disarms it. */
+  auto_delete_seconds?: number | null
+  /** A number sets the auto-pause timeout; null disables it. */
+  timeout_seconds?: number | null
 }
 
 export type SortDirection = "asc" | "desc"

--- a/apps/console/src/lib/format.ts
+++ b/apps/console/src/lib/format.ts
@@ -35,3 +35,11 @@ export function formatTime(date: Date): { relative: string; absolute: string } {
 
   return { relative, absolute }
 }
+
+/** Compact duration label (s/m/h/d) for timeout and auto-delete windows. */
+export function formatTimeout(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h`
+  return `${Math.floor(seconds / 86400)}d`
+}

--- a/bun.lock
+++ b/bun.lock
@@ -144,7 +144,7 @@
     },
     "packages/mcp": {
       "name": "@superserve/mcp",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "bin": {
         "superserve-mcp": "./dist/index.js",
         "superserve-mcp-http": "./dist/httpServer.js",
@@ -169,7 +169,7 @@
     },
     "packages/sdk": {
       "name": "@superserve/sdk",
-      "version": "0.7.7",
+      "version": "0.7.8",
       "devDependencies": {
         "@superserve/typescript-config": "workspace:*",
         "@types/node": "^25.5.2",

--- a/docs/sandbox/create.mdx
+++ b/docs/sandbox/create.mdx
@@ -68,6 +68,7 @@ Use **`secrets`** for credentials, not `envVars`. A secret binds an env var to a
 |---|---|---|
 | `name` | `string` | **Required.** Human-readable sandbox name. |
 | `timeoutSeconds` / `timeout_seconds` | `number` | Max time the sandbox can stay `active` before auto-pause. |
+| `autoDeleteSeconds` / `auto_delete_seconds` | `number` | Delete the sandbox once continuously paused for this many seconds. See [Lifecycle](/sandbox/lifecycle#auto-delete). |
 | `metadata` | `Record<string, string>` | String tags. See [Metadata](/sandbox/metadata). |
 | `envVars` / `env_vars` | `Record<string, string>` | Env vars applied to every process. See [Environment variables](/sandbox/environment-variables). |
 | `network` | `NetworkConfig` | Egress allow/deny rules. See [Networking](/sandbox/networking). |

--- a/docs/sandbox/lifecycle.mdx
+++ b/docs/sandbox/lifecycle.mdx
@@ -107,3 +107,60 @@ Sandbox.kill_by_id("7a3f2b8c-1234-...")
 ```
 </CodeGroup>
 
+
+## Auto-delete
+
+By default a paused sandbox is kept forever. Set `autoDeleteSeconds` to have the platform delete it once it has been **continuously paused** for that long — useful for short-lived or unattended sandboxes: scheduled jobs, one-off experiments, or agent sessions that never get an explicit `kill()`.
+
+<CodeGroup>
+```typescript TypeScript {5}
+import { Sandbox } from "@superserve/sdk"
+
+const sandbox = await Sandbox.create({
+  name: "scratch-job",
+  autoDeleteSeconds: 3600, // delete after 1h of continuous pause
+})
+```
+
+```python Python {5}
+from superserve import Sandbox
+
+sandbox = Sandbox.create(
+    name="scratch-job",
+    auto_delete_seconds=3600,  # delete after 1h of continuous pause
+)
+```
+</CodeGroup>
+
+The timer is tied to the paused state itself:
+
+- **Pause** arms the countdown; **resume** cancels it. Pausing again later starts a fresh window, so a sandbox in use is never deleted.
+- `0` deletes the sandbox as soon as it pauses.
+- While the sandbox is paused, its info includes `autoDeleteAt` — the exact deletion time.
+- Maximum window: 30 days.
+
+You can also set or clear the window on an existing sandbox:
+
+<CodeGroup>
+```typescript TypeScript
+// Arm: delete after 1h of continuous pause. On an already-paused sandbox
+// the countdown starts now, so you always get the full window.
+await sandbox.update({ autoDeleteSeconds: 3600 })
+
+// Disarm: keep the sandbox until explicitly killed.
+await sandbox.update({ autoDeleteSeconds: null })
+```
+
+```python Python
+# Arm: delete after 1h of continuous pause. On an already-paused sandbox
+# the countdown starts now, so you always get the full window.
+sandbox.update(auto_delete_seconds=3600)
+
+# Disarm: keep the sandbox until explicitly killed.
+sandbox.update(auto_delete_seconds=None)
+```
+</CodeGroup>
+
+<Tip>
+Pair `autoDeleteSeconds` with `timeoutSeconds`: the timeout pauses an idle sandbox, then the auto-delete window cleans it up. A sandbox that never pauses is never auto-deleted.
+</Tip>

--- a/docs/sdk-reference/sandbox.mdx
+++ b/docs/sdk-reference/sandbox.mdx
@@ -70,6 +70,7 @@ sandbox = Sandbox.create(
 | `fromTemplate` / `from_template` | `string \| Template` | Template name, UUID, or `Template` instance to boot from. Defaults to `superserve/base`. |
 | `fromSnapshot` / `from_snapshot` | `string` | Snapshot UUID to boot from. |
 | `timeoutSeconds` / `timeout_seconds` | `number` | Max active lifetime before auto-pause. API-side upper bound (subject to change). |
+| `autoDeleteSeconds` / `auto_delete_seconds` | `number` | Delete the sandbox once continuously paused for this many seconds (max 30 days, `0` = delete on pause). See [Lifecycle](/sandbox/lifecycle#auto-delete). |
 | `metadata` | `Record<string, string>` | String tags. |
 | `envVars` / `env_vars` | `Record<string, string>` | Env vars injected into every process. |
 | `secrets` | `Record<string, string>` | Bind secrets to env vars (`ENV_VAR → secret name`). The agent sees a stand-in token; the real credential is attached to outbound requests. See [Secrets](/secrets/overview). |
@@ -121,6 +122,24 @@ await Sandbox.killById("7a3f2b8c-1234-...")
 
 ```python Python
 Sandbox.kill_by_id("7a3f2b8c-1234-...")
+```
+</CodeGroup>
+
+### `Sandbox.updateById` / `Sandbox.update_by_id`
+
+Update a sandbox by ID without instantiating it. Unlike `connect(id)` followed
+by `update(...)`, this does **not** resume a paused sandbox — so it's the right
+way to arm auto-delete or change the auto-pause timeout on a box you want to
+leave paused.
+Same fields and clear-with-`null`/`None` semantics as [`update`](#update).
+
+<CodeGroup>
+```typescript TypeScript
+await Sandbox.updateById("7a3f2b8c-1234-...", { autoDeleteSeconds: 3600 })
+```
+
+```python Python
+Sandbox.update_by_id("7a3f2b8c-1234-...", auto_delete_seconds=3600)
 ```
 </CodeGroup>
 
@@ -186,7 +205,7 @@ sandbox.kill()
 
 ### `update`
 
-Patch `metadata` and/or `network` on a live sandbox.
+Patch `metadata`, `network`, `autoDeleteSeconds`, and/or `timeoutSeconds` on a sandbox.
 
 <CodeGroup>
 ```typescript TypeScript
@@ -194,6 +213,14 @@ await sandbox.update({
   metadata: { env: "staging" },
   network: { allowOut: ["api.openai.com"] },
 })
+
+// Auto-delete: a number arms the window, null disarms it.
+await sandbox.update({ autoDeleteSeconds: 3600 })
+await sandbox.update({ autoDeleteSeconds: null })
+
+// Auto-pause timeout: same set/clear contract.
+await sandbox.update({ timeoutSeconds: 900 })
+await sandbox.update({ timeoutSeconds: null })
 ```
 
 ```python Python
@@ -201,8 +228,18 @@ sandbox.update(
     metadata={"env": "staging"},
     network=NetworkConfig(allow_out=["api.openai.com"]),
 )
+
+# Auto-delete: a number arms the window, None disarms it.
+sandbox.update(auto_delete_seconds=3600)
+sandbox.update(auto_delete_seconds=None)
+
+# Auto-pause timeout: same set/clear contract.
+sandbox.update(timeout_seconds=900)
+sandbox.update(timeout_seconds=None)
 ```
 </CodeGroup>
+
+On an already-paused sandbox, arming `autoDeleteSeconds` starts the countdown from the moment of the call — never retroactively from when the sandbox paused. See [Lifecycle](/sandbox/lifecycle#auto-delete).
 
 ### `attachSecret` / `attach_secret`
 
@@ -312,6 +349,8 @@ interface SandboxInfo {
   memoryMib: number
   createdAt: Date
   timeoutSeconds?: number
+  autoDeleteSeconds?: number
+  autoDeleteAt?: Date // present only while paused with autoDeleteSeconds set
   network?: NetworkConfig
   metadata: Record<string, string>
 }
@@ -329,6 +368,9 @@ class SandboxInfo(BaseModel):
     memory_mib: int
     created_at: datetime
     timeout_seconds: int | None = None
+    auto_delete_seconds: int | None = None
+    # Set only while paused with auto_delete_seconds configured.
+    auto_delete_at: datetime | None = None
     network: NetworkConfig | None = None
     metadata: dict[str, str]
 ```

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superserve/mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Model Context Protocol (MCP) server for Superserve sandboxes — create, exec, and manage Firecracker microVMs from any MCP client",
   "keywords": [
     "agents",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.superserve-ai/mcp",
   "title": "Superserve",
   "description": "MCP server for Superserve sandboxes: create, exec, and manage Firecracker microVMs",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "websiteUrl": "https://superserve.ai",
   "repository": {
     "url": "https://github.com/superserve-ai/superserve",
@@ -15,7 +15,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@superserve/mcp",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "runtimeHint": "npx",
       "transport": { "type": "stdio" },
       "environmentVariables": [

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -123,6 +123,8 @@ export interface CreateInput {
   fromTemplate?: string
   fromSnapshot?: string
   timeoutSeconds?: number
+  /** Delete the sandbox once continuously paused for this many seconds. */
+  autoDeleteSeconds?: number
   metadata?: Record<string, string>
   envVars?: Record<string, string>
   /** Bind team-stored secrets to env vars: `{ ENV_VAR: secretName }`. */
@@ -134,6 +136,10 @@ export interface CreateInput {
 export interface UpdateInput {
   metadata?: Record<string, string>
   network?: NetworkConfig
+  /** A number (re)arms the auto-delete window; null disarms it. */
+  autoDeleteSeconds?: number | null
+  /** A number sets the auto-pause timeout; null disables it. */
+  timeoutSeconds?: number | null
 }
 
 export interface ExecInput {
@@ -254,6 +260,7 @@ export function createSdkClient(config: ClientConfig): SandboxClient {
         fromTemplate: input.fromTemplate,
         fromSnapshot: input.fromSnapshot,
         timeoutSeconds: input.timeoutSeconds,
+        autoDeleteSeconds: input.autoDeleteSeconds,
         metadata: input.metadata,
         envVars: input.envVars,
         secrets: input.secrets,
@@ -269,8 +276,18 @@ export function createSdkClient(config: ClientConfig): SandboxClient {
     },
 
     async update(id, input) {
-      const sb = await Sandbox.connect(id, conn)
-      await sb.update({ metadata: input.metadata, network: input.network })
+      // updateById (not connect().update()) so patching a paused sandbox —
+      // e.g. arming auto-delete — does not resume it.
+      await Sandbox.updateById(
+        id,
+        {
+          metadata: input.metadata,
+          network: input.network,
+          autoDeleteSeconds: input.autoDeleteSeconds,
+          timeoutSeconds: input.timeoutSeconds,
+        },
+        conn,
+      )
     },
 
     async list(metadata) {

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -277,7 +277,8 @@ export function createSdkClient(config: ClientConfig): SandboxClient {
 
     async update(id, input) {
       // updateById (not connect().update()) so patching a paused sandbox —
-      // e.g. arming auto-delete — does not resume it.
+      // e.g. arming auto-delete — does not resume it. Requires @superserve/sdk
+      // >= 0.7.8; MIN_SDK_VERSION in mcp-publish.yml tracks this floor.
       await Sandbox.updateById(
         id,
         {
@@ -405,9 +406,8 @@ export function createSdkClient(config: ClientConfig): SandboxClient {
     },
 
     // Zips + streams the dir from the data plane (VM must be up, so connect's
-    // resume is intrinsic, like readFile). Requires @superserve/sdk >= 0.7.7
-    // (downloadDir landed in #221). The publish workflow enforces this floor via
-    // MIN_SDK_VERSION in .github/workflows/mcp-publish.yml — bump both together.
+    // resume is intrinsic, like readFile). downloadDir landed in @superserve/sdk
+    // 0.7.7; the MCP floor (MIN_SDK_VERSION) is the max across features.
     async downloadDir(id, path, maxBytes) {
       const sb = await Sandbox.connect(id, conn)
       return sb.files.downloadDir(

--- a/packages/mcp/src/constants.ts
+++ b/packages/mcp/src/constants.ts
@@ -32,7 +32,7 @@ export const SERVER_INSTRUCTIONS =
  * Server version. Kept in sync with `package.json` `version`
  * (enforced by `tests/version.test.ts`).
  */
-export const SERVER_VERSION = "0.1.0"
+export const SERVER_VERSION = "0.1.1"
 
 /** Default per-command timeout when a tool call omits `timeout_ms`. */
 export const DEFAULT_EXEC_TIMEOUT_MS = 60_000

--- a/packages/mcp/src/constants.ts
+++ b/packages/mcp/src/constants.ts
@@ -88,3 +88,12 @@ export const DEFAULT_NETWORK_LOG_LIMIT = 50
 
 /** Hard cap on `sandbox_network_log` rows per call (bounds output + API load). */
 export const MAX_NETWORK_LOG_LIMIT = 200
+
+/**
+ * Hard caps for lifecycle windows, mirroring the control-plane API limits so an
+ * over-limit value is rejected at the tool boundary instead of after a round
+ * trip. Keep in sync with the API (`auto_delete_seconds` ≤ 30d, `timeout_seconds`
+ * ≤ 7d); the API remains the source of truth and re-validates.
+ */
+export const MAX_AUTO_DELETE_SECONDS = 30 * 24 * 60 * 60 // 2592000 (30 days)
+export const MAX_TIMEOUT_SECONDS = 7 * 24 * 60 * 60 // 604800 (7 days)

--- a/packages/mcp/src/tools/lifecycle.ts
+++ b/packages/mcp/src/tools/lifecycle.ts
@@ -10,7 +10,9 @@ import { z } from "zod"
 import type { SandboxClient } from "../client.js"
 import {
   DEFAULT_NETWORK_LOG_LIMIT,
+  MAX_AUTO_DELETE_SECONDS,
   MAX_NETWORK_LOG_LIMIT,
+  MAX_TIMEOUT_SECONDS,
 } from "../constants.js"
 import { formatSdkError } from "../lib/errors.js"
 import { toolError, toolOk } from "../lib/result.js"
@@ -35,6 +37,7 @@ interface CreateArgs {
   from_template?: string
   from_snapshot?: string
   timeout_seconds?: number
+  auto_delete_seconds?: number
   metadata?: Record<string, string>
   env_vars?: Record<string, string>
   secrets?: Record<string, string>
@@ -47,6 +50,8 @@ interface UpdateArgs {
   metadata?: Record<string, string>
   allow_out?: string[]
   deny_out?: string[]
+  auto_delete_seconds?: number | null
+  timeout_seconds?: number | null
 }
 
 interface TemplateCreateArgs {
@@ -128,8 +133,22 @@ export function registerLifecycleTools(
           .number()
           .int()
           .positive()
+          .max(MAX_TIMEOUT_SECONDS)
           .optional()
-          .describe("Idle timeout before the sandbox is auto-paused."),
+          .describe(
+            "Idle timeout before the sandbox is auto-paused (max 604800 = 7 days).",
+          ),
+        auto_delete_seconds: z
+          .number()
+          .int()
+          .min(0)
+          .max(MAX_AUTO_DELETE_SECONDS)
+          .optional()
+          .describe(
+            "Delete the sandbox once continuously paused for this many seconds (0 = delete on " +
+              "pause, max 2592000 = 30 days). Resume cancels the countdown. Omit to keep paused " +
+              "sandboxes forever.",
+          ),
         metadata: stringRecord()
           .optional()
           .describe("Arbitrary key/value tags for filtering in sandbox_list."),
@@ -172,6 +191,7 @@ export function registerLifecycleTools(
       from_template,
       from_snapshot,
       timeout_seconds,
+      auto_delete_seconds,
       metadata,
       env_vars,
       secrets,
@@ -184,6 +204,7 @@ export function registerLifecycleTools(
           fromTemplate: from_template,
           fromSnapshot: from_snapshot,
           timeoutSeconds: timeout_seconds,
+          autoDeleteSeconds: auto_delete_seconds,
           metadata,
           envVars: env_vars,
           secrets,
@@ -415,6 +436,12 @@ export function registerLifecycleTools(
         if (i.timeoutSeconds !== undefined) {
           structured.timeout_seconds = i.timeoutSeconds
         }
+        if (i.autoDeleteSeconds !== undefined) {
+          structured.auto_delete_seconds = i.autoDeleteSeconds
+        }
+        if (i.autoDeleteAt !== undefined) {
+          structured.auto_delete_at = toIsoOrUndefined(i.autoDeleteAt)
+        }
         if (i.network) {
           structured.network = {
             allow_out: i.network.allowOut,
@@ -535,9 +562,9 @@ export function registerLifecycleTools(
     {
       title: "Update a sandbox",
       description:
-        "Change a sandbox's metadata or egress network rules after creation. Use this to lock down or open up " +
-        "outbound network access on an existing sandbox (the rules apply to new connections). Only the fields " +
-        "you pass are changed; omit allow_out/deny_out to leave network rules untouched.",
+        "Change a sandbox's metadata, egress network rules, auto-delete window, or auto-pause timeout after " +
+        "creation. Use this to lock down or open up outbound network access (rules apply to new connections), " +
+        "or to schedule cleanup of a sandbox you no longer need running. Only the fields you pass are changed.",
       inputSchema: {
         sandbox_id: z.string().describe("ID of the sandbox to update."),
         metadata: stringRecord()
@@ -554,19 +581,56 @@ export function registerLifecycleTools(
           .describe(
             "Egress deny rules — CIDRs only ('0.0.0.0/0' denies all egress). Combine with allow_out to lock down egress.",
           ),
+        auto_delete_seconds: z
+          .number()
+          .int()
+          .min(0)
+          .max(MAX_AUTO_DELETE_SECONDS)
+          .nullable()
+          .optional()
+          .describe(
+            "Delete the sandbox once continuously paused for this many seconds (max 2592000 = 30 " +
+              "days); the countdown starts now if it is already paused. Pass null to disable " +
+              "auto-delete. Omit to leave unchanged.",
+          ),
+        timeout_seconds: z
+          .number()
+          .int()
+          .positive()
+          .max(MAX_TIMEOUT_SECONDS)
+          .nullable()
+          .optional()
+          .describe(
+            "Idle timeout before the sandbox is auto-paused (max 604800 = 7 days). Pass null to " +
+              "disable auto-pause. Omit to leave unchanged.",
+          ),
       },
       annotations: {
         readOnlyHint: false,
-        destructiveHint: false,
-        idempotentHint: true,
+        // auto_delete_seconds can schedule (or, at 0 on a paused sandbox,
+        // effectively trigger) deletion, so this tool is destructive.
+        destructiveHint: true,
+        // Re-arming auto_delete_seconds on a paused sandbox restarts the
+        // countdown from now, so the same call repeated moves the deadline —
+        // not idempotent.
+        idempotentHint: false,
         openWorldHint: true,
       },
     },
-    async ({ sandbox_id, metadata, allow_out, deny_out }) => {
+    async ({
+      sandbox_id,
+      metadata,
+      allow_out,
+      deny_out,
+      auto_delete_seconds,
+      timeout_seconds,
+    }) => {
       try {
         await client.update(sandbox_id, {
           metadata,
           network: toNetwork(allow_out, deny_out),
+          autoDeleteSeconds: auto_delete_seconds,
+          timeoutSeconds: timeout_seconds,
         })
         return toolOk(`updated ${sandbox_id}`, { id: sandbox_id })
       } catch (e) {

--- a/packages/mcp/tests/bounds.test.ts
+++ b/packages/mcp/tests/bounds.test.ts
@@ -7,6 +7,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 
 import {
+  MAX_AUTO_DELETE_SECONDS,
   MAX_DOWNLOAD_DIR_BYTES,
   MAX_EXEC_TIMEOUT_MS,
   MAX_FILE_BYTES,
@@ -31,6 +32,15 @@ describe("resource bounds (in-memory, fake client)", () => {
     const r = await callTool(conn.client, "sandbox_create", { name: "t" })
     return r.structured.id as string
   }
+
+  it("sandbox_create rejects auto_delete_seconds over the 30-day cap", async () => {
+    const r = await callTool(conn.client, "sandbox_create", {
+      name: "t",
+      auto_delete_seconds: MAX_AUTO_DELETE_SECONDS + 1,
+    })
+    expect(r.isError).toBe(true)
+    expect(r.text).toMatch(/validation|too_big/i)
+  })
 
   it("sandbox_files_read refuses a file over the read cap (no full buffering)", async () => {
     const id = await createSandbox()

--- a/packages/mcp/tests/fake-client.ts
+++ b/packages/mcp/tests/fake-client.ts
@@ -29,6 +29,8 @@ interface FakeSandbox {
   files: Map<string, Uint8Array>
   network?: NetworkConfig
   secrets: SandboxSecretBinding[]
+  autoDeleteSeconds?: number
+  timeoutSeconds?: number
 }
 
 export interface FakeClient {
@@ -75,6 +77,8 @@ export function createFakeClient(): FakeClient {
         metadata: input.metadata ?? {},
         files: new Map(),
         network: input.network,
+        autoDeleteSeconds: input.autoDeleteSeconds,
+        timeoutSeconds: input.timeoutSeconds ?? 3600,
         secrets: Object.entries(input.secrets ?? {}).map(
           ([envKey, secretName]) => ({ envKey, secretName, revoked: false }),
         ),
@@ -87,6 +91,10 @@ export function createFakeClient(): FakeClient {
       const sb = must(id)
       if (input.metadata !== undefined) sb.metadata = input.metadata
       if (input.network !== undefined) sb.network = input.network
+      if (input.autoDeleteSeconds !== undefined)
+        sb.autoDeleteSeconds = input.autoDeleteSeconds ?? undefined
+      if (input.timeoutSeconds !== undefined)
+        sb.timeoutSeconds = input.timeoutSeconds ?? undefined
     },
 
     async list(metadata) {
@@ -126,7 +134,8 @@ export function createFakeClient(): FakeClient {
         vcpuCount: 2,
         memoryMib: 2048,
         createdAt: new Date(0),
-        timeoutSeconds: 3600,
+        timeoutSeconds: sb.timeoutSeconds,
+        autoDeleteSeconds: sb.autoDeleteSeconds,
         network: sb.network,
         metadata: sb.metadata,
         secrets: sb.secrets.length ? sb.secrets : undefined,

--- a/packages/mcp/tests/surface.test.ts
+++ b/packages/mcp/tests/surface.test.ts
@@ -47,6 +47,26 @@ describe("network rules + sandbox_update (in-memory, fake client)", () => {
       (info.structured.network as { deny_out: string[] }).deny_out,
     ).toEqual(["evil.example.com"])
   })
+
+  it("sandbox_update arms and clears the auto-delete window", async () => {
+    const created = await callTool(conn.client, "sandbox_create", {
+      name: "gc",
+      auto_delete_seconds: 3600,
+    })
+    const id = created.structured.id as string
+
+    let info = await callTool(conn.client, "sandbox_info", { sandbox_id: id })
+    expect(info.structured.auto_delete_seconds).toBe(3600)
+
+    const upd = await callTool(conn.client, "sandbox_update", {
+      sandbox_id: id,
+      auto_delete_seconds: null,
+    })
+    expect(upd.isError).toBe(false)
+
+    info = await callTool(conn.client, "sandbox_info", { sandbox_id: id })
+    expect(info.structured.auto_delete_seconds).toBeUndefined()
+  })
 })
 
 describe("secrets (in-memory, fake client)", () => {

--- a/packages/mcp/tests/tools.test.ts
+++ b/packages/mcp/tests/tools.test.ts
@@ -141,6 +141,16 @@ describe("tool calls (in-memory, fake client)", () => {
     expect(resumed.structured.status).toBe("active")
   })
 
+  it("sandbox_update is flagged destructive and non-idempotent", async () => {
+    // auto_delete_seconds can schedule deletion and re-arming moves the
+    // deadline, so MCP clients must not treat this tool as safe to
+    // auto-approve or auto-retry.
+    const { tools } = await conn.client.listTools()
+    const update = tools.find((t) => t.name === "sandbox_update")
+    expect(update?.annotations?.destructiveHint).toBe(true)
+    expect(update?.annotations?.idempotentHint).toBe(false)
+  })
+
   it("kill is idempotent", async () => {
     const id = await createSandbox()
     const first = await callTool(conn.client, "sandbox_kill", {

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "superserve"
-version = "0.7.7"
+version = "0.7.8"
 description = "Python SDK for the Superserve sandbox API"
 license = "Apache-2.0"
 readme = "README.md"

--- a/packages/python-sdk/src/superserve/__init__.py
+++ b/packages/python-sdk/src/superserve/__init__.py
@@ -49,7 +49,7 @@ from .types import (
     WorkdirStep,
 )
 
-__version__ = "0.7.7"
+__version__ = "0.7.8"
 
 __all__ = [
     "AsyncCommandSession",

--- a/packages/python-sdk/src/superserve/_http.py
+++ b/packages/python-sdk/src/superserve/_http.py
@@ -25,7 +25,7 @@ DEFAULT_MAX_DOWNLOAD_BYTES = (
     2 * 1024 * 1024 * 1024
 )  # 2 GiB; matches boxd's server-side zip cap
 
-SDK_VERSION = "0.7.7"
+SDK_VERSION = "0.7.8"
 USER_AGENT = (
     f"superserve-python/{SDK_VERSION} "
     f"(python/{sys.version_info.major}.{sys.version_info.minor})"

--- a/packages/python-sdk/src/superserve/async_sandbox.py
+++ b/packages/python-sdk/src/superserve/async_sandbox.py
@@ -15,6 +15,8 @@ from .commands import AsyncCommands, AsyncCommandsDeps
 from .errors import NotFoundError, SandboxError
 from .files import AsyncFiles, AsyncFilesDeps
 from .types import (
+    UNSET,
+    build_update_body,
     NetworkConfig,
     NetworkLogPage,
     NetworkVerdict,
@@ -100,6 +102,7 @@ class AsyncSandbox:
         from_template: "str | Template | AsyncTemplate | None" = None,
         from_snapshot: str | None = None,
         timeout_seconds: int | None = None,
+        auto_delete_seconds: int | None = None,
         metadata: dict[str, str] | None = None,
         env_vars: dict[str, str] | None = None,
         secrets: dict[str, str] | None = None,
@@ -128,6 +131,8 @@ class AsyncSandbox:
             body["from_snapshot"] = from_snapshot
         if timeout_seconds is not None:
             body["timeout_seconds"] = timeout_seconds
+        if auto_delete_seconds is not None:
+            body["auto_delete_seconds"] = auto_delete_seconds
         if metadata is not None:
             body["metadata"] = metadata
         if env_vars is not None:
@@ -220,6 +225,37 @@ class AsyncSandbox:
         except NotFoundError:
             pass  # Already deleted
 
+    @classmethod
+    async def update_by_id(
+        cls,
+        sandbox_id: str,
+        *,
+        metadata: dict[str, str] | None = None,
+        network: NetworkConfig | None = None,
+        auto_delete_seconds: int | None = UNSET,
+        timeout_seconds: int | None = UNSET,
+        api_key: str | None = None,
+        base_url: str | None = None,
+    ) -> None:
+        """Update a sandbox by ID without holding a live instance.
+
+        Unlike ``connect(id).update(...)`` this does not activate the sandbox —
+        a paused sandbox stays paused. Pass ``None`` for ``auto_delete_seconds``
+        / ``timeout_seconds`` to clear them; omit to leave unchanged.
+        """
+        config = resolve_config(api_key=api_key, base_url=base_url)
+        await async_api_request(
+            "PATCH",
+            f"{config.base_url}/sandboxes/{sandbox_id}",
+            headers={"X-API-Key": config.api_key},
+            json_body=build_update_body(
+                metadata=metadata,
+                network=network,
+                auto_delete_seconds=auto_delete_seconds,
+                timeout_seconds=timeout_seconds,
+            ),
+        )
+
     # Methods on sandbox
 
     async def _close_http_client(self) -> None:
@@ -301,17 +337,23 @@ class AsyncSandbox:
         *,
         metadata: dict[str, str] | None = None,
         network: NetworkConfig | None = None,
+        auto_delete_seconds: int | None = UNSET,
+        timeout_seconds: int | None = UNSET,
     ) -> None:
-        """Partially update this sandbox."""
+        """Partially update this sandbox.
+
+        ``auto_delete_seconds`` sets the auto-delete window (counting from now
+        when the sandbox is already paused); pass ``None`` to disable
+        auto-delete. ``timeout_seconds`` sets the auto-pause timeout; pass
+        ``None`` to disable auto-pause. Omit either to leave it unchanged.
+        """
         self._require_live()
-        body: dict[str, Any] = {}
-        if metadata is not None:
-            body["metadata"] = metadata
-        if network is not None:
-            body["network"] = {
-                "allow_out": network.allow_out,
-                "deny_out": network.deny_out,
-            }
+        body = build_update_body(
+            metadata=metadata,
+            network=network,
+            auto_delete_seconds=auto_delete_seconds,
+            timeout_seconds=timeout_seconds,
+        )
 
         await async_api_request(
             "PATCH",

--- a/packages/python-sdk/src/superserve/sandbox.py
+++ b/packages/python-sdk/src/superserve/sandbox.py
@@ -15,6 +15,8 @@ from .commands import Commands, CommandsDeps
 from .errors import NotFoundError, SandboxError
 from .files import Files, FilesDeps
 from .types import (
+    UNSET,
+    build_update_body,
     NetworkConfig,
     NetworkLogPage,
     NetworkVerdict,
@@ -106,6 +108,7 @@ class Sandbox:
         from_template: "str | Template | AsyncTemplate | None" = None,
         from_snapshot: str | None = None,
         timeout_seconds: int | None = None,
+        auto_delete_seconds: int | None = None,
         metadata: dict[str, str] | None = None,
         env_vars: dict[str, str] | None = None,
         secrets: dict[str, str] | None = None,
@@ -134,6 +137,8 @@ class Sandbox:
             body["from_snapshot"] = from_snapshot
         if timeout_seconds is not None:
             body["timeout_seconds"] = timeout_seconds
+        if auto_delete_seconds is not None:
+            body["auto_delete_seconds"] = auto_delete_seconds
         if metadata is not None:
             body["metadata"] = metadata
         if env_vars is not None:
@@ -226,6 +231,37 @@ class Sandbox:
         except NotFoundError:
             pass  # Already deleted
 
+    @classmethod
+    def update_by_id(
+        cls,
+        sandbox_id: str,
+        *,
+        metadata: dict[str, str] | None = None,
+        network: NetworkConfig | None = None,
+        auto_delete_seconds: int | None = UNSET,
+        timeout_seconds: int | None = UNSET,
+        api_key: str | None = None,
+        base_url: str | None = None,
+    ) -> None:
+        """Update a sandbox by ID without holding a live instance.
+
+        Unlike ``connect(id).update(...)`` this does not activate the sandbox —
+        a paused sandbox stays paused. Pass ``None`` for ``auto_delete_seconds``
+        / ``timeout_seconds`` to clear them; omit to leave unchanged.
+        """
+        config = resolve_config(api_key=api_key, base_url=base_url)
+        api_request(
+            "PATCH",
+            f"{config.base_url}/sandboxes/{sandbox_id}",
+            headers={"X-API-Key": config.api_key},
+            json_body=build_update_body(
+                metadata=metadata,
+                network=network,
+                auto_delete_seconds=auto_delete_seconds,
+                timeout_seconds=timeout_seconds,
+            ),
+        )
+
     # Methods on sandbox
 
     def _close_http_client(self) -> None:
@@ -307,17 +343,23 @@ class Sandbox:
         *,
         metadata: dict[str, str] | None = None,
         network: NetworkConfig | None = None,
+        auto_delete_seconds: int | None = UNSET,
+        timeout_seconds: int | None = UNSET,
     ) -> None:
-        """Partially update this sandbox."""
+        """Partially update this sandbox.
+
+        ``auto_delete_seconds`` sets the auto-delete window (counting from now
+        when the sandbox is already paused); pass ``None`` to disable
+        auto-delete. ``timeout_seconds`` sets the auto-pause timeout; pass
+        ``None`` to disable auto-pause. Omit either to leave it unchanged.
+        """
         self._require_live()
-        body: dict[str, Any] = {}
-        if metadata is not None:
-            body["metadata"] = metadata
-        if network is not None:
-            body["network"] = {
-                "allow_out": network.allow_out,
-                "deny_out": network.deny_out,
-            }
+        body = build_update_body(
+            metadata=metadata,
+            network=network,
+            auto_delete_seconds=auto_delete_seconds,
+            timeout_seconds=timeout_seconds,
+        )
 
         api_request(
             "PATCH",

--- a/packages/python-sdk/src/superserve/types.py
+++ b/packages/python-sdk/src/superserve/types.py
@@ -40,6 +40,10 @@ class SandboxInfo(BaseModel):
     memory_mib: int = 0
     created_at: datetime
     timeout_seconds: Optional[int] = None
+    # Delete the sandbox after it has been continuously paused for this many seconds.
+    auto_delete_seconds: Optional[int] = None
+    # When the sandbox will be auto-deleted. Set only while paused with auto_delete_seconds configured.
+    auto_delete_at: Optional[datetime] = None
     network: Optional[NetworkConfig] = None
     metadata: dict[str, str] = Field(default_factory=dict)
     # Secrets bound to this sandbox, when any are attached.
@@ -50,6 +54,35 @@ class CommandResult(BaseModel):
     stdout: str = ""
     stderr: str = ""
     exit_code: int = 0
+
+
+# Sentinel distinguishing "argument not provided" from an explicit None in
+# update() kwargs, where None means "clear the setting" on the wire.
+UNSET: Any = object()
+
+
+def build_update_body(
+    *,
+    metadata: dict[str, str] | None,
+    network: "NetworkConfig | None",
+    auto_delete_seconds: int | None,
+    timeout_seconds: int | None,
+) -> dict[str, Any]:
+    """Serialize sandbox update args to the wire body. UNSET fields are omitted;
+    an explicit None for auto_delete_seconds / timeout_seconds clears them."""
+    body: dict[str, Any] = {}
+    if metadata is not None:
+        body["metadata"] = metadata
+    if auto_delete_seconds is not UNSET:
+        body["auto_delete_seconds"] = auto_delete_seconds
+    if timeout_seconds is not UNSET:
+        body["timeout_seconds"] = timeout_seconds
+    if network is not None:
+        body["network"] = {
+            "allow_out": network.allow_out,
+            "deny_out": network.deny_out,
+        }
+    return body
 
 
 def _parse_iso8601(value: str) -> datetime:
@@ -94,6 +127,10 @@ def to_sandbox_info(raw: dict[str, Any]) -> SandboxInfo:
         memory_mib=raw.get("memory_mib", 0),
         created_at=_parse_iso8601(raw["created_at"]),
         timeout_seconds=raw.get("timeout_seconds"),
+        auto_delete_seconds=raw.get("auto_delete_seconds"),
+        auto_delete_at=(
+            _parse_iso8601(raw["auto_delete_at"]) if raw.get("auto_delete_at") else None
+        ),
         network=network,
         metadata=raw.get("metadata", {}),
         secrets=secrets,

--- a/packages/python-sdk/tests/test_async.py
+++ b/packages/python-sdk/tests/test_async.py
@@ -47,6 +47,9 @@ class TestAsyncStaticMethodsAreAsync:
     def test_kill_by_id_is_coroutine(self) -> None:
         assert inspect.iscoroutinefunction(AsyncSandbox.kill_by_id)
 
+    def test_update_by_id_is_coroutine(self) -> None:
+        assert inspect.iscoroutinefunction(AsyncSandbox.update_by_id)
+
 
 class TestAsyncSandboxSmoke:
     async def test_create_returns_instance(self) -> None:

--- a/packages/python-sdk/tests/test_sandbox.py
+++ b/packages/python-sdk/tests/test_sandbox.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 import httpx
 import pytest
 import respx
@@ -290,6 +292,60 @@ class TestInstanceMethods:
                 assert sbx.metadata == {}
             finally:
                 sbx._close_http_client()
+
+    def test_update_auto_delete_set_clear_omit(self) -> None:
+        with respx.mock() as router:
+            router.post(f"{API}/sandboxes/sbx-1/activate").mock(
+                return_value=httpx.Response(200, json=_raw())
+            )
+            route = router.patch(f"{API}/sandboxes/sbx-1").mock(
+                return_value=httpx.Response(204)
+            )
+            sbx = Sandbox.connect("sbx-1")
+            try:
+                sbx.update(auto_delete_seconds=3600)
+                assert json.loads(route.calls[0].request.content) == {
+                    "auto_delete_seconds": 3600
+                }
+                # Explicit None clears the window on the wire.
+                sbx.update(auto_delete_seconds=None)
+                assert json.loads(route.calls[1].request.content) == {
+                    "auto_delete_seconds": None
+                }
+                # Omitted entirely: the field must not appear in the body.
+                sbx.update(metadata={"env": "prod"})
+                assert json.loads(route.calls[2].request.content) == {
+                    "metadata": {"env": "prod"}
+                }
+                # timeout_seconds follows the same set/clear contract.
+                sbx.update(timeout_seconds=900)
+                assert json.loads(route.calls[3].request.content) == {
+                    "timeout_seconds": 900
+                }
+                sbx.update(timeout_seconds=None)
+                assert json.loads(route.calls[4].request.content) == {
+                    "timeout_seconds": None
+                }
+            finally:
+                sbx._close_http_client()
+
+    def test_update_by_id_patches_without_activating(self) -> None:
+        # assert_all_called=False: the activate route is registered only to
+        # prove update_by_id never calls it.
+        with respx.mock(assert_all_called=False) as router:
+            activate = router.post(f"{API}/sandboxes/sbx-1/activate").mock(
+                return_value=httpx.Response(200, json=_raw())
+            )
+            patch = router.patch(f"{API}/sandboxes/sbx-1").mock(
+                return_value=httpx.Response(204)
+            )
+            Sandbox.update_by_id("sbx-1", auto_delete_seconds=3600)
+            # The point of update_by_id: never resume the sandbox.
+            assert not activate.called
+            assert patch.call_count == 1
+            assert json.loads(patch.calls[0].request.content) == {
+                "auto_delete_seconds": 3600
+            }
 
     def test_attach_secret_posts_binding(self) -> None:
         with respx.mock() as router:

--- a/packages/python-sdk/tests/test_types.py
+++ b/packages/python-sdk/tests/test_types.py
@@ -51,6 +51,15 @@ class TestToSandboxInfo:
         assert info.memory_mib == 1024
         assert info.timeout_seconds == 600
         assert info.metadata == {"key": "value"}
+
+    def test_auto_delete_fields_parse(self) -> None:
+        raw = _valid_raw()
+        raw["auto_delete_seconds"] = 3600
+        raw["auto_delete_at"] = "2026-01-01T13:00:00Z"
+        info = to_sandbox_info(raw)
+        assert info.auto_delete_seconds == 3600
+        assert isinstance(info.auto_delete_at, datetime)
+        assert info.auto_delete_at.hour == 13
         assert info.network is not None
         assert info.network.allow_out == ["1.2.3.4"]
         assert info.network.deny_out == []
@@ -78,6 +87,8 @@ class TestToSandboxInfo:
         assert info.vcpu_count == 0
         assert info.memory_mib == 0
         assert info.timeout_seconds is None
+        assert info.auto_delete_seconds is None
+        assert info.auto_delete_at is None
         assert info.network is None
         assert info.metadata == {}
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superserve/sdk",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "TypeScript SDK for the Superserve sandbox API",
   "keywords": [
     "firecracker",

--- a/packages/sdk/src/Sandbox.ts
+++ b/packages/sdk/src/Sandbox.ts
@@ -153,6 +153,8 @@ export class Sandbox {
     const body: Record<string, unknown> = { name: options.name }
     if (options.timeoutSeconds !== undefined)
       body.timeout_seconds = options.timeoutSeconds
+    if (options.autoDeleteSeconds !== undefined)
+      body.auto_delete_seconds = options.autoDeleteSeconds
     if (options.fromTemplate !== undefined) {
       body.from_template =
         typeof options.fromTemplate === "string"
@@ -275,6 +277,29 @@ export class Sandbox {
     }
   }
 
+  /**
+   * Update a sandbox by ID without holding a live instance.
+   *
+   * Unlike `connect(id).then(s => s.update(...))`, this does not activate the
+   * sandbox — a paused sandbox stays paused. Use it to change `metadata`,
+   * `network`, `autoDeleteSeconds`, or `timeoutSeconds` from just an ID.
+   * Pass `null` for `autoDeleteSeconds` / `timeoutSeconds` to clear them.
+   */
+  static async updateById(
+    sandboxId: string,
+    options: SandboxUpdateOptions,
+    connection: ConnectionOptions = {},
+  ): Promise<void> {
+    const config = resolveConfig(connection)
+    await requestVoid({
+      method: "PATCH",
+      url: `${config.baseUrl}/sandboxes/${sandboxId}`,
+      headers: { "X-API-Key": config.apiKey },
+      body: Sandbox.buildUpdateBody(options),
+      signal: connection.signal,
+    })
+  }
+
   // -------------------------------------------------------------------------
   // Instance lifecycle methods
   // -------------------------------------------------------------------------
@@ -335,24 +360,39 @@ export class Sandbox {
   }
 
   /**
-   * Partially update this sandbox (metadata, network rules).
+   * Partially update this sandbox (metadata, network rules, auto-delete,
+   * timeout).
+   *
+   * `autoDeleteSeconds: null` clears the auto-delete window; a number sets
+   * it, counting from now when the sandbox is already paused.
+   * `timeoutSeconds: null` clears the auto-pause timeout.
    */
   async update(options: SandboxUpdateOptions): Promise<void> {
+    await requestVoid({
+      method: "PATCH",
+      url: `${this._config.baseUrl}/sandboxes/${this.id}`,
+      headers: { "X-API-Key": this._config.apiKey },
+      body: Sandbox.buildUpdateBody(options),
+    })
+  }
+
+  /** Serialize update options to the wire body (snake_case, null preserved). */
+  private static buildUpdateBody(
+    options: SandboxUpdateOptions,
+  ): Record<string, unknown> {
     const body: Record<string, unknown> = {}
     if (options.metadata !== undefined) body.metadata = options.metadata
+    if (options.autoDeleteSeconds !== undefined)
+      body.auto_delete_seconds = options.autoDeleteSeconds
+    if (options.timeoutSeconds !== undefined)
+      body.timeout_seconds = options.timeoutSeconds
     if (options.network !== undefined) {
       body.network = {
         allow_out: options.network.allowOut,
         deny_out: options.network.denyOut,
       }
     }
-
-    await requestVoid({
-      method: "PATCH",
-      url: `${this._config.baseUrl}/sandboxes/${this.id}`,
-      headers: { "X-API-Key": this._config.apiKey },
-      body,
-    })
+    return body
   }
 
   /**

--- a/packages/sdk/src/http.ts
+++ b/packages/sdk/src/http.ts
@@ -20,7 +20,7 @@ import type { ApiExecStreamEvent } from "./types.js"
 
 const DEFAULT_TIMEOUT_MS = 30_000
 
-const SDK_VERSION = "0.7.7"
+const SDK_VERSION = "0.7.8"
 const USER_AGENT = `@superserve/sdk/${SDK_VERSION} (node/${
   typeof process !== "undefined" && process.versions?.node
     ? `v${process.versions.node}`

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -26,6 +26,10 @@ export interface SandboxInfo {
   memoryMib: number
   createdAt: Date
   timeoutSeconds?: number
+  /** Delete the sandbox after it has been continuously paused for this many seconds. */
+  autoDeleteSeconds?: number
+  /** When the sandbox will be auto-deleted. Present only while paused with `autoDeleteSeconds` set. */
+  autoDeleteAt?: Date
   network?: NetworkConfig
   metadata: Record<string, string>
   /** Secrets bound to this sandbox (env-var → secret), when any are attached. */
@@ -49,6 +53,13 @@ export interface SandboxCreateOptions extends ConnectionOptions {
   /** Snapshot UUID. */
   fromSnapshot?: string
   timeoutSeconds?: number
+  /**
+   * Delete the sandbox once it has been continuously paused for this
+   * many seconds. The window arms on every pause and is cancelled by resume;
+   * `0` deletes as soon as the sandbox pauses. Omit to keep paused
+   * sandboxes forever (the default).
+   */
+  autoDeleteSeconds?: number
   metadata?: Record<string, string>
   envVars?: Record<string, string>
   /**
@@ -67,6 +78,17 @@ export interface SandboxListOptions extends ConnectionOptions {
 export interface SandboxUpdateOptions {
   metadata?: Record<string, string>
   network?: NetworkConfig
+  /**
+   * Set or clear the auto-delete window. A number (re)arms it — on an
+   * already-paused sandbox the countdown starts now, never retroactively.
+   * `null` disables auto-delete; `undefined` leaves it unchanged.
+   */
+  autoDeleteSeconds?: number | null
+  /**
+   * Set or clear the auto-pause timeout. `null` disables auto-pause;
+   * `undefined` leaves it unchanged.
+   */
+  timeoutSeconds?: number | null
 }
 
 // ---------------------------------------------------------------------------
@@ -157,6 +179,8 @@ export interface ApiSandboxResponse {
   access_token?: string
   created_at?: string
   timeout_seconds?: number
+  auto_delete_seconds?: number
+  auto_delete_at?: string
   network?: { allow_out?: string[]; deny_out?: string[] }
   metadata?: Record<string, string>
   secrets?: Array<{
@@ -220,6 +244,8 @@ export function toSandboxInfo(raw: ApiSandboxResponse): SandboxInfo {
     memoryMib: raw.memory_mib ?? 0,
     createdAt: new Date(raw.created_at),
     timeoutSeconds: raw.timeout_seconds ?? undefined,
+    autoDeleteSeconds: raw.auto_delete_seconds ?? undefined,
+    autoDeleteAt: raw.auto_delete_at ? new Date(raw.auto_delete_at) : undefined,
     network: raw.network
       ? { allowOut: raw.network.allow_out, denyOut: raw.network.deny_out }
       : undefined,

--- a/packages/sdk/tests/sandbox.test.ts
+++ b/packages/sdk/tests/sandbox.test.ts
@@ -103,6 +103,85 @@ describe("Sandbox statics", () => {
     expect(body).toEqual({ name: "my-sandbox", metadata: { env: "test" } })
   })
 
+  it("Sandbox.create sends auto_delete_seconds when set", async () => {
+    const mock = vi.fn(async () => jsonResponse(baseSandbox))
+    vi.stubGlobal("fetch", mock)
+
+    await Sandbox.create({
+      ...commonOpts,
+      name: "my-sandbox",
+      autoDeleteSeconds: 3600,
+    })
+
+    const [, init] = mock.mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(init.body as string)
+    expect(body).toEqual({ name: "my-sandbox", auto_delete_seconds: 3600 })
+  })
+
+  it("sandbox.update sets and clears auto_delete_seconds", async () => {
+    const mock = vi.fn(async () => jsonResponse(baseSandbox))
+    vi.stubGlobal("fetch", mock)
+    const sandbox = await Sandbox.create({ ...commonOpts, name: "my-sandbox" })
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 204 })),
+    )
+    const patchMock = globalThis.fetch as ReturnType<typeof vi.fn>
+
+    await sandbox.update({ autoDeleteSeconds: 600 })
+    let [url, init] = patchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe("https://api.superserve.ai/sandboxes/sbx-1")
+    expect(init.method).toBe("PATCH")
+    expect(JSON.parse(init.body as string)).toEqual({
+      auto_delete_seconds: 600,
+    })
+
+    await sandbox.update({ autoDeleteSeconds: null })
+    ;[url, init] = patchMock.mock.calls[1] as [string, RequestInit]
+    expect(JSON.parse(init.body as string)).toEqual({
+      auto_delete_seconds: null,
+    })
+  })
+
+  it("sandbox.update sets and clears timeout_seconds", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse(baseSandbox)),
+    )
+    const sandbox = await Sandbox.create({ ...commonOpts, name: "my-sandbox" })
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 204 })),
+    )
+    const patchMock = globalThis.fetch as ReturnType<typeof vi.fn>
+
+    await sandbox.update({ timeoutSeconds: 900 })
+    let [, init] = patchMock.mock.calls[0] as [string, RequestInit]
+    expect(JSON.parse(init.body as string)).toEqual({ timeout_seconds: 900 })
+
+    await sandbox.update({ timeoutSeconds: null })
+    ;[, init] = patchMock.mock.calls[1] as [string, RequestInit]
+    expect(JSON.parse(init.body as string)).toEqual({ timeout_seconds: null })
+  })
+
+  it("Sandbox.updateById PATCHes directly without activating", async () => {
+    const mock = vi.fn(async () => new Response(null, { status: 204 }))
+    vi.stubGlobal("fetch", mock)
+
+    await Sandbox.updateById("sbx-9", { autoDeleteSeconds: 3600 }, commonOpts)
+
+    expect(mock).toHaveBeenCalledOnce()
+    const [url, init] = mock.mock.calls[0] as [string, RequestInit]
+    // The whole point: no /activate call, so a paused sandbox stays paused.
+    expect(url).toBe("https://api.superserve.ai/sandboxes/sbx-9")
+    expect(init.method).toBe("PATCH")
+    expect(JSON.parse(init.body as string)).toEqual({
+      auto_delete_seconds: 3600,
+    })
+  })
+
   it("Sandbox.create throws when access_token missing", async () => {
     vi.stubGlobal(
       "fetch",

--- a/packages/sdk/tests/types.test.ts
+++ b/packages/sdk/tests/types.test.ts
@@ -38,6 +38,17 @@ describe("toSandboxInfo", () => {
     expect(info.metadata).toEqual({ env: "prod" })
   })
 
+  it("converts auto-delete fields", () => {
+    const info = toSandboxInfo({
+      ...valid,
+      auto_delete_seconds: 3600,
+      auto_delete_at: "2026-01-01T01:00:00.000Z",
+    })
+    expect(info.autoDeleteSeconds).toBe(3600)
+    expect(info.autoDeleteAt).toBeInstanceOf(Date)
+    expect(info.autoDeleteAt?.toISOString()).toBe("2026-01-01T01:00:00.000Z")
+  })
+
   it("throws when id is missing", () => {
     expect(() => toSandboxInfo({ ...valid, id: undefined })).toThrow(
       /missing sandbox id/,
@@ -60,6 +71,8 @@ describe("toSandboxInfo", () => {
     expect(info.vcpuCount).toBe(0)
     expect(info.memoryMib).toBe(0)
     expect(info.timeoutSeconds).toBeUndefined()
+    expect(info.autoDeleteSeconds).toBeUndefined()
+    expect(info.autoDeleteAt).toBeUndefined()
     expect(info.network).toBeUndefined()
     expect(info.metadata).toEqual({})
   })

--- a/skills/superserve/SKILL.md
+++ b/skills/superserve/SKILL.md
@@ -14,8 +14,8 @@ TypeScript or Python.
 
 Two flagship uses:
 
-- **Agent runtime** — run an AI agent *inside* the box (e.g. boot `superserve/claude-code`
-  and run `claude`), or give an agent *hosted elsewhere* a sandboxed shell / file tool.
+- **Agent runtime** — run an AI agent _inside_ the box (e.g. boot `superserve/claude-code`
+  and run `claude`), or give an agent _hosted elsewhere_ a sandboxed shell / file tool.
 - **Persistent execution / dev environment** — a box that survives across processes and
   sessions; pause it to stop compute billing, and it auto-resumes on the next exec or connect.
 
@@ -25,7 +25,7 @@ plane** (rotating access token) — you never build data-plane URLs or manage to
 
 ## When this skill wins
 
-- **Agent runtime** — run an AI coding agent (Claude Code, OpenClaw, a custom loop) *inside* a sandbox
+- **Agent runtime** — run an AI coding agent (Claude Code, OpenClaw, a custom loop) _inside_ a sandbox
 - **Sandboxed tool for a hosted agent** — back a Claude Agent SDK / OpenAI Agents SDK `bash` or file tool with the box
 - **Persistent execution / dev environment** — create once, reconnect by id across sessions, pause/resume with full state
 - A remote shell / command runner with file I/O and controlled network egress
@@ -44,7 +44,7 @@ plane** (rotating access token) — you never build data-plane URLs or manage to
    - Python: `pip install superserve` (Python ≥ 3.9; uv/poetry also work)
 2. **Set `SUPERSERVE_API_KEY`** (key prefix `ss_live_`) in the environment — get it
    from the Superserve console. With it set, `create()` needs no other config.
-3. *(Optional)* Override the API base with `SUPERSERVE_BASE_URL` (default `https://api.superserve.ai`).
+3. _(Optional)_ Override the API base with `SUPERSERVE_BASE_URL` (default `https://api.superserve.ai`).
 
 ## Quickstart
 
@@ -88,7 +88,7 @@ For async Python, use `AsyncSandbox` and `await` every call.
 
 The primary use case, in two shapes.
 
-**A — Agent runs *inside* the box.** Boot a template with the agent preinstalled and pass its
+**A — Agent runs _inside_ the box.** Boot a template with the agent preinstalled and pass its
 model key as a secret; its shell commands and edits stay isolated, and `pause()` / `resume()`
 checkpoint and restore the whole session.
 
@@ -110,7 +110,7 @@ sandbox = Sandbox.create(
 )
 ```
 
-**B — Agent *hosted elsewhere* calls into the box.** Expose `sandbox.commands.run` as a single
+**B — Agent _hosted elsewhere_ calls into the box.** Expose `sandbox.commands.run` as a single
 `bash` tool, so every command the model emits runs in the VM, not on your machine (Claude
 Agent SDK shown; OpenAI Agents SDK is analogous):
 
@@ -118,12 +118,20 @@ Agent SDK shown; OpenAI Agents SDK is analogous):
 import { tool, createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk"
 import { z } from "zod"
 // assumes an active Sandbox instance `sandbox`
-const bash = tool("bash", "Run a shell command in the sandbox.", { command: z.string() },
+const bash = tool(
+  "bash",
+  "Run a shell command in the sandbox.",
+  { command: z.string() },
   async ({ command }) => {
     const r = await sandbox.commands.run(command, { timeoutMs: 60_000 })
     return { content: [{ type: "text", text: `${r.stdout}\n${r.stderr}` }] }
-  })
-const superserve = createSdkMcpServer({ name: "superserve", version: "1.0.0", tools: [bash] })
+  },
+)
+const superserve = createSdkMcpServer({
+  name: "superserve",
+  version: "1.0.0",
+  tools: [bash],
+})
 // query(..., { mcpServers: { superserve }, allowedTools: ["mcp__superserve__bash"] })
 ```
 
@@ -147,8 +155,13 @@ Key behaviors:
   and processes pick up where they left off.
 - **Exec auto-resumes.** Running a command or file op (or `connect()`) on a `paused`
   sandbox transparently resumes it first — you do **not** call `resume()` yourself.
-- **`timeoutSeconds` / `timeout_seconds` caps active lifetime, then auto-*pauses*** —
+- **`timeoutSeconds` / `timeout_seconds` caps active lifetime, then auto-_pauses_** —
   state is preserved, it is **not** deleted. (Bounded by an API-side upper limit.)
+- **`autoDeleteSeconds` / `auto_delete_seconds` garbage-collects paused sandboxes** — the box
+  is deleted once continuously paused for that long (resume cancels the countdown; `0` =
+  delete on pause; unset = kept forever). Set it for scratch work you won't `kill()` yourself,
+  and pair it with `timeoutSeconds` so the box actually pauses. Both are settable after
+  creation via `update()`; pass `null`/`None` to clear.
 - `resume()` rotates the per-sandbox access token; the SDK re-injects it into
   `sandbox.files` for you — keep using the **same** object after resume.
 - `kill()` is **idempotent** (a 404 is swallowed). `pause()`/`resume()`/`kill()` return nothing.
@@ -188,11 +201,11 @@ or `disk` argument on `create()`**. To change the shape, boot from (or build) a 
 template. The default template `superserve/base` (`ubuntu:24.04`) is **1 vCPU · 1024 MiB
 memory · 4096 MiB disk**.
 
-| Shape field | Min | Max (platform ceiling) | Default |
-|---|---|---|---|
-| `vcpu` | 1 | 4 | 1 |
-| `memoryMib` | 256 | 4096 | 1024 |
-| `diskMib` | 1024 | 8192 | 4096 |
+| Shape field | Min  | Max (platform ceiling) | Default |
+| ----------- | ---- | ---------------------- | ------- |
+| `vcpu`      | 1    | 4                      | 1       |
+| `memoryMib` | 256  | 4096                   | 1024    |
+| `diskMib`   | 1024 | 8192                   | 4096    |
 
 - **New teams are capped at 2 vCPU / 2048 MiB** — email support@superserve.ai to raise it.
 - Heavier system templates (`superserve/python-ml`, `code-interpreter`, `claude-code`,
@@ -202,23 +215,23 @@ memory · 4096 MiB disk**.
 
 ## Common operations
 
-| Task | TypeScript | Python (sync) | Returns / notes |
-|---|---|---|---|
-| Create | `Sandbox.create({ name })` | `Sandbox.create(name=...)` | `Sandbox`; opts: `timeoutSeconds`, `metadata`, `envVars`, `network`, `fromTemplate`, `fromSnapshot` (snapshot UUID) |
-| Reconnect | `Sandbox.connect(id)` | `Sandbox.connect(id)` | `Sandbox`; auto-resumes if paused |
-| List | `Sandbox.list({ metadata })` | `Sandbox.list(metadata=...)` | `SandboxInfo[]` (no live instance); metadata filters combine with AND |
-| Delete by id | `Sandbox.killById(id)` | `Sandbox.kill_by_id(id)` | idempotent |
-| Fresh info | `sandbox.getInfo()` | `sandbox.get_info()` | `SandboxInfo` |
-| Pause | `sandbox.pause()` | `sandbox.pause()` | — |
-| Resume | `sandbox.resume()` | `sandbox.resume()` | rotates access token |
-| Delete | `sandbox.kill()` | `sandbox.kill()` | idempotent |
-| Update | `sandbox.update({ metadata, network })` | `sandbox.update(metadata=..., network=...)` | patches tags / egress; **metadata is replaced, not merged — pass the full map** |
-| Run command | `sandbox.commands.run(cmd, opts)` | `sandbox.commands.run(cmd, ...)` | `{ stdout, stderr, exitCode }` / `CommandResult`; opts: `cwd`, `env`, timeout |
-| Stream output | `run(cmd, { onStdout, onStderr })` | `run(cmd, on_stdout=..., on_stderr=...)` | chunks via callbacks; result still holds full buffer |
-| Interactive process | `sandbox.commands.spawn(cmd, opts)` | `AsyncSandbox(...).commands.spawn(...)` | full-duplex session (sync Python raises — use async) |
-| Write file | `sandbox.files.write(path, content)` | `sandbox.files.write(path, content)` | parent dirs auto-created |
-| Read bytes | `sandbox.files.read(path)` | `sandbox.files.read(path)` | `Uint8Array` / `bytes` |
-| Read text | `sandbox.files.readText(path)` | `sandbox.files.read_text(path)` | UTF-8 string |
+| Task                | TypeScript                                                                 | Python (sync)                                                                             | Returns / notes                                                                                                                          |
+| ------------------- | -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Create              | `Sandbox.create({ name })`                                                 | `Sandbox.create(name=...)`                                                                | `Sandbox`; opts: `timeoutSeconds`, `autoDeleteSeconds`, `metadata`, `envVars`, `network`, `fromTemplate`, `fromSnapshot` (snapshot UUID) |
+| Reconnect           | `Sandbox.connect(id)`                                                      | `Sandbox.connect(id)`                                                                     | `Sandbox`; auto-resumes if paused                                                                                                        |
+| List                | `Sandbox.list({ metadata })`                                               | `Sandbox.list(metadata=...)`                                                              | `SandboxInfo[]` (no live instance); metadata filters combine with AND                                                                    |
+| Delete by id        | `Sandbox.killById(id)`                                                     | `Sandbox.kill_by_id(id)`                                                                  | idempotent                                                                                                                               |
+| Fresh info          | `sandbox.getInfo()`                                                        | `sandbox.get_info()`                                                                      | `SandboxInfo`                                                                                                                            |
+| Pause               | `sandbox.pause()`                                                          | `sandbox.pause()`                                                                         | —                                                                                                                                        |
+| Resume              | `sandbox.resume()`                                                         | `sandbox.resume()`                                                                        | rotates access token                                                                                                                     |
+| Delete              | `sandbox.kill()`                                                           | `sandbox.kill()`                                                                          | idempotent                                                                                                                               |
+| Update              | `sandbox.update({ metadata, network, autoDeleteSeconds, timeoutSeconds })` | `sandbox.update(metadata=..., network=..., auto_delete_seconds=..., timeout_seconds=...)` | patches tags / egress / auto-delete / timeout; **metadata is replaced, not merged**; pass `null`/`None` to clear auto-delete or timeout  |
+| Run command         | `sandbox.commands.run(cmd, opts)`                                          | `sandbox.commands.run(cmd, ...)`                                                          | `{ stdout, stderr, exitCode }` / `CommandResult`; opts: `cwd`, `env`, timeout                                                            |
+| Stream output       | `run(cmd, { onStdout, onStderr })`                                         | `run(cmd, on_stdout=..., on_stderr=...)`                                                  | chunks via callbacks; result still holds full buffer                                                                                     |
+| Interactive process | `sandbox.commands.spawn(cmd, opts)`                                        | `AsyncSandbox(...).commands.spawn(...)`                                                   | full-duplex session (sync Python raises — use async)                                                                                     |
+| Write file          | `sandbox.files.write(path, content)`                                       | `sandbox.files.write(path, content)`                                                      | parent dirs auto-created                                                                                                                 |
+| Read bytes          | `sandbox.files.read(path)`                                                 | `sandbox.files.read(path)`                                                                | `Uint8Array` / `bytes`                                                                                                                   |
+| Read text           | `sandbox.files.readText(path)`                                             | `sandbox.files.read_text(path)`                                                           | UTF-8 string                                                                                                                             |
 
 **Unit footgun:** the command timeout is **`timeoutMs` (milliseconds) in TS** but
 **`timeout_seconds` (seconds) in Python**. `run("…", { timeoutMs: 10000 })` ≈ `run("…", timeout_seconds=10)`.
@@ -252,7 +265,7 @@ event, `run()` **throws** — but the command keeps running in the sandbox, so r
 `Sandbox.connect(id)` if you saved the ID.
 
 Use **`spawn()`** when you need to send stdin, signal the process, or keep a REPL open. It
-resolves once the process is *running* and hands back a session: `stdin.write(data)`,
+resolves once the process is _running_ and hands back a session: `stdin.write(data)`,
 `stdin.close()` (EOF), `kill(signal?)` (default `SIGTERM`), `wait()` (resolves on exit;
 rejects if the socket drops first). `spawn()` is **async-only in Python** (`AsyncSandbox`;
 sync raises and points you there) and needs **Node 22+** in TS (or a `ws` polyfill).
@@ -290,12 +303,12 @@ import { Template, Sandbox } from "@superserve/sdk"
 
 const template = await Template.create({
   name: "my-python-env",
-  from: "python:3.11",           // linux/amd64 OCI image; Alpine & distroless are rejected
+  from: "python:3.11", // linux/amd64 OCI image; Alpine & distroless are rejected
   vcpu: 2,
   memoryMib: 2048,
   steps: [{ run: "pip install numpy pandas" }, { workdir: "/app" }],
 }) // resolves once the build is QUEUED, not finished
-await template.waitUntilReady()  // blocks until the build finishes (throws BuildError on failure)
+await template.waitUntilReady() // blocks until the build finishes (throws BuildError on failure)
 const sandbox = await Sandbox.create({ name: "run-1", fromTemplate: template })
 ```
 
@@ -352,7 +365,11 @@ a prompt-injected agent, or a leaked log exposes nothing usable.
 import { Secret, Sandbox } from "@superserve/sdk"
 
 // 1. Store the credential once — a provider shortcut sets the auth scheme + allowed hosts.
-await Secret.create({ name: "anthropic-prod", value: process.env.ANTHROPIC_API_KEY!, provider: "anthropic" })
+await Secret.create({
+  name: "anthropic-prod",
+  value: process.env.ANTHROPIC_API_KEY!,
+  provider: "anthropic",
+})
 
 // 2. Bind it: env var → secret name. Pair with egress lockdown for defense in depth.
 const sandbox = await Sandbox.create({
@@ -389,13 +406,13 @@ sandbox = Sandbox.create(
 ## Network egress control
 
 By default a sandbox reaches any **public** IP; the platform **always** blocks private,
-link-local, and loopback ranges (non-overridable). `network` rules only *narrow* egress —
+link-local, and loopback ranges (non-overridable). `network` rules only _narrow_ egress —
 ideal for restricting what an agent or untrusted code can reach.
 
-| Field | Accepts | Notes |
-|---|---|---|
+| Field                    | Accepts             | Notes                                                                                                      |
+| ------------------------ | ------------------- | ---------------------------------------------------------------------------------------------------------- |
 | `allowOut` / `allow_out` | CIDRs **+ domains** | Wildcards (`*.example.com`) match subdomains at any depth but **not the apex** — list both if you need it. |
-| `denyOut` / `deny_out` | **CIDRs only** | `0.0.0.0/0` denies the whole internet; allow exceptions via `allowOut`. |
+| `denyOut` / `deny_out`   | **CIDRs only**      | `0.0.0.0/0` denies the whole internet; allow exceptions via `allowOut`.                                    |
 
 Allow rules win over deny on overlap, so the strict pattern is **deny-all + allowlist**.
 Egress is editable live via `update({ network })`. **Never block `*.superserve.ai`** — it
@@ -404,7 +421,10 @@ breaks the SDK↔sandbox connection.
 ```ts
 await Sandbox.create({
   name: "restricted",
-  network: { allowOut: ["api.openai.com", "*.github.com", "140.82.112.0/20"], denyOut: ["0.0.0.0/0"] },
+  network: {
+    allowOut: ["api.openai.com", "*.github.com", "140.82.112.0/20"],
+    denyOut: ["0.0.0.0/0"],
+  },
 })
 ```
 
@@ -418,7 +438,7 @@ Sandbox.create(name="restricted", network=NetworkConfig(
 ## Preview URLs — expose a port publicly
 
 Run a server in the box (a dev server, the agent's web UI, an API) and hand out a **public
-URL** (also called a *tunnel URL*) that routes to it. `getPreviewUrl(port)` / `get_preview_url(port)` is pure string
+URL** (also called a _tunnel URL_) that routes to it. `getPreviewUrl(port)` / `get_preview_url(port)` is pure string
 construction — no network call — returning `https://{port}-{id}.{host}`; the edge proxy
 forwards that subdomain straight to the port on the VM.
 
@@ -447,26 +467,28 @@ url = sandbox.get_preview_url(8000)  # https://8000-<id>.sandbox.superserve.ai
 Every SDK call throws a typed error extending `SandboxError`. Catch the base, or
 narrow to a subclass. A **non-zero `exitCode` is a normal result, not a thrown error.**
 
-| Error | Thrown when |
-|---|---|
-| `SandboxError` | Base class for all SDK errors (carries `statusCode`, `code`) |
-| `AuthenticationError` | API key missing / invalid / forbidden (401/403) |
-| `ValidationError` | Bad request or invalid arguments (400) |
-| `NotFoundError` | Sandbox / template / resource does not exist (404) |
-| `ConflictError` | Invalid state transition, e.g. an unsupported lifecycle change (409) |
-| `TimeoutError` | A request timed out — **Python: `SandboxTimeoutError`** (avoids shadowing the builtin) |
-| `RateLimitError` | Quota / rate limit exceeded (429); `code` names which limit (`too_many_builds`, `too_many_templates`, `too_many_sandboxes`) |
-| `ServerError` | Platform error (500+) |
-| `BuildError` | Template build failed (carries `buildId`, `templateId`, `code`) |
+| Error                 | Thrown when                                                                                                                 |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `SandboxError`        | Base class for all SDK errors (carries `statusCode`, `code`)                                                                |
+| `AuthenticationError` | API key missing / invalid / forbidden (401/403)                                                                             |
+| `ValidationError`     | Bad request or invalid arguments (400)                                                                                      |
+| `NotFoundError`       | Sandbox / template / resource does not exist (404)                                                                          |
+| `ConflictError`       | Invalid state transition, e.g. an unsupported lifecycle change (409)                                                        |
+| `TimeoutError`        | A request timed out — **Python: `SandboxTimeoutError`** (avoids shadowing the builtin)                                      |
+| `RateLimitError`      | Quota / rate limit exceeded (429); `code` names which limit (`too_many_builds`, `too_many_templates`, `too_many_sandboxes`) |
+| `ServerError`         | Platform error (500+)                                                                                                       |
+| `BuildError`          | Template build failed (carries `buildId`, `templateId`, `code`)                                                             |
 
 ```ts
 import { Sandbox, NotFoundError, AuthenticationError } from "@superserve/sdk"
 try {
   const sandbox = await Sandbox.connect(id)
 } catch (e) {
-  if (e instanceof NotFoundError) { /* gone — create a fresh one */ }
-  else if (e instanceof AuthenticationError) { /* fix SUPERSERVE_API_KEY */ }
-  else throw e
+  if (e instanceof NotFoundError) {
+    /* gone — create a fresh one */
+  } else if (e instanceof AuthenticationError) {
+    /* fix SUPERSERVE_API_KEY */
+  } else throw e
 }
 ```
 
@@ -479,7 +501,7 @@ try {
 - Use `getInfo()` for current state — the instance `status`/`metadata` are stale snapshots.
 - `update({ metadata })` **replaces** the whole map; omitted keys are dropped.
 - No `vcpu`/`memory`/`disk` on `create()` — size the VM via the template.
-- `Template.create()` returns when the build is *queued*; boot a sandbox only **after**
+- `Template.create()` returns when the build is _queued_; boot a sandbox only **after**
   `waitUntilReady()` resolves.
 - Streaming `run()` uses an idle timeout (resets per chunk) and throws if the stream ends
   without a `finished` event; the command keeps running — reconnect via `connect(id)`.

--- a/uv.lock
+++ b/uv.lock
@@ -492,7 +492,7 @@ wheels = [
 
 [[package]]
 name = "superserve"
-version = "0.7.7"
+version = "0.7.8"
 source = { editable = "packages/python-sdk" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
SDK, console, MCP, and docs support for paused-sandbox auto-delete, plus a patchable auto-pause timeout. Mirrors the control-plane API (superserve-ai/sandbox#178).

- **TS + Python SDKs**: `autoDeleteSeconds`/`auto_delete_seconds` on create; `update()` sets or clears (`null`/`None`) both `autoDeleteSeconds` and `timeoutSeconds` (absent = unchanged); `autoDeleteSeconds` + `autoDeleteAt` on `SandboxInfo`.
- **Console**: auto-delete field in the create dialog and a deadline cell on the detail grid.
- **MCP**: `sandbox_create`/`sandbox_update` accept the fields; `sandbox_info` reports them.
- **Docs**: Auto-delete section on the lifecycle page, option rows, `update()` reference, SKILL.md.

Semantics match the API: pause arms the window, resume cancels it, `0` = delete on pause, arming on an already-paused sandbox counts from now.

Tests: vitest (SDK 215, console 351), pytest (287), MCP (88); typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)