### PR TITLE
document public-repo hygiene in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,3 +87,9 @@ The console has a deliberate austere, technical aesthetic:
 
 - Single-line commit messages
 - No "Co-Authored-By" or AI attribution in commits
+
+## Public repo
+
+- Code, comments, fixtures, commits, and PR titles/descriptions are all public
+- Never name customers or their domains — use neutral placeholders (`pilot-team`, `example.com`)
+- Never cite internal tracker IDs or internal URLs — describe the purpose in words instead

--- a/apps/console/src/lib/cells.ts
+++ b/apps/console/src/lib/cells.ts
@@ -77,8 +77,8 @@ export function cellFor(region: string): Cell {
   return cell
 }
 
-// Multi-cell UI allowlist. Region choice (and later the team switcher,
-// SS-162) rolls out person-by-person, independent of which cells are
+// Multi-cell UI allowlist. Region choice (and later the team switcher)
+// rolls out person-by-person, independent of which cells are
 // configured: MULTI_CELL_UI_ALLOWLIST is a comma-separated list of email
 // addresses and/or @domain entries (e.g. "@superserve.ai,pilot@acme.com").
 // Absent or unmatched, users see only the default region even when other


### PR DESCRIPTION
Everything in this repo and its PR metadata is public, so the guidelines now say what that implies: no customer names, no internal tracker IDs, no internal URLs — in code, fixtures, commits, or PR text. Also rewords one merged comment that cited a tracker ID.

Testing: docs + comment-only change; lint clean on the touched file.