### PR TITLE
revert: unset SDK/Python 0.7.8 bump so release.yml owns the version bump

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -169,7 +169,7 @@
     },
     "packages/sdk": {
       "name": "@superserve/sdk",
-      "version": "0.7.8",
+      "version": "0.7.7",
       "devDependencies": {
         "@superserve/typescript-config": "workspace:*",
         "@types/node": "^25.5.2",

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "superserve"
-version = "0.7.8"
+version = "0.7.7"
 description = "Python SDK for the Superserve sandbox API"
 license = "Apache-2.0"
 readme = "README.md"

--- a/packages/python-sdk/src/superserve/__init__.py
+++ b/packages/python-sdk/src/superserve/__init__.py
@@ -49,7 +49,7 @@ from .types import (
     WorkdirStep,
 )
 
-__version__ = "0.7.8"
+__version__ = "0.7.7"
 
 __all__ = [
     "AsyncCommandSession",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superserve/sdk",
-  "version": "0.7.8",
+  "version": "0.7.7",
   "description": "TypeScript SDK for the Superserve sandbox API",
   "keywords": [
     "firecracker",

--- a/uv.lock
+++ b/uv.lock
@@ -492,7 +492,7 @@ wheels = [
 
 [[package]]
 name = "superserve"
-version = "0.7.8"
+version = "0.7.7"
 source = { editable = "packages/python-sdk" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
The auto-delete PR (#265) pre-bumped the SDK and Python package versions to 0.7.8. But `release.yml` (the `workflow_dispatch` publisher) is designed to **own** the version bump — it bumps `package.json`/`pyproject.toml`/`__init__.py` to the input version, publishes via OIDC, then commits the bump and tags. With `main` already at 0.7.8, that workflow's `git commit` step fails ("nothing to commit") and no tag gets created.

This reverts the three release-managed files (plus their two lockfile entries, which uv's strict check requires) back to **0.7.7**, so `release.yml` can bump `0.7.7 → 0.7.8` cleanly and publish.

Deliberately **not** reverted (not release-managed; correct at 0.7.8):
- `SDK_VERSION` User-Agent constants in `http.ts` / `_http.py`
- `MIN_SDK_VERSION` publish floor in `mcp-publish.yml`
- MCP package version (0.1.1) — publishes via its own `mcp-v*` tag

After merge: run `release.yml` (package: both, version: 0.7.8), then push the `mcp-v0.1.1` tag once the SDK is live on npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)