### PR TITLE
release: reconcile main to 0.7.8 and fix release.yml push to protected main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,15 +56,12 @@ jobs:
       - name: Publish to npm (Trusted Publishing + provenance)
         run: cd packages/sdk && npm publish --access public --provenance
 
-      - name: Commit version bump
+      # main is a protected branch (PR-only), so we push only the tag, never a
+      # commit. Bump the version on main via a PR before running this workflow.
+      - name: Tag release
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add packages/sdk/package.json
-          git commit -m "release: @superserve/sdk@${{ inputs.version }}"
           git tag "@superserve/sdk@${{ inputs.version }}"
-          git push
-          git push --tags
+          git push origin "@superserve/sdk@${{ inputs.version }}"
 
   release-python:
     if: ${{ inputs.package == 'python' || inputs.package == 'both' }}
@@ -93,12 +90,9 @@ jobs:
       - name: Publish to PyPI (Trusted Publishing)
         run: uv publish --trusted-publishing always dist/superserve-${{ inputs.version }}*
 
-      - name: Commit version bump
+      # main is a protected branch (PR-only), so we push only the tag, never a
+      # commit. Bump the version on main via a PR before running this workflow.
+      - name: Tag release
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add packages/python-sdk/pyproject.toml packages/python-sdk/src/superserve/__init__.py
-          git commit -m "release: superserve-py@${{ inputs.version }}"
           git tag "superserve-py@${{ inputs.version }}"
-          git push
-          git push --tags
+          git push origin "superserve-py@${{ inputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,9 +66,11 @@ jobs:
   release-python:
     if: ${{ inputs.package == 'python' || inputs.package == 'both' }}
     runs-on: ubuntu-latest
+    # Must match the environment on the PyPI trusted publisher (OIDC claim).
+    environment: pypi
     permissions:
       id-token: write # PyPI Trusted Publishing (OIDC)
-      contents: write # push the version-bump commit + tag
+      contents: write # push the release tag
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/bun.lock
+++ b/bun.lock
@@ -169,7 +169,7 @@
     },
     "packages/sdk": {
       "name": "@superserve/sdk",
-      "version": "0.7.7",
+      "version": "0.7.8",
       "devDependencies": {
         "@superserve/typescript-config": "workspace:*",
         "@types/node": "^25.5.2",

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "superserve"
-version = "0.7.7"
+version = "0.7.8"
 description = "Python SDK for the Superserve sandbox API"
 license = "Apache-2.0"
 readme = "README.md"

--- a/packages/python-sdk/src/superserve/__init__.py
+++ b/packages/python-sdk/src/superserve/__init__.py
@@ -49,7 +49,7 @@ from .types import (
     WorkdirStep,
 )
 
-__version__ = "0.7.7"
+__version__ = "0.7.8"
 
 __all__ = [
     "AsyncCommandSession",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superserve/sdk",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "TypeScript SDK for the Superserve sandbox API",
   "keywords": [
     "firecracker",

--- a/uv.lock
+++ b/uv.lock
@@ -492,7 +492,7 @@ wheels = [
 
 [[package]]
 name = "superserve"
-version = "0.7.7"
+version = "0.7.8"
 source = { editable = "packages/python-sdk" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Recovers from a partial release and fixes the underlying workflow bug.

## Context
`@superserve/sdk@0.7.8` **published successfully to npm**, but the `release.yml` "Commit version bump" step failed:
```
GH006: Protected branch update failed for refs/heads/main.
Changes must be made through a pull request.
```
The workflow does `git push` **directly to `main`** to record the bump + tag, but `main` is protected (PR-only), so that push is rejected on every run. Result: package published, but no git tag and `main` left un-bumped.

## This PR
1. **Reconciles `main` to 0.7.8** — re-applies the SDK/Python version to `package.json` / `pyproject.toml` / `__init__.py` + the two lockfile entries, to match what's now published on npm. (These were temporarily reverted to 0.7.7 in #267 to let the workflow attempt run.)
2. **Fixes `release.yml`** — both jobs now push **only the release tag**, never a commit to protected `main`. The version bump is expected to land on `main` via a PR *before* the workflow runs (matching the existing "Bump SDK versions" PR pattern).

## Still needs a human (not code)
- **PyPI Trusted Publishing is not configured** for `superserve` — the Python job failed to publish with `invalid-publisher: no corresponding publisher`. A PyPI project owner must add a Trusted Publisher (repo `superserve-ai/superserve`, workflow `release.yml`) before Python can publish. npm's was already set up, which is why the SDK went out.

## After merge
- Tag the SDK release: `@superserve/sdk@0.7.8` on the merge commit (I'll push it — tags aren't branch-protected; `mcp-v0.1.0` exists as proof).
- Once PyPI Trusted Publishing is configured, re-run `release.yml` (python, 0.7.8), which will now tag cleanly.
- MCP: push `mcp-v0.1.1` (SDK is live on npm, so its `MIN_SDK_VERSION` floor check passes).

cc @pavitrabhalla — you own these release workflows; flagging the protected-branch design and the PyPI publisher config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)