### PR TITLE
docs: add auto-pause lifecycle section and fix timeout wording

### DIFF
--- a/docs/sandbox/create.mdx
+++ b/docs/sandbox/create.mdx
@@ -67,7 +67,7 @@ Use **`secrets`** for credentials, not `envVars`. A secret binds an env var to a
 | Option | Type | Description |
 |---|---|---|
 | `name` | `string` | **Required.** Human-readable sandbox name. |
-| `timeoutSeconds` / `timeout_seconds` | `number` | Max time the sandbox can stay `active` before auto-pause. |
+| `timeoutSeconds` / `timeout_seconds` | `number` | Auto-pause after this many seconds of active time (per session; re-armed on resume). See [Lifecycle](/sandbox/lifecycle#auto-pause). |
 | `autoDeleteSeconds` / `auto_delete_seconds` | `number` | Delete the sandbox once continuously paused for this many seconds. See [Lifecycle](/sandbox/lifecycle#auto-delete). |
 | `metadata` | `Record<string, string>` | String tags. See [Metadata](/sandbox/metadata). |
 | `envVars` / `env_vars` | `Record<string, string>` | Env vars applied to every process. See [Environment variables](/sandbox/environment-variables). |

--- a/docs/sandbox/lifecycle.mdx
+++ b/docs/sandbox/lifecycle.mdx
@@ -110,7 +110,7 @@ Sandbox.kill_by_id("7a3f2b8c-1234-...")
 
 ## Auto-pause
 
-Set `timeoutSeconds` to have the platform pause a sandbox once it has been **active** for that long — checkpointing its state and stopping compute billing. It's the standard way to keep idle sandboxes from burning compute: the box isn't deleted, and the next `commands.run()`, file op, or `connect()` auto-resumes it right where it left off.
+Set `timeoutSeconds` to have the platform pause a sandbox once it has been **active** for that long — checkpointing its state and stopping compute billing. It bounds how long a sandbox can run (and bill) before it's automatically parked, so a forgotten sandbox doesn't run indefinitely. The box isn't deleted, and the next `commands.run()`, file op, or `connect()` auto-resumes it right where it left off.
 
 <CodeGroup>
 ```typescript TypeScript {3}
@@ -130,7 +130,8 @@ sandbox = Sandbox.create(
 
 The window tracks the **current active session**, not total lifetime:
 
-- It counts active time and **re-arms on each resume** — a resumed sandbox gets a fresh window.
+- It's a cap on active time, **not an idle timer** — running work doesn't reset it, so a task still going when the window elapses is paused mid-run. Size it for your longest expected active session.
+- It **re-arms on each resume** — a resumed sandbox gets a fresh window.
 - The sandbox is **paused, not deleted** — resume (or auto-resume) restores it with full state.
 - Unset (the default) means no auto-pause: the sandbox stays active until you pause or kill it.
 

--- a/docs/sandbox/lifecycle.mdx
+++ b/docs/sandbox/lifecycle.mdx
@@ -110,7 +110,7 @@ Sandbox.kill_by_id("7a3f2b8c-1234-...")
 
 ## Auto-pause
 
-Set `timeoutSeconds` to have the platform pause a sandbox once it has been **active** for that long — checkpointing its state and stopping compute billing. It bounds how long a sandbox can run (and bill) before it's automatically parked, so a forgotten sandbox doesn't run indefinitely. The box isn't deleted, and the next `commands.run()`, file op, or `connect()` auto-resumes it right where it left off.
+Set `timeoutSeconds` to auto-pause a sandbox after it has been active for that long. Pausing checkpoints its state and stops compute billing, so a sandbox you forget about won't keep running and billing. It isn't deleted; the next `commands.run()`, file operation, or `connect()` resumes it where it left off.
 
 <CodeGroup>
 ```typescript TypeScript {3}
@@ -128,12 +128,12 @@ sandbox = Sandbox.create(
 ```
 </CodeGroup>
 
-The window tracks the **current active session**, not total lifetime:
+The timeout is scoped to the current active session:
 
-- It's a cap on active time, **not an idle timer** — running work doesn't reset it, so a task still going when the window elapses is paused mid-run. Size it for your longest expected active session.
-- It **re-arms on each resume** — a resumed sandbox gets a fresh window.
-- The sandbox is **paused, not deleted** — resume (or auto-resume) restores it with full state.
-- Unset (the default) means no auto-pause: the sandbox stays active until you pause or kill it.
+- It's a cap on active time, not idle time. Running work doesn't reset it, so a task still going when the window elapses is paused mid-run. Size it for your longest active session.
+- Each resume starts a fresh window.
+- The sandbox is paused, not deleted. Resume restores full memory and filesystem.
+- Leave it unset (the default) to disable auto-pause; the sandbox stays active until you pause or kill it.
 
 Set or clear it on an existing sandbox:
 
@@ -151,7 +151,7 @@ sandbox.update(timeout_seconds=None)  # disable auto-pause
 
 ## Auto-delete
 
-By default a paused sandbox is kept forever. Set `autoDeleteSeconds` to have the platform delete it once it has been **continuously paused** for that long — useful for short-lived or unattended sandboxes: scheduled jobs, one-off experiments, or agent sessions that never get an explicit `kill()`.
+By default a paused sandbox is kept forever. Set `autoDeleteSeconds` to delete it once it has been continuously paused for that long. This suits short-lived or unattended sandboxes: scheduled jobs, one-off experiments, or agent sessions that never get an explicit `kill()`.
 
 <CodeGroup>
 ```typescript TypeScript {5}
@@ -173,11 +173,11 @@ sandbox = Sandbox.create(
 ```
 </CodeGroup>
 
-The timer is tied to the paused state itself:
+The countdown is tied to the paused state:
 
-- **Pause** arms the countdown; **resume** cancels it. Pausing again later starts a fresh window, so a sandbox in use is never deleted.
+- Pause starts it and resume cancels it. Pausing again starts a fresh window, so a sandbox in use is never deleted.
 - `0` deletes the sandbox as soon as it pauses.
-- While the sandbox is paused, its info includes `autoDeleteAt` — the exact deletion time.
+- While paused, the sandbox's info includes `autoDeleteAt`, the exact deletion time.
 - Maximum window: 30 days.
 
 You can also set or clear the window on an existing sandbox:

--- a/docs/sandbox/lifecycle.mdx
+++ b/docs/sandbox/lifecycle.mdx
@@ -203,5 +203,5 @@ sandbox.update(auto_delete_seconds=None)
 </CodeGroup>
 
 <Tip>
-Pair `autoDeleteSeconds` with `timeoutSeconds`: the timeout pauses an idle sandbox, then the auto-delete window cleans it up. A sandbox that never pauses is never auto-deleted.
+Pair `autoDeleteSeconds` with `timeoutSeconds`: the timeout pauses the sandbox, then the auto-delete window cleans it up. A sandbox that never pauses is never auto-deleted.
 </Tip>

--- a/docs/sandbox/lifecycle.mdx
+++ b/docs/sandbox/lifecycle.mdx
@@ -113,14 +113,18 @@ Sandbox.kill_by_id("7a3f2b8c-1234-...")
 Set `timeoutSeconds` to auto-pause a sandbox after it has been active for that long. Pausing checkpoints its state and stops compute billing, so a sandbox you forget about won't keep running and billing. It isn't deleted; the next `commands.run()`, file operation, or `connect()` resumes it where it left off.
 
 <CodeGroup>
-```typescript TypeScript {3}
+```typescript TypeScript {5}
+import { Sandbox } from "@superserve/sdk"
+
 const sandbox = await Sandbox.create({
   name: "worker",
   timeoutSeconds: 3600, // auto-pause after 1h of active time
 })
 ```
 
-```python Python {3}
+```python Python {5}
+from superserve import Sandbox
+
 sandbox = Sandbox.create(
     name="worker",
     timeout_seconds=3600,  # auto-pause after 1h of active time

--- a/docs/sandbox/lifecycle.mdx
+++ b/docs/sandbox/lifecycle.mdx
@@ -108,6 +108,46 @@ Sandbox.kill_by_id("7a3f2b8c-1234-...")
 </CodeGroup>
 
 
+## Auto-pause
+
+Set `timeoutSeconds` to have the platform pause a sandbox once it has been **active** for that long — checkpointing its state and stopping compute billing. It's the standard way to keep idle sandboxes from burning compute: the box isn't deleted, and the next `commands.run()`, file op, or `connect()` auto-resumes it right where it left off.
+
+<CodeGroup>
+```typescript TypeScript {3}
+const sandbox = await Sandbox.create({
+  name: "worker",
+  timeoutSeconds: 3600, // auto-pause after 1h of active time
+})
+```
+
+```python Python {3}
+sandbox = Sandbox.create(
+    name="worker",
+    timeout_seconds=3600,  # auto-pause after 1h of active time
+)
+```
+</CodeGroup>
+
+The window tracks the **current active session**, not total lifetime:
+
+- It counts active time and **re-arms on each resume** — a resumed sandbox gets a fresh window.
+- The sandbox is **paused, not deleted** — resume (or auto-resume) restores it with full state.
+- Unset (the default) means no auto-pause: the sandbox stays active until you pause or kill it.
+
+Set or clear it on an existing sandbox:
+
+<CodeGroup>
+```typescript TypeScript
+await sandbox.update({ timeoutSeconds: 900 }) // auto-pause after 15m active
+await sandbox.update({ timeoutSeconds: null }) // disable auto-pause
+```
+
+```python Python
+sandbox.update(timeout_seconds=900)  # auto-pause after 15m active
+sandbox.update(timeout_seconds=None)  # disable auto-pause
+```
+</CodeGroup>
+
 ## Auto-delete
 
 By default a paused sandbox is kept forever. Set `autoDeleteSeconds` to have the platform delete it once it has been **continuously paused** for that long — useful for short-lived or unattended sandboxes: scheduled jobs, one-off experiments, or agent sessions that never get an explicit `kill()`.

--- a/docs/sdk-reference/sandbox.mdx
+++ b/docs/sdk-reference/sandbox.mdx
@@ -69,7 +69,7 @@ sandbox = Sandbox.create(
 | `name` | `string` | **Required.** Human-readable sandbox name. |
 | `fromTemplate` / `from_template` | `string \| Template` | Template name, UUID, or `Template` instance to boot from. Defaults to `superserve/base`. |
 | `fromSnapshot` / `from_snapshot` | `string` | Snapshot UUID to boot from. |
-| `timeoutSeconds` / `timeout_seconds` | `number` | Max active lifetime before auto-pause. API-side upper bound (subject to change). |
+| `timeoutSeconds` / `timeout_seconds` | `number` | Auto-pause after this many seconds of active time (per session; re-armed on resume). See [Lifecycle](/sandbox/lifecycle#auto-pause). |
 | `autoDeleteSeconds` / `auto_delete_seconds` | `number` | Delete the sandbox once continuously paused for this many seconds (max 30 days, `0` = delete on pause). See [Lifecycle](/sandbox/lifecycle#auto-delete). |
 | `metadata` | `Record<string, string>` | String tags. |
 | `envVars` / `env_vars` | `Record<string, string>` | Env vars injected into every process. |


### PR DESCRIPTION
Auto-pause (`timeoutSeconds`) was only documented as scattered field descriptions — the lifecycle page had Pause/Resume/Kill/Auto-delete but no Auto-pause section, even though it's the more fundamental behavior (auto-delete depends on a box pausing first).

- Adds an **Auto-pause** section to the lifecycle page, before Auto-delete, so it reads active → auto-pause → auto-delete.
- Fixes the "max active lifetime" wording in the create + SDK-reference field rows — the timeout tracks the current active session and re-arms on resume; it's not a total lifetime. Both now link to the new section.