### PR TITLE
feat: server-side pagination for audit logs page

### DIFF
--- a/apps/console/src/app/(dashboard)/audit-logs/page.tsx
+++ b/apps/console/src/app/(dashboard)/audit-logs/page.tsx
@@ -1,21 +1,36 @@
 "use client"
 
+import { Suspense } from "react"
+
+import { TableSkeleton } from "@/components/table-skeleton"
+
+export default function AuditLogsPage() {
+  return (
+    <Suspense fallback={<TableSkeleton columns={6} tabs={4} />}>
+      <AuditLogsPageContent />
+    </Suspense>
+  )
+}
+
 import { ClipboardTextIcon } from "@phosphor-icons/react"
-import { Table, TableHead, TableHeader, TableRow } from "@superserve/ui"
-import { useMemo, useState } from "react"
+import { cn, Table, TableHead, TableHeader, TableRow } from "@superserve/ui"
+import { useSearchParams } from "next/navigation"
+import { useEffect, useState } from "react"
 
 import {
   ActivityDetailRow,
   ActivitySummaryRow,
 } from "@/components/audit/activity-row"
-import { DateRangeFilter } from "@/components/date-range-filter"
+import { type DateRange, DateRangeFilter } from "@/components/date-range-filter"
 import { EmptyState } from "@/components/empty-state"
 import { ErrorState } from "@/components/error-state"
 import { PageHeader } from "@/components/page-header"
+import { Pagination } from "@/components/pagination"
 import { StickyHoverTableBody } from "@/components/sticky-hover-table"
-import { TableSkeleton } from "@/components/table-skeleton"
 import { TableToolbar } from "@/components/table-toolbar"
-import { useActivity } from "@/hooks/use-activity"
+import { useActivityPage } from "@/hooks/use-activity"
+import { useListParams } from "@/hooks/use-list-params"
+import { ACTIVITY_SORT_COLUMNS, type ActivityListParams } from "@/lib/api/types"
 
 const CATEGORY_TABS = [
   { label: "All", value: "all" },
@@ -26,56 +41,102 @@ const CATEGORY_TABS = [
   { label: "Errors", value: "_errors" },
 ]
 
-export default function AuditLogsPage() {
-  const [categoryFilter, setCategoryFilter] = useState("all")
-  const [search, setSearch] = useState("")
-  const [dateRange, setDateRange] = useState<{
-    start: Date
-    end: Date
-  } | null>(null)
+/** Parses ?start/?end ISO params into a DateRange, ignoring invalid values so
+ * a hand-crafted URL can't send an unparseable timestamp to the API. */
+function parseDateRange(
+  startParam: string | null,
+  endParam: string | null,
+): DateRange | null {
+  if (!startParam || !endParam) return null
+  const start = new Date(startParam)
+  const end = new Date(endParam)
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return null
+  // Reject an inverted range (mirrors DateRangeFilter's own end >= start
+  // invariant) so a reversed or corrupted URL degrades to "no filter" instead
+  // of silently returning an empty result set.
+  if (end < start) return null
+  return { start, end }
+}
+
+function AuditLogsPageContent() {
+  const searchParams = useSearchParams()
+
+  const {
+    page,
+    pageSize,
+    sort,
+    order,
+    q,
+    debouncedQ,
+    setParam,
+    setPage,
+    setPageSize,
+    setSearch,
+  } = useListParams({
+    columns: ACTIVITY_SORT_COLUMNS,
+    defaultSort: "created_at",
+  })
+
+  // The active category tab lives in the URL; an unknown value falls back to
+  // "all" instead of being forwarded to the API.
+  const rawTab = searchParams.get("tab")
+  const activeTab = CATEGORY_TABS.some((t) => t.value === rawTab)
+    ? (rawTab as string)
+    : "all"
+  // The Errors tab filters by status; the resource tabs filter by category.
+  const category =
+    activeTab !== "all" && activeTab !== "_errors" ? activeTab : undefined
+  const status = activeTab === "_errors" ? "error" : undefined
+
+  const dateRange = parseDateRange(
+    searchParams.get("start"),
+    searchParams.get("end"),
+  )
+
   const [expandedId, setExpandedId] = useState<string | null>(null)
 
-  const { data: activity, isPending, error, refetch } = useActivity()
+  const params: ActivityListParams = {
+    page,
+    pageSize,
+    sort,
+    order,
+    category,
+    status,
+    q: debouncedQ || undefined,
+    start: dateRange?.start.toISOString(),
+    end: dateRange?.end.toISOString(),
+  }
 
-  const filtered = useMemo(() => {
-    return (activity ?? []).filter((a) => {
-      if (dateRange) {
-        const created = new Date(a.created_at)
-        if (created < dateRange.start || created > dateRange.end) return false
-      }
-      if (categoryFilter === "_errors" && a.status !== "error") return false
-      if (
-        categoryFilter !== "all" &&
-        categoryFilter !== "_errors" &&
-        a.category !== categoryFilter
-      )
-        return false
-      if (search) {
-        const q = search.toLowerCase()
-        if (
-          !a.sandbox_name?.toLowerCase().includes(q) &&
-          !a.secret_name?.toLowerCase().includes(q) &&
-          !a.action.toLowerCase().includes(q) &&
-          !a.category.toLowerCase().includes(q)
-        )
-          return false
-      }
-      return true
+  const { data, isPending, error, refetch, isPlaceholderData } =
+    useActivityPage(params)
+  const logs = data?.items ?? []
+  const total = data?.total ?? 0
+
+  const pageCount = Math.max(1, Math.ceil(total / pageSize))
+
+  // If the current page falls past the end (e.g. after a filter narrows the
+  // result set), snap back to the last valid page.
+  useEffect(() => {
+    if (total > 0 && page > pageCount) setPage(pageCount)
+  }, [total, page, pageCount, setPage])
+
+  const handleDateChange = (range: DateRange | null) => {
+    setParam({
+      start: range ? range.start.toISOString() : null,
+      end: range ? range.end.toISOString() : null,
     })
-  }, [activity, categoryFilter, search, dateRange])
+  }
 
-  // oxlint-disable-next-line no-map-spread -- small static array; clarity > micro-perf
-  const tabs = CATEGORY_TABS.map((tab) => ({
-    ...tab,
-    count:
-      tab.value === "all"
-        ? (activity?.length ?? 0)
-        : tab.value === "_errors"
-          ? (activity?.filter((a) => a.status === "error").length ?? 0)
-          : (activity?.filter((a) => a.category === tab.value).length ?? 0),
-  }))
-
-  const isEmpty = (activity?.length ?? 0) === 0
+  // Uses debouncedQ (what the data was fetched with), not q: clearing a
+  // zero-result search would otherwise flash the account-level empty state
+  // until the unfiltered refetch lands.
+  const hasFilters =
+    activeTab !== "all" || debouncedQ !== "" || dateRange !== null
+  // A truly empty account gets the informational empty state; a zero-result
+  // filter keeps the toolbar so the user can clear it. Placeholder data is a
+  // stale page during a params change — never treat its total as empty.
+  const isEmpty =
+    !isPending && !error && !isPlaceholderData && total === 0 && !hasFilters
 
   if (isPending) {
     return (
@@ -108,54 +169,80 @@ export default function AuditLogsPage() {
       ) : (
         <>
           <TableToolbar
-            tabs={tabs}
-            activeTab={categoryFilter}
-            onTabChange={setCategoryFilter}
+            tabs={CATEGORY_TABS}
+            activeTab={activeTab}
+            onTabChange={(v) => setParam({ tab: v === "all" ? null : v })}
             filters={
-              <DateRangeFilter value={dateRange} onChange={setDateRange} />
+              <DateRangeFilter value={dateRange} onChange={handleDateChange} />
             }
             searchPlaceholder="Search by sandbox, secret, or action..."
-            searchValue={search}
+            searchValue={q}
             onSearchChange={setSearch}
           />
 
-          <div className="flex-1 overflow-y-auto">
-            <Table>
-              <TableHeader className="sticky top-0 z-10 bg-background/70 backdrop-blur-md">
-                <TableRow>
-                  <TableHead className="w-[20%]">Time</TableHead>
-                  <TableHead className="w-[20%]">Resource</TableHead>
-                  <TableHead className="w-[12%]">Category</TableHead>
-                  <TableHead className="w-[15%]">Action</TableHead>
-                  <TableHead className="w-[10%]">Duration</TableHead>
-                  <TableHead className="w-[12%]">Status</TableHead>
-                </TableRow>
-              </TableHeader>
-              <StickyHoverTableBody>
-                {filtered.flatMap((log) => {
-                  const isOpen = expandedId === log.id
-                  const rows = [
-                    <ActivitySummaryRow
-                      key={log.id}
-                      log={log}
-                      isOpen={isOpen}
-                      onToggle={() =>
-                        setExpandedId((prev) =>
-                          prev === log.id ? null : log.id,
-                        )
-                      }
-                    />,
-                  ]
-                  if (isOpen) {
-                    rows.push(
-                      <ActivityDetailRow key={`${log.id}-detail`} log={log} />,
-                    )
-                  }
-                  return rows
-                })}
-              </StickyHoverTableBody>
-            </Table>
+          <div
+            className={cn(
+              "flex-1 overflow-y-auto transition-opacity",
+              isPlaceholderData && "opacity-60",
+            )}
+          >
+            {logs.length === 0 ? (
+              <EmptyState
+                icon={ClipboardTextIcon}
+                title="No activity matches"
+                description="Try a different search term, category, or date range."
+              />
+            ) : (
+              <Table>
+                <TableHeader className="sticky top-0 z-10 bg-background/70 backdrop-blur-md">
+                  <TableRow>
+                    <TableHead className="w-[20%]">Time</TableHead>
+                    <TableHead className="w-[20%]">Resource</TableHead>
+                    <TableHead className="w-[12%]">Category</TableHead>
+                    <TableHead className="w-[15%]">Action</TableHead>
+                    <TableHead className="w-[10%]">Duration</TableHead>
+                    <TableHead className="w-[12%]">Status</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <StickyHoverTableBody>
+                  {logs.flatMap((log) => {
+                    const isOpen = expandedId === log.id
+                    const rows = [
+                      <ActivitySummaryRow
+                        key={log.id}
+                        log={log}
+                        isOpen={isOpen}
+                        onToggle={() =>
+                          setExpandedId((prev) =>
+                            prev === log.id ? null : log.id,
+                          )
+                        }
+                      />,
+                    ]
+                    if (isOpen) {
+                      rows.push(
+                        <ActivityDetailRow
+                          key={`${log.id}-detail`}
+                          log={log}
+                        />,
+                      )
+                    }
+                    return rows
+                  })}
+                </StickyHoverTableBody>
+              </Table>
+            )}
           </div>
+
+          {total > 0 && (
+            <Pagination
+              page={page}
+              pageSize={pageSize}
+              total={total}
+              onPageChange={setPage}
+              onPageSizeChange={setPageSize}
+            />
+          )}
         </>
       )}
     </div>

--- a/apps/console/src/app/api/[...path]/route.test.ts
+++ b/apps/console/src/app/api/[...path]/route.test.ts
@@ -74,7 +74,7 @@ describe("api proxy /api/[...path]", () => {
     expect(res.status).toBe(404)
   })
 
-  it("forwards the secrets and providers prefixes", async () => {
+  it("forwards the secrets, providers, and activity prefixes", async () => {
     fetchSpy.mockImplementation(() =>
       Promise.resolve(
         new Response("[]", {
@@ -84,11 +84,16 @@ describe("api proxy /api/[...path]", () => {
       ),
     )
 
-    for (const path of [["secrets"], ["secrets", "my_key"], ["providers"]]) {
+    for (const path of [
+      ["secrets"],
+      ["secrets", "my_key"],
+      ["providers"],
+      ["activity"],
+    ]) {
       const res = await GET(req("GET", path), params(path))
       expect(res.status).toBe(200)
     }
-    expect(fetchSpy).toHaveBeenCalledTimes(3)
+    expect(fetchSpy).toHaveBeenCalledTimes(4)
   })
 
   it("returns 401 when the user is not authenticated", async () => {

--- a/apps/console/src/app/api/[...path]/route.ts
+++ b/apps/console/src/app/api/[...path]/route.ts
@@ -9,6 +9,7 @@ import { createServerClient } from "@/lib/supabase/server"
 
 const ALLOWED_PREFIXES = [
   "sandboxes",
+  "activity",
   "health",
   "v1",
   "templates",

--- a/apps/console/src/hooks/use-activity.ts
+++ b/apps/console/src/hooks/use-activity.ts
@@ -1,11 +1,15 @@
-import { useQuery } from "@tanstack/react-query"
+import { keepPreviousData, useQuery } from "@tanstack/react-query"
 
-import { listActivityAction } from "@/lib/api/activity-actions"
+import { listActivityPaged } from "@/lib/api/activity"
 import { auditLogKeys } from "@/lib/api/query-keys"
+import type { ActivityListParams } from "@/lib/api/types"
 
-export function useActivity(limit = 100) {
+export function useActivityPage(params: ActivityListParams) {
   return useQuery({
-    queryKey: auditLogKeys.all,
-    queryFn: () => listActivityAction(limit),
+    queryKey: auditLogKeys.list(params),
+    queryFn: () => listActivityPaged(params),
+    // Keep the current page on screen while the next page/filter loads so
+    // navigation doesn't flash an empty table.
+    placeholderData: keepPreviousData,
   })
 }

--- a/apps/console/src/lib/api/activity-actions.ts
+++ b/apps/console/src/lib/api/activity-actions.ts
@@ -29,7 +29,7 @@ export async function listActivityBySandboxAction(
   const { data, error } = await admin
     .from("activity")
     .select(
-      "id, sandbox_id, category, action, status, sandbox_name, secret_id, secret_name, duration_ms, error, metadata, created_at",
+      "id, sandbox_id, template_id, category, action, status, sandbox_name, secret_id, secret_name, actor_id, duration_ms, error, metadata, created_at",
     )
     .eq("sandbox_id", sandboxId)
     .eq("team_id", team.teamId)
@@ -41,50 +41,14 @@ export async function listActivityBySandboxAction(
   return (data ?? []).map((a) => ({
     id: a.id as string,
     sandbox_id: (a.sandbox_id as string | null) ?? null,
+    template_id: (a.template_id as string | null) ?? null,
     category: a.category as string,
     action: a.action as string,
     status: (a.status as string | null) ?? null,
     sandbox_name: (a.sandbox_name as string | null) ?? null,
     secret_id: (a.secret_id as string | null) ?? null,
     secret_name: (a.secret_name as string | null) ?? null,
-    duration_ms: (a.duration_ms as number | null) ?? null,
-    error: (a.error as string | null) ?? null,
-    metadata: a.metadata as Record<string, unknown>,
-    created_at: a.created_at as string,
-  }))
-}
-
-export async function listActivityAction(limit = 100) {
-  const supabase = await createServerClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-  if (!user) throw new Error("Not authenticated")
-
-  const team = await getTeam(user.id)
-  if (!team) return []
-
-  const admin = cellFor(team.region).createAdminClient()
-  const { data, error } = await admin
-    .from("activity")
-    .select(
-      "id, sandbox_id, category, action, status, sandbox_name, secret_id, secret_name, duration_ms, error, metadata, created_at",
-    )
-    .eq("team_id", team.teamId)
-    .order("created_at", { ascending: false })
-    .limit(limit)
-
-  if (error) throw new Error(error.message)
-
-  return (data ?? []).map((a) => ({
-    id: a.id as string,
-    sandbox_id: (a.sandbox_id as string | null) ?? null,
-    category: a.category as string,
-    action: a.action as string,
-    status: (a.status as string | null) ?? null,
-    sandbox_name: (a.sandbox_name as string | null) ?? null,
-    secret_id: (a.secret_id as string | null) ?? null,
-    secret_name: (a.secret_name as string | null) ?? null,
+    actor_id: (a.actor_id as string | null) ?? null,
     duration_ms: (a.duration_ms as number | null) ?? null,
     error: (a.error as string | null) ?? null,
     metadata: a.metadata as Record<string, unknown>,

--- a/apps/console/src/lib/api/activity.test.ts
+++ b/apps/console/src/lib/api/activity.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { activityListQuery, listActivityPaged } from "./activity"
+import type { ActivityListParams } from "./types"
+
+const fetchSpy = vi.fn()
+vi.stubGlobal("fetch", fetchSpy)
+
+const baseParams: ActivityListParams = {
+  page: 1,
+  pageSize: 50,
+  sort: "created_at",
+  order: "desc",
+}
+
+describe("activityListQuery", () => {
+  it("maps page/pageSize to limit/offset alongside sort + order", () => {
+    const q = new URLSearchParams(
+      activityListQuery({ ...baseParams, page: 3, pageSize: 25 }),
+    )
+    expect(q.get("limit")).toBe("25")
+    expect(q.get("offset")).toBe("50") // (3 - 1) * 25
+    expect(q.get("sort")).toBe("created_at")
+    expect(q.get("order")).toBe("desc")
+  })
+
+  it("omits optional filters when unset", () => {
+    const q = new URLSearchParams(activityListQuery(baseParams))
+    expect(q.has("category")).toBe(false)
+    expect(q.has("status")).toBe(false)
+    expect(q.has("q")).toBe(false)
+    expect(q.has("start")).toBe(false)
+    expect(q.has("end")).toBe(false)
+  })
+
+  it("includes category, status, q, and the date window when set", () => {
+    const q = new URLSearchParams(
+      activityListQuery({
+        ...baseParams,
+        category: "sandbox",
+        status: "error",
+        q: "web",
+        start: "2026-07-01T00:00:00.000Z",
+        end: "2026-07-09T00:00:00.000Z",
+      }),
+    )
+    expect(q.get("category")).toBe("sandbox")
+    expect(q.get("status")).toBe("error")
+    expect(q.get("q")).toBe("web")
+    expect(q.get("start")).toBe("2026-07-01T00:00:00.000Z")
+    expect(q.get("end")).toBe("2026-07-09T00:00:00.000Z")
+  })
+})
+
+describe("listActivityPaged", () => {
+  afterEach(() => {
+    fetchSpy.mockReset()
+  })
+
+  it("GETs /api/activity and reads the total from X-Total-Count", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify([{ id: "a1" }]), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+          "X-Total-Count": "42",
+        },
+      }),
+    )
+
+    const result = await listActivityPaged({
+      ...baseParams,
+      category: "sandbox",
+    })
+
+    const [url] = fetchSpy.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain("/api/activity?")
+    expect(url).toContain("category=sandbox")
+    expect(result.total).toBe(42)
+    expect(result.items).toEqual([{ id: "a1" }])
+  })
+
+  it("falls back to the item count when X-Total-Count is absent", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify([{ id: "a1" }, { id: "a2" }]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    )
+
+    const result = await listActivityPaged(baseParams)
+    expect(result.total).toBe(2)
+  })
+})

--- a/apps/console/src/lib/api/activity.test.ts
+++ b/apps/console/src/lib/api/activity.test.ts
@@ -74,7 +74,7 @@ describe("listActivityPaged", () => {
     })
 
     const [url] = fetchSpy.mock.calls[0] as [string, RequestInit]
-    expect(url).toContain("/api/activity?")
+    expect(url).toContain("/api/activity/?")
     expect(url).toContain("category=sandbox")
     expect(result.total).toBe(42)
     expect(result.items).toEqual([{ id: "a1" }])

--- a/apps/console/src/lib/api/activity.ts
+++ b/apps/console/src/lib/api/activity.ts
@@ -1,0 +1,25 @@
+import { apiClientList, type PagedResult } from "./client"
+import type { ActivityListParams, ActivityResponse } from "./types"
+
+/** Serializes ActivityListParams into the GET /activity query string. */
+export function activityListQuery(params: ActivityListParams): string {
+  const q = new URLSearchParams()
+  q.set("limit", String(params.pageSize))
+  q.set("offset", String((params.page - 1) * params.pageSize))
+  q.set("sort", params.sort)
+  q.set("order", params.order)
+  if (params.category) q.set("category", params.category)
+  if (params.status) q.set("status", params.status)
+  if (params.q) q.set("q", params.q)
+  if (params.start) q.set("start", params.start)
+  if (params.end) q.set("end", params.end)
+  return q.toString()
+}
+
+export async function listActivityPaged(
+  params: ActivityListParams,
+): Promise<PagedResult<ActivityResponse>> {
+  return apiClientList<ActivityResponse>(
+    `/activity?${activityListQuery(params)}`,
+  )
+}

--- a/apps/console/src/lib/api/query-keys.ts
+++ b/apps/console/src/lib/api/query-keys.ts
@@ -1,4 +1,8 @@
-import type { SandboxListParams, TemplateListParams } from "./types"
+import type {
+  ActivityListParams,
+  SandboxListParams,
+  TemplateListParams,
+} from "./types"
 
 export const sandboxKeys = {
   all: ["sandboxes"] as const,
@@ -42,8 +46,8 @@ export const snapshotKeys = {
 export const auditLogKeys = {
   all: ["audit-logs"] as const,
   lists: () => [...auditLogKeys.all, "list"] as const,
-  list: (filters?: { action?: string; search?: string }) =>
-    [...auditLogKeys.lists(), filters] as const,
+  list: (params: ActivityListParams) =>
+    [...auditLogKeys.lists(), params] as const,
   bySandbox: (sandboxId: string) =>
     [...auditLogKeys.all, "sandbox", sandboxId] as const,
 }

--- a/apps/console/src/lib/api/types.ts
+++ b/apps/console/src/lib/api/types.ts
@@ -118,6 +118,8 @@ export interface ActivityResponse {
   id: string
   /** Null for events not tied to a sandbox (e.g. secret CRUD). */
   sandbox_id: string | null
+  /** Set on template events. */
+  template_id: string | null
   category: string
   action: string
   status: string | null
@@ -125,10 +127,36 @@ export interface ActivityResponse {
   /** Set on secret events; secret_id is null once the secret is purged. */
   secret_id: string | null
   secret_name: string | null
+  /** Team member who performed the action; null for system-initiated events. */
+  actor_id: string | null
   duration_ms: number | null
   error: string | null
   metadata: Record<string, unknown>
   created_at: string
+}
+
+/** Sort columns GET /activity accepts; also the allowlist for URL ?sort=. */
+export const ACTIVITY_SORT_COLUMNS = ["created_at"] as const
+
+export type ActivitySortColumn = (typeof ACTIVITY_SORT_COLUMNS)[number]
+
+/** Query params for the paginated audit-log list (GET /activity). */
+export interface ActivityListParams {
+  /** 1-based page number. */
+  page: number
+  pageSize: number
+  sort: ActivitySortColumn
+  order: SortDirection
+  /** Exact category filter (e.g. "sandbox", "template", "secret"). */
+  category?: string
+  /** Exact status filter; the Errors tab sends "error". */
+  status?: string
+  /** Case-insensitive substring across sandbox/secret name, action, category. */
+  q?: string
+  /** RFC3339 lower bound on created_at (inclusive). */
+  start?: string
+  /** RFC3339 upper bound on created_at (inclusive). */
+  end?: string
 }
 
 export type TemplateStatus = "pending" | "building" | "ready" | "failed"

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -214,6 +214,10 @@
               "POST /teams/{team_id}/roles",
               "DELETE /teams/{team_id}/roles/{assignment_id}"
             ]
+          },
+          {
+            "group": "Activity",
+            "pages": ["GET /activity"]
           }
         ],
         "openapi": "https://raw.githubusercontent.com/superserve-ai/sandbox/refs/heads/main/api/openapi.yaml"


### PR DESCRIPTION
## Summary

Migrates the Audit Logs page from client-side filtering of a capped ≤100-row fetch to true server-side pagination against the new `GET /activity` endpoint, mirroring the Sandboxes list page.

Previously the page fetched up to 100 activity rows via a Supabase server action (`listActivityAction`) and did all category/search/date filtering client-side — so it rendered a long unpaginated list and never loaded history beyond the latest 100. Now:

- `useActivityPage` → `listActivityPaged` → the API proxy → `GET /activity`, reusing the shared `useListParams` + `Pagination` machinery. The team-wide Supabase read is removed (the per-sandbox `listActivityBySandboxAction` stays).
- Filters move to the server and into the URL (shareable, survive refresh): category tabs → `category` (Errors tab → `status=error`), date range → `start`/`end`, search → `q`. The global total drives the pager's "X of Y".
- Per-tab counts dropped (tabs are plain filters now); `ActivityResponse` gains `template_id` + `actor_id` to match the endpoint.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `oxlint` + `oxfmt --check` clean (pre-commit hook)
- [x] Full console suite: **397 tests pass**, including new `activity.test.ts` (query-builder param mapping + `X-Total-Count` parsing / fallback)
- [ ] Manual: page through, filter by tab/search/date, confirm URL state + "X of Y" (after the backend endpoint is deployed)

## Depends on

- superserve-ai/sandbox#189 (the `GET /activity` endpoint). **Merge + deploy that first** — until the route is live, this page will 404 its data.

## Follow-up (not in this PR)

The API-reference **Activity** nav entry (`docs.json`) is intentionally deferred: `check-docs-nav` validates the nav against the backend's `openapi.yaml` on `main`, so a `GET /activity` nav entry can only land once #189 is merged. It'll go in a small docs-only PR right after — merge it promptly, since once #189 is on `main` the check will expect the nav entry on subsequent console PRs.

## Review notes

Independently reviewed (hooks order / Suspense boundary / empty-state / dead-code all confirmed clean). One robustness fix applied: `parseDateRange` now rejects an inverted (`end < start`) URL range, degrading to "no filter" instead of a confusing empty result.
