### PR TITLE
docs: add Activity group to API reference nav (blocked on sandbox#189)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -200,6 +200,10 @@
             ]
           },
           {
+            "group": "Activity",
+            "pages": ["GET /activity"]
+          },
+          {
             "group": "Billing",
             "pages": ["GET /billing/pricing", "GET /billing/pricing/public"]
           },


### PR DESCRIPTION
## Summary

Adds the **Activity** group (`GET /activity`) to the REST API reference nav in `docs.json`, so the new team audit-log endpoint renders in the docs.

Split out from the console PR (#270) on purpose: `check-docs-nav` validates the nav against the backend's `openapi.yaml` **on `main`**, so this entry cannot pass CI until the endpoint's spec is live there.

## ⚠️ Blocked on — merge order

1. **superserve-ai/sandbox#189** merges to `main` (adds `GET /activity` to `openapi.yaml`)
2. Re-run this PR's CI → `Check docs nav matches OpenAPI spec` goes green → mark ready & merge

Until step 1, the `Check docs nav matches OpenAPI spec` step here will fail by design (nav lists an op the `main` spec doesn't have yet). Draft until then.

**Merge this promptly after #189** — once `/activity` is in `main`'s spec, `check-docs-nav` starts *requiring* the nav entry, so every open console PR fails that check until this lands.

## Test plan

- [ ] Blocked: passes once #189 is on `main` (`bun run docs:check-nav`)
