### PR TITLE
console: team switcher — cookie-backed active team

### DIFF
--- a/apps/console/src/components/sandboxes/files-section.test.tsx
+++ b/apps/console/src/components/sandboxes/files-section.test.tsx
@@ -148,7 +148,7 @@ describe("FileBrowser — listing & navigation", () => {
 
     const [url] = fetchSpy.mock.calls[0]
     expect(String(url)).toContain("/api/sandboxes/")
-    expect(String(url)).toContain("/files?path=%2Fhome%2Fuser")
+    expect(String(url)).toContain("/files/?path=%2Fhome%2Fuser")
   })
 
   it("descends into a folder and lists the subpath", async () => {

--- a/apps/console/src/components/settings/teams-section.tsx
+++ b/apps/console/src/components/settings/teams-section.tsx
@@ -63,7 +63,7 @@ export function TeamsSection() {
         <div>
           <h2 className="text-base font-medium text-foreground">Teams</h2>
           <p className="mt-1 text-xs text-muted">
-            Your teams and the region each is homed in.
+            Your teams and their primary region.
           </p>
         </div>
         <div className="max-w-md space-y-5">

--- a/apps/console/src/components/settings/teams-section.tsx
+++ b/apps/console/src/components/settings/teams-section.tsx
@@ -18,9 +18,12 @@ import { useCreateTeam, useSwitchTeam, useTeams } from "@/hooks/use-teams"
 import { regionLabel } from "@/lib/format"
 
 /**
- * Team directory + create-team form. Only rendered when more than one cell
- * is configured — the single-cell console has no team creation surface, and
- * that must stay true until a second region exists to choose from.
+ * Team directory + create-team form. The directory renders whenever the
+ * user has more than one team or more than one cell is configured — a
+ * multi-team user needs the Active marker and Switch buttons regardless of
+ * region count. The create-team form stays multi-cell-only: the single-cell
+ * console has no team creation surface, and that must stay true until a
+ * second region exists to choose from.
  */
 export function TeamsSection() {
   const { data } = useTeams()
@@ -31,7 +34,10 @@ export function TeamsSection() {
   const [name, setName] = useState("")
   const [region, setRegion] = useState("use")
 
-  if (!data || data.regions.length <= 1) return null
+  if (!data || (data.regions.length <= 1 && data.teams.length <= 1)) {
+    return null
+  }
+  const canCreate = data.regions.length > 1
 
   const handleCreate = () => {
     createTeam.mutate(
@@ -110,39 +116,43 @@ export function TeamsSection() {
               <p className="px-4 py-3 text-xs text-muted">No teams yet.</p>
             )}
           </div>
-          <Field label="New Team Name">
-            <Input
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="my-team"
-            />
-          </Field>
-          <Field label="Region">
-            <Select
-              value={region}
-              onValueChange={(v) => setRegion(v as string)}
-            >
-              <SelectTrigger aria-label="Team region">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectPopup>
-                {data.regions.map((r) => (
-                  <SelectItem key={r} value={r}>
-                    {regionLabel(r)}
-                  </SelectItem>
-                ))}
-              </SelectPopup>
-            </Select>
-          </Field>
-          <div>
-            <Button
-              onClick={handleCreate}
-              disabled={!name.trim() || createTeam.isPending}
-              size="sm"
-            >
-              {createTeam.isPending ? "Creating..." : "Create Team"}
-            </Button>
-          </div>
+          {canCreate && (
+            <>
+              <Field label="New Team Name">
+                <Input
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="my-team"
+                />
+              </Field>
+              <Field label="Region">
+                <Select
+                  value={region}
+                  onValueChange={(v) => setRegion(v as string)}
+                >
+                  <SelectTrigger aria-label="Team region">
+                    <SelectValue>{() => regionLabel(region)}</SelectValue>
+                  </SelectTrigger>
+                  <SelectPopup>
+                    {data.regions.map((r) => (
+                      <SelectItem key={r} value={r}>
+                        {regionLabel(r)}
+                      </SelectItem>
+                    ))}
+                  </SelectPopup>
+                </Select>
+              </Field>
+              <div>
+                <Button
+                  onClick={handleCreate}
+                  disabled={!name.trim() || createTeam.isPending}
+                  size="sm"
+                >
+                  {createTeam.isPending ? "Creating..." : "Create Team"}
+                </Button>
+              </div>
+            </>
+          )}
         </div>
       </div>
 

--- a/apps/console/src/components/settings/teams-section.tsx
+++ b/apps/console/src/components/settings/teams-section.tsx
@@ -80,7 +80,7 @@ export function TeamsSection() {
                       <span className="font-mono text-xs text-brand uppercase">
                         Active
                       </span>
-                    ) : (
+                    ) : !data.switchingEnabled ? null : (
                       <Button
                         variant="outline"
                         size="sm"

--- a/apps/console/src/components/settings/teams-section.tsx
+++ b/apps/console/src/components/settings/teams-section.tsx
@@ -14,16 +14,8 @@ import {
 } from "@superserve/ui"
 import { useState } from "react"
 
-import { useCreateTeam, useTeams } from "@/hooks/use-teams"
-
-const REGION_LABELS: Record<string, string> = {
-  use: "US East",
-  usw: "US West",
-}
-
-function regionLabel(region: string): string {
-  return REGION_LABELS[region] ?? region
-}
+import { useCreateTeam, useSwitchTeam, useTeams } from "@/hooks/use-teams"
+import { regionLabel } from "@/lib/format"
 
 /**
  * Team directory + create-team form. Only rendered when more than one cell
@@ -33,6 +25,7 @@ function regionLabel(region: string): string {
 export function TeamsSection() {
   const { data } = useTeams()
   const createTeam = useCreateTeam()
+  const switchTeam = useSwitchTeam()
   const { addToast } = useToast()
 
   const [name, setName] = useState("")
@@ -69,17 +62,50 @@ export function TeamsSection() {
         </div>
         <div className="max-w-md space-y-5">
           <div className="border border-dashed border-border">
-            {data.teams.map((team) => (
-              <div
-                key={`${team.region}:${team.id}`}
-                className="flex items-center justify-between border-b border-dashed border-border px-4 py-3 last:border-b-0"
-              >
-                <span className="text-sm text-foreground">{team.name}</span>
-                <span className="font-mono text-xs text-muted uppercase">
-                  {regionLabel(team.region)}
-                </span>
-              </div>
-            ))}
+            {data.teams.map((team) => {
+              const isActive =
+                team.id === data.activeTeamId &&
+                team.region === data.activeRegion
+              return (
+                <div
+                  key={`${team.region}:${team.id}`}
+                  className="flex items-center justify-between gap-3 border-b border-dashed border-border px-4 py-3 last:border-b-0"
+                >
+                  <span className="text-sm text-foreground">{team.name}</span>
+                  <span className="flex items-center gap-3">
+                    <span className="font-mono text-xs text-muted uppercase">
+                      {regionLabel(team.region)}
+                    </span>
+                    {isActive ? (
+                      <span className="font-mono text-xs text-brand uppercase">
+                        Active
+                      </span>
+                    ) : (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={switchTeam.isPending}
+                        onClick={() =>
+                          switchTeam.mutate(
+                            { teamId: team.id, region: team.region },
+                            {
+                              onError: (error) => {
+                                addToast(
+                                  error.message || "Failed to switch team",
+                                  "error",
+                                )
+                              },
+                            },
+                          )
+                        }
+                      >
+                        Switch
+                      </Button>
+                    )}
+                  </span>
+                </div>
+              )
+            })}
             {data.teams.length === 0 && (
               <p className="px-4 py-3 text-xs text-muted">No teams yet.</p>
             )}

--- a/apps/console/src/components/settings/teams-section.tsx
+++ b/apps/console/src/components/settings/teams-section.tsx
@@ -14,21 +14,21 @@ import {
 } from "@superserve/ui"
 import { useState } from "react"
 
-import { useCreateTeam, useSwitchTeam, useTeams } from "@/hooks/use-teams"
+import { useCreateTeam, useTeams } from "@/hooks/use-teams"
 import { regionLabel } from "@/lib/format"
 
 /**
  * Team directory + create-team form. The directory renders whenever the
  * user has more than one team or more than one cell is configured — a
- * multi-team user needs the Active marker and Switch buttons regardless of
- * region count. The create-team form stays multi-cell-only: the single-cell
- * console has no team creation surface, and that must stay true until a
- * second region exists to choose from.
+ * multi-team user needs the Active marker regardless of region count
+ * (switching itself lives in the sidebar team dropdown). The create-team
+ * form stays multi-cell-only: the single-cell console has no team creation
+ * surface, and that must stay true until a second region exists to choose
+ * from.
  */
 export function TeamsSection() {
   const { data } = useTeams()
   const createTeam = useCreateTeam()
-  const switchTeam = useSwitchTeam()
   const { addToast } = useToast()
 
   const [name, setName] = useState("")
@@ -82,31 +82,12 @@ export function TeamsSection() {
                     <span className="font-mono text-xs text-muted uppercase">
                       {regionLabel(team.region)}
                     </span>
-                    {isActive ? (
+                    {/* Switching lives in the sidebar team dropdown; this
+                        directory only marks which team is active. */}
+                    {isActive && (
                       <span className="font-mono text-xs text-brand uppercase">
                         Active
                       </span>
-                    ) : !data.switchingEnabled ? null : (
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        disabled={switchTeam.isPending}
-                        onClick={() =>
-                          switchTeam.mutate(
-                            { teamId: team.id, region: team.region },
-                            {
-                              onError: (error) => {
-                                addToast(
-                                  error.message || "Failed to switch team",
-                                  "error",
-                                )
-                              },
-                            },
-                          )
-                        }
-                      >
-                        Switch
-                      </Button>
                     )}
                   </span>
                 </div>

--- a/apps/console/src/components/settings/teams-section.tsx
+++ b/apps/console/src/components/settings/teams-section.tsx
@@ -79,9 +79,6 @@ export function TeamsSection() {
                 >
                   <span className="text-sm text-foreground">{team.name}</span>
                   <span className="flex items-center gap-3">
-                    <span className="font-mono text-xs text-muted uppercase">
-                      {regionLabel(team.region)}
-                    </span>
                     {/* Switching lives in the sidebar team dropdown; this
                         directory only marks which team is active. */}
                     {isActive && (
@@ -89,6 +86,9 @@ export function TeamsSection() {
                         Active
                       </span>
                     )}
+                    <span className="font-mono text-xs text-muted uppercase">
+                      {regionLabel(team.region)}
+                    </span>
                   </span>
                 </div>
               )

--- a/apps/console/src/components/sidebar/sidebar.tsx
+++ b/apps/console/src/components/sidebar/sidebar.tsx
@@ -22,6 +22,7 @@ import {
 import { useSidebar } from "./sidebar-context"
 import { SidebarNav } from "./sidebar-nav"
 import { SidebarUserMenu } from "./sidebar-user-menu"
+import { TeamSwitcher } from "./team-switcher"
 
 function openCommandPalette() {
   window.dispatchEvent(
@@ -64,6 +65,9 @@ export function Sidebar() {
           />
         )}
       </div>
+
+      {/* Team Switcher — scopes every view below to the active team */}
+      {!isCollapsed && <TeamSwitcher />}
 
       {/* Search */}
       <div className="mb-2 px-2.5">

--- a/apps/console/src/components/sidebar/team-switcher.test.tsx
+++ b/apps/console/src/components/sidebar/team-switcher.test.tsx
@@ -87,3 +87,25 @@ describe("TeamSwitcher", () => {
     expect(container).toBeEmptyDOMElement()
   })
 })
+
+describe("TeamSwitcher ordering", () => {
+  it("lists the active team first, the rest alphabetical", async () => {
+    teamsData = {
+      switchingEnabled: true,
+      activeTeamId: "team-m",
+      activeRegion: "use",
+      teams: [
+        { id: "team-z", name: "zeta", region: "use" },
+        { id: "team-m", name: "mango", region: "use" },
+        { id: "team-a", name: "apple", region: "use" },
+      ],
+    }
+    const user = userEvent.setup()
+    render(<TeamSwitcher />)
+    await user.click(screen.getByRole("combobox", { name: "Active team" }))
+    const labels = (await screen.findAllByRole("option")).map(
+      (o) => o.textContent,
+    )
+    expect(labels).toEqual(["mango", "apple", "zeta"])
+  })
+})

--- a/apps/console/src/components/sidebar/team-switcher.test.tsx
+++ b/apps/console/src/components/sidebar/team-switcher.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+const mutate = vi.fn()
+let teamsData: unknown
+
+vi.mock("@/hooks/use-teams", () => ({
+  useTeams: () => ({ data: teamsData }),
+  useSwitchTeam: () => ({ mutate, isPending: false }),
+}))
+
+vi.mock("@superserve/ui", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return { ...actual, useToast: () => ({ addToast: vi.fn() }) }
+})
+
+import { TeamSwitcher } from "./team-switcher"
+
+const twoRegions = {
+  switchingEnabled: true,
+  activeTeamId: "team-a",
+  activeRegion: "use",
+  teams: [
+    { id: "team-a", name: "alpha", region: "use" },
+    { id: "team-w", name: "westside", region: "usw" },
+  ],
+}
+
+describe("TeamSwitcher", () => {
+  it("renders the active team's name, not the raw option value", () => {
+    teamsData = twoRegions
+    render(<TeamSwitcher />)
+    expect(screen.getByText("alpha · US East")).toBeInTheDocument()
+    expect(screen.queryByText(/use:team-a/)).not.toBeInTheDocument()
+  })
+
+  it("opens the dropdown and lists every team on click", async () => {
+    teamsData = twoRegions
+    const user = userEvent.setup()
+    render(<TeamSwitcher />)
+
+    await user.click(screen.getByRole("combobox", { name: "Active team" }))
+
+    expect(
+      await screen.findByRole("option", { name: "westside · US West" }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("option", { name: "alpha · US East" }),
+    ).toBeInTheDocument()
+  })
+
+  it("switches to the picked team", async () => {
+    teamsData = twoRegions
+    const user = userEvent.setup()
+    render(<TeamSwitcher />)
+
+    await user.click(screen.getByRole("combobox", { name: "Active team" }))
+    await user.click(
+      await screen.findByRole("option", { name: "westside · US West" }),
+    )
+
+    expect(mutate).toHaveBeenCalledWith(
+      { teamId: "team-w", region: "usw" },
+      expect.anything(),
+    )
+  })
+
+  it("omits region labels when all teams share one region", () => {
+    teamsData = {
+      ...twoRegions,
+      teams: [
+        { id: "team-a", name: "alpha", region: "use" },
+        { id: "team-b", name: "beta", region: "use" },
+      ],
+    }
+    render(<TeamSwitcher />)
+    expect(screen.getByText("alpha")).toBeInTheDocument()
+  })
+
+  it("renders nothing for single-team users", () => {
+    teamsData = {
+      ...twoRegions,
+      teams: [{ id: "team-a", name: "alpha", region: "use" }],
+    }
+    const { container } = render(<TeamSwitcher />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/apps/console/src/components/sidebar/team-switcher.tsx
+++ b/apps/console/src/components/sidebar/team-switcher.tsx
@@ -67,7 +67,7 @@ export function TeamSwitcher() {
             {() => (active ? teamLabel(active) : "Select team")}
           </SelectValue>
         </SelectTrigger>
-        <SelectPopup>
+        <SelectPopup dropdown>
           {data.teams.map((team) => (
             <SelectItem key={optionValue(team)} value={optionValue(team)}>
               {teamLabel(team)}

--- a/apps/console/src/components/sidebar/team-switcher.tsx
+++ b/apps/console/src/components/sidebar/team-switcher.tsx
@@ -20,19 +20,22 @@ function optionValue(team: { id: string; region: string }): string {
 
 /**
  * Sidebar control for the active team — the team every dashboard surface
- * (sandboxes, keys, snapshots, billing) operates on. Hidden for
- * single-team users, who have nothing to switch between.
+ * (sandboxes, keys, snapshots, billing) operates on. Hidden for single-team
+ * users (nothing to switch between) and off the multi-cell UI allowlist
+ * (switching rolls out person-by-person; the server enforces this too).
  */
 export function TeamSwitcher() {
   const { data } = useTeams()
   const switchTeam = useSwitchTeam()
   const { addToast } = useToast()
 
-  if (!data || data.teams.length < 2) return null
+  if (!data || !data.switchingEnabled || data.teams.length < 2) return null
 
   const active = data.teams.find(
     (t) => t.id === data.activeTeamId && t.region === data.activeRegion,
   )
+  // Region badges only add signal when the directory spans regions.
+  const multiRegion = new Set(data.teams.map((t) => t.region)).size > 1
 
   const handleSwitch = (value: string) => {
     const team = data.teams.find((t) => optionValue(t) === value)
@@ -60,7 +63,9 @@ export function TeamSwitcher() {
         <SelectPopup>
           {data.teams.map((team) => (
             <SelectItem key={optionValue(team)} value={optionValue(team)}>
-              {team.name} · {regionLabel(team.region)}
+              {multiRegion
+                ? `${team.name} · ${regionLabel(team.region)}`
+                : team.name}
             </SelectItem>
           ))}
         </SelectPopup>

--- a/apps/console/src/components/sidebar/team-switcher.tsx
+++ b/apps/console/src/components/sidebar/team-switcher.tsx
@@ -37,6 +37,9 @@ export function TeamSwitcher() {
   // Region badges only add signal when the directory spans regions.
   const multiRegion = new Set(data.teams.map((t) => t.region)).size > 1
 
+  const teamLabel = (team: { name: string; region: string }) =>
+    multiRegion ? `${team.name} · ${regionLabel(team.region)}` : team.name
+
   const handleSwitch = (value: string) => {
     const team = data.teams.find((t) => optionValue(t) === value)
     if (!team || team === active) return
@@ -58,14 +61,16 @@ export function TeamSwitcher() {
         disabled={switchTeam.isPending}
       >
         <SelectTrigger aria-label="Active team" className="w-full">
-          <SelectValue />
+          {/* Base UI's Value renders the raw option value (`region:id`) by
+              default — the label has to be rendered explicitly. */}
+          <SelectValue className="truncate">
+            {() => (active ? teamLabel(active) : "Select team")}
+          </SelectValue>
         </SelectTrigger>
         <SelectPopup>
           {data.teams.map((team) => (
             <SelectItem key={optionValue(team)} value={optionValue(team)}>
-              {multiRegion
-                ? `${team.name} · ${regionLabel(team.region)}`
-                : team.name}
+              {teamLabel(team)}
             </SelectItem>
           ))}
         </SelectPopup>

--- a/apps/console/src/components/sidebar/team-switcher.tsx
+++ b/apps/console/src/components/sidebar/team-switcher.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import {
+  Select,
+  SelectItem,
+  SelectPopup,
+  SelectTrigger,
+  SelectValue,
+  useToast,
+} from "@superserve/ui"
+
+import { useSwitchTeam, useTeams } from "@/hooks/use-teams"
+import { regionLabel } from "@/lib/format"
+
+// Option values pair region with id: during a cross-cell migration the same
+// team id can exist in two cells, and they are different choices.
+function optionValue(team: { id: string; region: string }): string {
+  return `${team.region}:${team.id}`
+}
+
+/**
+ * Sidebar control for the active team — the team every dashboard surface
+ * (sandboxes, keys, snapshots, billing) operates on. Hidden for
+ * single-team users, who have nothing to switch between.
+ */
+export function TeamSwitcher() {
+  const { data } = useTeams()
+  const switchTeam = useSwitchTeam()
+  const { addToast } = useToast()
+
+  if (!data || data.teams.length < 2) return null
+
+  const active = data.teams.find(
+    (t) => t.id === data.activeTeamId && t.region === data.activeRegion,
+  )
+
+  const handleSwitch = (value: string) => {
+    const team = data.teams.find((t) => optionValue(t) === value)
+    if (!team || team === active) return
+    switchTeam.mutate(
+      { teamId: team.id, region: team.region },
+      {
+        onError: (error) => {
+          addToast(error.message || "Failed to switch team", "error")
+        },
+      },
+    )
+  }
+
+  return (
+    <div className="mb-2 px-2.5">
+      <Select
+        value={active ? optionValue(active) : undefined}
+        onValueChange={(v) => handleSwitch(v as string)}
+        disabled={switchTeam.isPending}
+      >
+        <SelectTrigger aria-label="Active team" className="w-full">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectPopup>
+          {data.teams.map((team) => (
+            <SelectItem key={optionValue(team)} value={optionValue(team)}>
+              {team.name} · {regionLabel(team.region)}
+            </SelectItem>
+          ))}
+        </SelectPopup>
+      </Select>
+    </div>
+  )
+}

--- a/apps/console/src/components/sidebar/team-switcher.tsx
+++ b/apps/console/src/components/sidebar/team-switcher.tsx
@@ -34,6 +34,17 @@ export function TeamSwitcher() {
   const active = data.teams.find(
     (t) => t.id === data.activeTeamId && t.region === data.activeRegion,
   )
+  // Active team first (it's what the trigger shows, so the list reads as a
+  // continuation), everything else alphabetical.
+  const ordered = [
+    ...(active ? [active] : []),
+    ...data.teams
+      .filter((t) => t !== active)
+      .toSorted(
+        (a, b) =>
+          a.name.localeCompare(b.name) || a.region.localeCompare(b.region),
+      ),
+  ]
   // Region badges only add signal when the directory spans regions.
   const multiRegion = new Set(data.teams.map((t) => t.region)).size > 1
 
@@ -68,7 +79,7 @@ export function TeamSwitcher() {
           </SelectValue>
         </SelectTrigger>
         <SelectPopup dropdown>
-          {data.teams.map((team) => (
+          {ordered.map((team) => (
             <SelectItem key={optionValue(team)} value={optionValue(team)}>
               {teamLabel(team)}
             </SelectItem>

--- a/apps/console/src/hooks/use-teams.ts
+++ b/apps/console/src/hooks/use-teams.ts
@@ -1,9 +1,14 @@
 "use client"
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useRouter } from "next/navigation"
 
 import { teamKeys } from "@/lib/api/query-keys"
-import { createTeamAction, listTeamsAction } from "@/lib/api/teams-actions"
+import {
+  createTeamAction,
+  listTeamsAction,
+  setActiveTeamAction,
+} from "@/lib/api/teams-actions"
 
 export function useTeams() {
   return useQuery({
@@ -15,11 +20,30 @@ export function useTeams() {
 
 export function useCreateTeam() {
   const queryClient = useQueryClient()
+  const router = useRouter()
   return useMutation({
     mutationFn: ({ name, region }: { name: string; region: string }) =>
       createTeamAction(name, region),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: teamKeys.all })
+      // Creating a team also switches to it, so the whole cache is stale,
+      // not just the directory.
+      queryClient.clear()
+      router.refresh()
+    },
+  })
+}
+
+export function useSwitchTeam() {
+  const queryClient = useQueryClient()
+  const router = useRouter()
+  return useMutation({
+    mutationFn: ({ teamId, region }: { teamId: string; region: string }) =>
+      setActiveTeamAction(teamId, region),
+    onSuccess: () => {
+      // Every cached list (sandboxes, keys, snapshots, …) belongs to the
+      // previous team; drop everything rather than enumerating keys.
+      queryClient.clear()
+      router.refresh()
     },
   })
 }

--- a/apps/console/src/hooks/use-teams.ts
+++ b/apps/console/src/hooks/use-teams.ts
@@ -1,13 +1,13 @@
 "use client"
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
-import { useRouter } from "next/navigation"
 
 import { teamKeys } from "@/lib/api/query-keys"
 import {
   createTeamAction,
   listTeamsAction,
   setActiveTeamAction,
+  type TeamDirectoryResponse,
 } from "@/lib/api/teams-actions"
 
 export function useTeams() {
@@ -18,32 +18,65 @@ export function useTeams() {
   })
 }
 
+/**
+ * Drop every cached dataset that belongs to the previous team. Reset (not
+ * invalidate) so stale rows can never flash while the new team's data loads;
+ * active queries refetch immediately, inactive ones on next mount. The team
+ * directory is exempt — it is team-agnostic and already carries the new
+ * selection.
+ */
+function resetTeamScopedQueries(
+  queryClient: ReturnType<typeof useQueryClient>,
+) {
+  void queryClient.resetQueries({
+    predicate: (query) => query.queryKey[0] !== teamKeys.all[0],
+  })
+}
+
 export function useCreateTeam() {
   const queryClient = useQueryClient()
-  const router = useRouter()
   return useMutation({
     mutationFn: ({ name, region }: { name: string; region: string }) =>
       createTeamAction(name, region),
     onSuccess: () => {
-      // Creating a team also switches to it, so the whole cache is stale,
-      // not just the directory.
-      queryClient.clear()
-      router.refresh()
+      // Creating a team also switches to it, and the directory itself gained
+      // a row — refetch it rather than patching it.
+      void queryClient.invalidateQueries({ queryKey: teamKeys.directory() })
+      resetTeamScopedQueries(queryClient)
     },
   })
 }
 
 export function useSwitchTeam() {
   const queryClient = useQueryClient()
-  const router = useRouter()
   return useMutation({
     mutationFn: ({ teamId, region }: { teamId: string; region: string }) =>
       setActiveTeamAction(teamId, region),
+    // Flip the switcher immediately; the server action only validates and
+    // stores the cookie. Rolled back on error.
+    onMutate: async ({ teamId, region }) => {
+      await queryClient.cancelQueries({ queryKey: teamKeys.directory() })
+      const previous = queryClient.getQueryData<TeamDirectoryResponse>(
+        teamKeys.directory(),
+      )
+      queryClient.setQueryData<TeamDirectoryResponse>(
+        teamKeys.directory(),
+        (old) =>
+          old ? { ...old, activeTeamId: teamId, activeRegion: region } : old,
+      )
+      return { previous }
+    },
+    onError: (_error, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(teamKeys.directory(), context.previous)
+      }
+    },
     onSuccess: () => {
-      // Every cached list (sandboxes, keys, snapshots, …) belongs to the
-      // previous team; drop everything rather than enumerating keys.
-      queryClient.clear()
-      router.refresh()
+      // No router.refresh(): the dashboard shell is a pure client layout, so
+      // a refresh would only re-render RSC payloads that carry no team data —
+      // and it invalidates the router cache, re-fetching every prefetched
+      // route alongside the query refetches.
+      resetTeamScopedQueries(queryClient)
     },
   })
 }

--- a/apps/console/src/lib/api/active-team.test.ts
+++ b/apps/console/src/lib/api/active-team.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from "vitest"
+
+// Cookie store stub — swapped per test via cookieValue.
+let cookieValue: string | undefined
+vi.mock("next/headers", () => ({
+  cookies: async () => ({
+    get: (name: string) =>
+      name === "ss-active-team" && cookieValue !== undefined
+        ? { name, value: cookieValue }
+        : undefined,
+  }),
+}))
+
+let memberships: Array<{ teamId: string; region: string }> = []
+vi.mock("@/lib/api/team-directory", () => ({
+  listTeamMembershipsForUser: vi.fn(async () => memberships),
+}))
+
+import {
+  parseTeamSelection,
+  pickActiveTeam,
+  resolveActiveTeam,
+  serializeTeamSelection,
+} from "./active-team"
+
+describe("parseTeamSelection", () => {
+  it("splits region and team id at the first colon", () => {
+    expect(parseTeamSelection("usw:team-1")).toEqual({
+      region: "usw",
+      teamId: "team-1",
+    })
+  })
+
+  it("round-trips through serializeTeamSelection", () => {
+    const selection = { region: "use", teamId: "abc-123" }
+    expect(parseTeamSelection(serializeTeamSelection(selection))).toEqual(
+      selection,
+    )
+  })
+
+  it("rejects missing, empty, and one-sided values", () => {
+    expect(parseTeamSelection(undefined)).toBeNull()
+    expect(parseTeamSelection("")).toBeNull()
+    expect(parseTeamSelection("no-colon")).toBeNull()
+    expect(parseTeamSelection(":team-1")).toBeNull()
+    expect(parseTeamSelection("usw:")).toBeNull()
+  })
+})
+
+describe("pickActiveTeam", () => {
+  const west = { teamId: "team-w", region: "usw" }
+  const eastA = { teamId: "team-a", region: "use" }
+  const eastB = { teamId: "team-b", region: "use" }
+
+  it("returns the selected team when it matches a membership", () => {
+    expect(
+      pickActiveTeam([eastA, west], { region: "usw", teamId: "team-w" }),
+    ).toBe(west)
+  })
+
+  it("requires region AND id to match (same id can exist in two cells mid-migration)", () => {
+    const mirrored = { teamId: "team-w", region: "use" }
+    expect(
+      pickActiveTeam([mirrored, west], { region: "usw", teamId: "team-w" }),
+    ).toBe(west)
+  })
+
+  it("falls back when the selection is not a live membership", () => {
+    expect(pickActiveTeam([eastA], { region: "usw", teamId: "gone" })).toBe(
+      eastA,
+    )
+  })
+
+  it("fallback is deterministic regardless of within-cell row order", () => {
+    expect(pickActiveTeam([eastB, eastA], null)).toBe(eastA)
+    expect(pickActiveTeam([eastA, eastB], null)).toBe(eastA)
+  })
+
+  it("fallback keeps cell order: default cell beats secondary cells", () => {
+    // A global id sort would pick team-a in usw; cell order must win instead.
+    const eastZ = { teamId: "team-z", region: "use" }
+    const westA = { teamId: "team-a", region: "usw" }
+    expect(pickActiveTeam([eastZ, westA], null)).toBe(eastZ)
+    expect(pickActiveTeam([west], null)).toBe(west)
+  })
+
+  it("returns null with no memberships", () => {
+    expect(pickActiveTeam([], null)).toBeNull()
+    expect(pickActiveTeam([], { region: "use", teamId: "x" })).toBeNull()
+  })
+})
+
+describe("resolveActiveTeam", () => {
+  it("honors the cookie when it matches a membership", async () => {
+    memberships = [
+      { teamId: "team-a", region: "use" },
+      { teamId: "team-w", region: "usw" },
+    ]
+    cookieValue = "usw:team-w"
+    expect(await resolveActiveTeam("u1")).toEqual({
+      teamId: "team-w",
+      region: "usw",
+    })
+  })
+
+  it("falls back to the first membership without a cookie", async () => {
+    memberships = [
+      { teamId: "team-a", region: "use" },
+      { teamId: "team-w", region: "usw" },
+    ]
+    cookieValue = undefined
+    expect(await resolveActiveTeam("u1")).toEqual({
+      teamId: "team-a",
+      region: "use",
+    })
+  })
+
+  it("ignores a stale cookie for a revoked membership", async () => {
+    memberships = [{ teamId: "team-a", region: "use" }]
+    cookieValue = "usw:team-w"
+    expect(await resolveActiveTeam("u1")).toEqual({
+      teamId: "team-a",
+      region: "use",
+    })
+  })
+})

--- a/apps/console/src/lib/api/active-team.ts
+++ b/apps/console/src/lib/api/active-team.ts
@@ -38,9 +38,12 @@ export async function readTeamSelection(): Promise<TeamSelection | null> {
 /**
  * The membership the console operates on. The selection wins when it matches
  * a live membership. The fallback must be deterministic across surfaces and
- * server instances (they resolve the team independently): memberships arrive
- * in cell order already, so only within-cell order needs pinning — the sort
- * is stable and compares nothing across regions.
+ * server instances (they resolve the team independently): regions keep their
+ * incoming (cell) order via a first-appearance rank, and within a region the
+ * team id pins the order. Ranking rather than a conditional comparator keeps
+ * the sort a strict weak ordering — returning 0 across regions while
+ * comparing ids within one is not transitive, and engines may order such
+ * comparators arbitrarily.
  */
 export function pickActiveTeam(
   memberships: TeamMembership[],
@@ -52,8 +55,15 @@ export function pickActiveTeam(
     )
     if (match) return match
   }
-  const ordered = memberships.toSorted((a, b) =>
-    a.region === b.region ? a.teamId.localeCompare(b.teamId) : 0,
+  const regionRank = new Map<string, number>()
+  for (const m of memberships) {
+    if (!regionRank.has(m.region)) regionRank.set(m.region, regionRank.size)
+  }
+  const ordered = memberships.toSorted(
+    (a, b) =>
+      (regionRank.get(a.region) as number) -
+        (regionRank.get(b.region) as number) ||
+      a.teamId.localeCompare(b.teamId),
   )
   return ordered[0] ?? null
 }

--- a/apps/console/src/lib/api/active-team.ts
+++ b/apps/console/src/lib/api/active-team.ts
@@ -1,0 +1,69 @@
+import { cookies } from "next/headers"
+
+import {
+  listTeamMembershipsForUser,
+  type TeamMembership,
+} from "@/lib/api/team-directory"
+
+// The user's selected team, stored as "<region>:<teamId>". The cookie is a
+// preference, never an authorization: every read validates it against the
+// user's live memberships and silently falls back when it no longer matches
+// (membership revoked, team moved to another cell, cookie hand-edited).
+export const ACTIVE_TEAM_COOKIE = "ss-active-team"
+
+export interface TeamSelection {
+  region: string
+  teamId: string
+}
+
+export function parseTeamSelection(
+  value: string | undefined,
+): TeamSelection | null {
+  if (!value) return null
+  const sep = value.indexOf(":")
+  if (sep <= 0 || sep === value.length - 1) return null
+  return { region: value.slice(0, sep), teamId: value.slice(sep + 1) }
+}
+
+export function serializeTeamSelection(selection: TeamSelection): string {
+  return `${selection.region}:${selection.teamId}`
+}
+
+/** The stored selection for this request, or null when none was ever set. */
+export async function readTeamSelection(): Promise<TeamSelection | null> {
+  const store = await cookies()
+  return parseTeamSelection(store.get(ACTIVE_TEAM_COOKIE)?.value)
+}
+
+/**
+ * The membership the console operates on. The selection wins when it matches
+ * a live membership. The fallback must be deterministic across surfaces and
+ * server instances (they resolve the team independently): memberships arrive
+ * in cell order already, so only within-cell order needs pinning — the sort
+ * is stable and compares nothing across regions.
+ */
+export function pickActiveTeam(
+  memberships: TeamMembership[],
+  selection: TeamSelection | null,
+): TeamMembership | null {
+  if (selection) {
+    const match = memberships.find(
+      (m) => m.teamId === selection.teamId && m.region === selection.region,
+    )
+    if (match) return match
+  }
+  const ordered = memberships.toSorted((a, b) =>
+    a.region === b.region ? a.teamId.localeCompare(b.teamId) : 0,
+  )
+  return ordered[0] ?? null
+}
+
+export async function resolveActiveTeam(
+  userId: string,
+): Promise<TeamMembership | null> {
+  const [memberships, selection] = await Promise.all([
+    listTeamMembershipsForUser(userId),
+    readTeamSelection(),
+  ])
+  return pickActiveTeam(memberships, selection)
+}

--- a/apps/console/src/lib/api/activity-actions.ts
+++ b/apps/console/src/lib/api/activity-actions.ts
@@ -1,15 +1,12 @@
 "use server"
 
-import {
-  listTeamMembershipsForUser,
-  type TeamMembership,
-} from "@/lib/api/team-directory"
+import { resolveActiveTeam } from "@/lib/api/active-team"
+import type { TeamMembership } from "@/lib/api/team-directory"
 import { cellFor } from "@/lib/cells"
 import { createServerClient } from "@/lib/supabase/server"
 
 async function getTeam(userId: string): Promise<TeamMembership | null> {
-  const memberships = await listTeamMembershipsForUser(userId).catch(() => [])
-  return memberships[0] ?? null
+  return resolveActiveTeam(userId).catch(() => null)
 }
 
 export async function listActivityBySandboxAction(

--- a/apps/console/src/lib/api/api-keys-actions.cell.test.ts
+++ b/apps/console/src/lib/api/api-keys-actions.cell.test.ts
@@ -10,6 +10,11 @@ vi.mock("@/lib/supabase/server", () => ({
   }),
 }))
 
+// No cookie set: active-team resolution falls back to the first membership.
+vi.mock("next/headers", () => ({
+  cookies: async () => ({ get: () => undefined }),
+}))
+
 let uswProfileChecked = false
 let insertedApiKeyRow: Record<string, unknown> | null = null
 

--- a/apps/console/src/lib/api/api-keys-actions.create.test.ts
+++ b/apps/console/src/lib/api/api-keys-actions.create.test.ts
@@ -15,6 +15,11 @@ vi.mock("@/lib/supabase/server", () => ({
   }),
 }))
 
+// No cookie set: active-team resolution falls back to the first membership.
+vi.mock("next/headers", () => ({
+  cookies: async () => ({ get: () => undefined }),
+}))
+
 // Per-test knobs read lazily by the admin-client mock.
 let homeRegionResult: { data: unknown; error: unknown } = {
   data: { home_region: "usw" },

--- a/apps/console/src/lib/api/api-keys-actions.ts
+++ b/apps/console/src/lib/api/api-keys-actions.ts
@@ -2,10 +2,8 @@
 
 import crypto from "node:crypto"
 
-import {
-  listTeamMembershipsForUser,
-  type TeamMembership,
-} from "@/lib/api/team-directory"
+import { resolveActiveTeam } from "@/lib/api/active-team"
+import type { TeamMembership } from "@/lib/api/team-directory"
 import { cellFor, DEFAULT_REGION } from "@/lib/cells"
 import { createServerClient } from "@/lib/supabase/server"
 
@@ -81,7 +79,8 @@ async function ensureProfile(
 }
 
 /**
- * Look up the user's team across configured cells. If no team exists,
+ * The user's active team (their selection when it's a live membership,
+ * otherwise the deterministic default). If no team exists at all,
  * auto-create one (named after their email) in the default cell and add
  * them as owner.
  */
@@ -92,9 +91,8 @@ async function getOrCreateTeamForUser(
   // Ensure profile exists first (FK target for team_member and api_key)
   await ensureProfile(DEFAULT_REGION, userId, email)
 
-  // Try to find existing team membership in any configured cell
-  const memberships = await listTeamMembershipsForUser(userId)
-  if (memberships[0]) return memberships[0]
+  const active = await resolveActiveTeam(userId)
+  if (active) return active
 
   // No team — create one in the default cell and add user as owner
   const admin = cellFor(DEFAULT_REGION).createAdminClient()

--- a/apps/console/src/lib/api/billing-actions.test.ts
+++ b/apps/console/src/lib/api/billing-actions.test.ts
@@ -19,6 +19,11 @@ vi.mock("@/lib/supabase/admin", () => ({
   })),
 }))
 
+// No cookie set: active-team resolution falls back to the first membership.
+vi.mock("next/headers", () => ({
+  cookies: async () => ({ get: () => undefined }),
+}))
+
 function featureFlagResult(enabled: boolean) {
   return Promise.resolve({ data: enabled, error: null })
 }

--- a/apps/console/src/lib/api/billing-actions.ts
+++ b/apps/console/src/lib/api/billing-actions.ts
@@ -55,8 +55,11 @@ export interface BillingSettingsResponse {
 }
 
 async function getTeam(userId: string): Promise<TeamMembership | null> {
+  // maxAgeMs 0: billing's fail-closed check below reasons about the
+  // freshness of the read itself, so it must not be served from the
+  // directory cache.
   const { memberships, degradedRegions } =
-    await listTeamMembershipsForUserDetailed(userId)
+    await listTeamMembershipsForUserDetailed(userId, { maxAgeMs: 0 })
 
   // Fail closed on a partial directory read: with a cell unreachable,
   // "exactly one membership" may just mean the other team's cell is down —

--- a/apps/console/src/lib/api/billing-actions.ts
+++ b/apps/console/src/lib/api/billing-actions.ts
@@ -2,6 +2,7 @@
 
 import type { SupabaseClient } from "@supabase/supabase-js"
 
+import { pickActiveTeam, readTeamSelection } from "@/lib/api/active-team"
 import {
   listTeamMembershipsForUserDetailed,
   type TeamMembership,
@@ -67,13 +68,7 @@ async function getTeam(userId: string): Promise<TeamMembership | null> {
     )
   }
 
-  if (!memberships.length) return null
-
-  const uniqueTeams = new Map(memberships.map((m) => [m.teamId, m]))
-  if (uniqueTeams.size !== 1) {
-    throw new Error("Select a team before viewing billing usage")
-  }
-  return [...uniqueTeams.values()][0]
+  return pickActiveTeam(memberships, await readTeamSelection())
 }
 
 function normalizePeriod(periodStart: string, periodEnd: string) {

--- a/apps/console/src/lib/api/client.test.ts
+++ b/apps/console/src/lib/api/client.test.ts
@@ -44,7 +44,7 @@ describe("apiClient", () => {
     )
     await apiClient("/sandboxes")
     expect(fetchSpy).toHaveBeenCalledWith(
-      "/api/sandboxes",
+      "/api/sandboxes/",
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     )
   })

--- a/apps/console/src/lib/api/client.ts
+++ b/apps/console/src/lib/api/client.ts
@@ -21,6 +21,18 @@ function getBaseUrl(): string {
 }
 
 /**
+ * The app is built with trailingSlash, so /api/foo answers only as
+ * /api/foo/ — request that form directly instead of paying a 308 redirect
+ * (a full extra round-trip) on every API call.
+ */
+function normalizePath(path: string): string {
+  const queryStart = path.indexOf("?")
+  const pathname = queryStart === -1 ? path : path.slice(0, queryStart)
+  const query = queryStart === -1 ? "" : path.slice(queryStart)
+  return pathname.endsWith("/") ? path : `${pathname}/${query}`
+}
+
+/**
  * Runs a request against the console API proxy with a 30s timeout and unified
  * error handling, then hands the successful Response to `read`. The reader runs
  * inside the timeout window so a slow body read still aborts.
@@ -30,7 +42,7 @@ async function request<R>(
   options: RequestInit,
   read: (response: Response) => Promise<R>,
 ): Promise<R> {
-  const url = `${getBaseUrl()}${path}`
+  const url = `${getBaseUrl()}${normalizePath(path)}`
 
   const headers = new Headers(options.headers)
   if (

--- a/apps/console/src/lib/api/files.test.ts
+++ b/apps/console/src/lib/api/files.test.ts
@@ -137,7 +137,7 @@ describe("listDir", () => {
     const entries = await listDir(sandbox, "/home/user")
 
     const [url] = fetchSpy.mock.calls[0]
-    expect(url).toBe("/api/sandboxes/sbx-1/files?path=%2Fhome%2Fuser")
+    expect(url).toBe("/api/sandboxes/sbx-1/files/?path=%2Fhome%2Fuser")
     expect(entries.map((e) => e.name)).toEqual(["sub", "b.txt"])
   })
 

--- a/apps/console/src/lib/api/proxy-auth.test.ts
+++ b/apps/console/src/lib/api/proxy-auth.test.ts
@@ -3,11 +3,11 @@
  *
  * These are the security-critical primitives used by every authenticated
  * request through the API proxy. Tests focus on:
- *  - Deterministic key derivation (same user → same key across instances)
- *  - Different users → different keys
+ *  - Deterministic key derivation (same user+team → same key across instances)
+ *  - Different users or teams → different keys
  *  - CONSOLE_PROXY_SECRET length guard
  *  - hashKey stability
- *  - Proxy key row / upstream URL resolving to the team's home cell
+ *  - Proxy key row / upstream URL resolving to the active team's home cell
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
@@ -20,6 +20,11 @@ vi.mock("@/lib/supabase/admin", () => ({
 }))
 vi.mock("@/lib/supabase/server", () => ({
   createServerClient: vi.fn(),
+}))
+
+// No cookie set: active-team resolution falls back to the first membership.
+vi.mock("next/headers", () => ({
+  cookies: async () => ({ get: () => undefined }),
 }))
 
 // The user's team lives in the usw cell — used by the cell-targeting tests.
@@ -97,33 +102,39 @@ describe("proxy-auth.deriveRawKey", () => {
       "test-secret-must-be-at-least-thirty-two-chars-long-abcdef"
   })
 
-  it("is deterministic: same user id always returns the same key", () => {
-    const k1 = deriveRawKey("user-123")
-    const k2 = deriveRawKey("user-123")
+  it("is deterministic: same user and team always return the same key", () => {
+    const k1 = deriveRawKey("user-123", "team-1")
+    const k2 = deriveRawKey("user-123", "team-1")
     expect(k1).toBe(k2)
   })
 
   it("produces different keys for different user ids", () => {
-    const k1 = deriveRawKey("user-a")
-    const k2 = deriveRawKey("user-b")
+    const k1 = deriveRawKey("user-a", "team-1")
+    const k2 = deriveRawKey("user-b", "team-1")
+    expect(k1).not.toBe(k2)
+  })
+
+  it("produces different keys for the same user's different teams", () => {
+    const k1 = deriveRawKey("user-123", "team-1")
+    const k2 = deriveRawKey("user-123", "team-2")
     expect(k1).not.toBe(k2)
   })
 
   it("prefixes the key with ss_live_", () => {
-    expect(deriveRawKey("user-123")).toMatch(/^ss_live_/)
+    expect(deriveRawKey("user-123", "team-1")).toMatch(/^ss_live_/)
   })
 
   it("uses base64url alphabet (safe for headers/URLs)", () => {
-    const key = deriveRawKey("user-123")
+    const key = deriveRawKey("user-123", "team-1")
     // base64url never uses +, /, or padding =
     expect(key).not.toMatch(/[+/=]/)
   })
 
   it("changes when the secret changes (force rotation)", () => {
-    const a = deriveRawKey("user-123")
+    const a = deriveRawKey("user-123", "team-1")
     process.env.CONSOLE_PROXY_SECRET =
       "different-secret-must-also-be-long-aaaaaaa"
-    const b = deriveRawKey("user-123")
+    const b = deriveRawKey("user-123", "team-1")
     expect(a).not.toBe(b)
   })
 })

--- a/apps/console/src/lib/api/proxy-auth.ts
+++ b/apps/console/src/lib/api/proxy-auth.ts
@@ -2,6 +2,11 @@ import crypto from "node:crypto"
 
 import type { User } from "@supabase/supabase-js"
 
+import {
+  pickActiveTeam,
+  readTeamSelection,
+  serializeTeamSelection,
+} from "@/lib/api/active-team"
 import { getProxySecret, hashKey } from "@/lib/api/proxy-secret"
 import {
   listTeamMembershipsForUser,
@@ -13,14 +18,21 @@ import { createServerClient } from "@/lib/supabase/server"
 export { getProxySecret, hashKey } from "@/lib/api/proxy-secret"
 
 const PROXY_KEY_NAME = "__console_proxy__"
-// Bump this when you want to force-rotate every user's proxy key.
-const PROXY_KEY_VERSION = "v1"
+// Bump this when you want to force-rotate every proxy key. v2 added the team
+// id to the derivation (one key per user per team, so switching teams swaps
+// keys instead of re-pointing one row); v1 rows are inert leftovers.
+const PROXY_KEY_VERSION = "v2"
 
-/** @internal — exported for tests. Deterministic per-user key derivation. */
-export function deriveRawKey(userId: string): string {
+/**
+ * @internal — exported for tests. Deterministic per-user-per-team key
+ * derivation. The team id is part of the MAC input so each of a user's teams
+ * gets its own key row in its own cell, and the injected key always
+ * authorizes exactly the active team.
+ */
+export function deriveRawKey(userId: string, teamId: string): string {
   const mac = crypto
     .createHmac("sha256", getProxySecret())
-    .update(`${PROXY_KEY_VERSION}:${userId}`)
+    .update(`${PROXY_KEY_VERSION}:${userId}:${teamId}`)
     .digest()
   return `ss_live_${mac.toString("base64url")}`
 }
@@ -51,11 +63,12 @@ function setFresh<T>(map: Map<string, Expiring<T>>, key: string, value: T) {
   map.set(key, { value, expires: Date.now() + AUTHZ_CACHE_TTL_MS })
 }
 
-// Users whose api_key row was ensured recently — re-ensuring is one
-// idempotent upsert, so the TTL also heals a server-side key-row deletion.
-const ensuredUsers = new Map<string, Expiring<true>>()
-// The user's team + home cell. Stable in practice, but it IS authorization
-// state, hence the TTL.
+// user:team pairs whose api_key row was ensured recently — re-ensuring is
+// one idempotent upsert, so the TTL also heals a server-side key-row
+// deletion.
+const ensuredKeys = new Map<string, Expiring<true>>()
+// The user's active team + home cell, keyed by user AND selection so a team
+// switch takes effect immediately instead of after the TTL.
 const teamCache = new Map<string, Expiring<TeamMembership>>()
 
 async function ensureProfile(userId: string, email: string): Promise<void> {
@@ -82,14 +95,19 @@ async function getTeamForUser(
   userId: string,
   email: string,
 ): Promise<TeamMembership> {
-  const cached = getFresh(teamCache, userId)
+  const selection = await readTeamSelection()
+  const cacheKey = `${userId}|${selection ? serializeTeamSelection(selection) : ""}`
+  const cached = getFresh(teamCache, cacheKey)
   if (cached) return cached
 
   await ensureProfile(userId, email)
 
-  const membership = (await listTeamMembershipsForUser(userId))[0]
+  const membership = pickActiveTeam(
+    await listTeamMembershipsForUser(userId),
+    selection,
+  )
   if (membership) {
-    setFresh(teamCache, userId, membership)
+    setFresh(teamCache, cacheKey, membership)
     return membership
   }
 
@@ -112,7 +130,7 @@ async function getTeamForUser(
     throw new Error(`Failed to add team member: ${memberErr.message}`)
 
   const created = { teamId: team.id as string, region: DEFAULT_REGION }
-  setFresh(teamCache, userId, created)
+  setFresh(teamCache, cacheKey, created)
   return created
 }
 
@@ -139,12 +157,12 @@ export async function getApiBaseUrlForUser(user: User): Promise<string> {
  */
 async function ensureProxyKeyRow(
   userId: string,
-  email: string,
+  team: TeamMembership,
   keyHash: string,
 ): Promise<void> {
-  if (getFresh(ensuredUsers, userId)) return
+  const ensureKey = `${userId}|${team.region}:${team.teamId}`
+  if (getFresh(ensuredKeys, ensureKey)) return
 
-  const team = await getTeamForUser(userId, email)
   const admin = cellFor(team.region).createAdminClient()
 
   const { error } = await admin.from("api_key").upsert(
@@ -160,7 +178,7 @@ async function ensureProxyKeyRow(
 
   if (error) throw new Error(`Failed to ensure proxy key: ${error.message}`)
 
-  setFresh(ensuredUsers, userId, true)
+  setFresh(ensuredKeys, ensureKey, true)
 }
 
 export async function getAuthApiKeyForUser(
@@ -168,8 +186,9 @@ export async function getAuthApiKeyForUser(
 ): Promise<string | null> {
   if (!user) return null
 
-  const rawKey = deriveRawKey(user.id)
-  await ensureProxyKeyRow(user.id, user.email ?? user.id, hashKey(rawKey))
+  const team = await getTeamForUser(user.id, user.email ?? user.id)
+  const rawKey = deriveRawKey(user.id, team.teamId)
+  await ensureProxyKeyRow(user.id, team, hashKey(rawKey))
   return rawKey
 }
 

--- a/apps/console/src/lib/api/quota-actions.ts
+++ b/apps/console/src/lib/api/quota-actions.ts
@@ -1,5 +1,6 @@
 "use server"
 
+import { pickActiveTeam, readTeamSelection } from "@/lib/api/active-team"
 import {
   listTeamMembershipsForUserDetailed,
   type TeamMembership,
@@ -21,15 +22,7 @@ async function getTeam(userId: string): Promise<TeamMembership | null> {
   // banner renders nothing rather than showing a possibly-wrong team's quota.
   if (degradedRegions.length > 0) return null
 
-  if (!memberships.length) return null
-
-  const uniqueTeams = new Map(memberships.map((m) => [m.teamId, m]))
-  // Ambient poller with no team-selector: an ambiguous (multi-team) membership
-  // renders nothing rather than throwing on every poll (which would spam logs).
-  if (uniqueTeams.size !== 1) {
-    return null
-  }
-  return [...uniqueTeams.values()][0]
+  return pickActiveTeam(memberships, await readTeamSelection())
 }
 
 // Current team's sandbox usage for the in-product quota banner; null when the

--- a/apps/console/src/lib/api/sandboxes.test.ts
+++ b/apps/console/src/lib/api/sandboxes.test.ts
@@ -23,7 +23,7 @@ describe("sandbox secret bindings", () => {
     await attachSandboxSecret("sbx-1", "ANTHROPIC_API_KEY", "anthropic-prod")
 
     const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit]
-    expect(url).toBe("/api/sandboxes/sbx-1/secrets")
+    expect(url).toBe("/api/sandboxes/sbx-1/secrets/")
     expect(init.method).toBe("POST")
     expect(JSON.parse(init.body as string)).toEqual({
       env_key: "ANTHROPIC_API_KEY",
@@ -36,7 +36,7 @@ describe("sandbox secret bindings", () => {
     await detachSandboxSecret("sbx-1", "A/B")
 
     const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit]
-    expect(url).toBe("/api/sandboxes/sbx-1/secrets/A%2FB")
+    expect(url).toBe("/api/sandboxes/sbx-1/secrets/A%2FB/")
     expect(init.method).toBe("DELETE")
   })
 })

--- a/apps/console/src/lib/api/snapshots-actions.ts
+++ b/apps/console/src/lib/api/snapshots-actions.ts
@@ -1,15 +1,12 @@
 "use server"
 
-import {
-  listTeamMembershipsForUser,
-  type TeamMembership,
-} from "@/lib/api/team-directory"
+import { resolveActiveTeam } from "@/lib/api/active-team"
+import type { TeamMembership } from "@/lib/api/team-directory"
 import { cellFor } from "@/lib/cells"
 import { createServerClient } from "@/lib/supabase/server"
 
 async function getTeam(userId: string): Promise<TeamMembership | null> {
-  const memberships = await listTeamMembershipsForUser(userId).catch(() => [])
-  return memberships[0] ?? null
+  return resolveActiveTeam(userId).catch(() => null)
 }
 
 export async function listSnapshotsBySandboxAction(sandboxId: string) {

--- a/apps/console/src/lib/api/team-directory.test.ts
+++ b/apps/console/src/lib/api/team-directory.test.ts
@@ -48,10 +48,18 @@ vi.mock("@/lib/cells", () => ({
 }))
 
 import {
+  clearMembershipDirectoryCache,
   listTeamMembershipsForUser,
   listTeamMembershipsForUserDetailed,
   listTeamsForUser,
+  membershipExistsInCell,
 } from "./team-directory"
+
+// The membership directory caches per user id and tests reuse ids across
+// cases with different mock data — every case starts cold.
+beforeEach(() => {
+  clearMembershipDirectoryCache()
+})
 
 describe("team directory fan-out", () => {
   beforeEach(() => {
@@ -247,5 +255,85 @@ describe("RBAC-authoritative membership", () => {
     expect(await listTeamMembershipsForUser("u1")).toEqual([
       { teamId: "team-2", region: "use" },
     ])
+  })
+})
+
+describe("membership directory cache", () => {
+  beforeEach(() => {
+    regions = ["use"]
+    cellClients = { use: cellClient([{ team_id: "t1" }]) }
+  })
+
+  it("serves repeat reads within the TTL from cache", async () => {
+    await listTeamMembershipsForUserDetailed("u1")
+    await listTeamMembershipsForUserDetailed("u1")
+    expect(cellClients.use.from).toHaveBeenCalledTimes(2) // one fan-out: rbac + legacy
+  })
+
+  it("collapses concurrent reads into one fan-out", async () => {
+    await Promise.all([
+      listTeamMembershipsForUserDetailed("u1"),
+      listTeamMembershipsForUserDetailed("u1"),
+      listTeamMembershipsForUserDetailed("u1"),
+    ])
+    expect(cellClients.use.from).toHaveBeenCalledTimes(2)
+  })
+
+  it("maxAgeMs 0 always reads fresh", async () => {
+    await listTeamMembershipsForUserDetailed("u1")
+    await listTeamMembershipsForUserDetailed("u1", { maxAgeMs: 0 })
+    expect(cellClients.use.from).toHaveBeenCalledTimes(4)
+  })
+
+  it("does not share entries across users", async () => {
+    await listTeamMembershipsForUserDetailed("u1")
+    await listTeamMembershipsForUserDetailed("u2")
+    expect(cellClients.use.from).toHaveBeenCalledTimes(4)
+  })
+
+  it("invalidateMembershipDirectory forces the next read to fetch", async () => {
+    const { invalidateMembershipDirectory } = await import("./team-directory")
+    await listTeamMembershipsForUserDetailed("u1")
+    invalidateMembershipDirectory("u1")
+    await listTeamMembershipsForUserDetailed("u1")
+    expect(cellClients.use.from).toHaveBeenCalledTimes(4)
+  })
+
+  it("does not cache failures", async () => {
+    const failing = {
+      from: vi.fn(() => {
+        throw new Error("cell down")
+      }),
+    }
+    cellClients = { use: failing as unknown as ReturnType<typeof cellClient> }
+    await expect(listTeamMembershipsForUserDetailed("u1")).rejects.toThrow()
+    cellClients = { use: cellClient([{ team_id: "t1" }]) }
+    const result = await listTeamMembershipsForUserDetailed("u1")
+    expect(result.memberships).toEqual([{ teamId: "t1", region: "use" }])
+  })
+})
+
+describe("membershipExistsInCell", () => {
+  it("checks only the named cell and honors RBAC precedence", async () => {
+    regions = ["use", "usw"]
+    cellClients = {
+      use: cellClient([{ team_id: "t-legacy" }]),
+      usw: cellClient([], [], [{ team_id: "t-west", status: "active" }]),
+    }
+    expect(await membershipExistsInCell("usw", "u1", "t-west")).toBe(true)
+    expect(await membershipExistsInCell("usw", "u1", "t-legacy")).toBe(false)
+    expect(cellClients.use.from).not.toHaveBeenCalled()
+  })
+
+  it("denies an inactive RBAC membership even with a legacy row", async () => {
+    regions = ["use"]
+    cellClients = {
+      use: cellClient(
+        [{ team_id: "t1" }],
+        [],
+        [{ team_id: "t1", status: "inactive" }],
+      ),
+    }
+    expect(await membershipExistsInCell("use", "u1", "t1")).toBe(false)
   })
 })

--- a/apps/console/src/lib/api/team-directory.ts
+++ b/apps/console/src/lib/api/team-directory.ts
@@ -62,14 +62,74 @@ export interface MembershipDirectory {
  */
 export async function listTeamMembershipsForUserDetailed(
   userId: string,
+  opts?: { maxAgeMs?: number },
 ): Promise<MembershipDirectory> {
-  const { items, degradedRegions } = await acrossCells(async (region) => {
+  const maxAgeMs = opts?.maxAgeMs ?? DIRECTORY_CACHE_TTL_MS
+  // Strict inequality so maxAgeMs 0 can never hit cache, even for a read in
+  // the same millisecond as the fill.
+  const cached = directoryCache.get(userId)
+  if (cached && Date.now() - cached.fetchedAt < maxAgeMs) {
+    return cached.promise
+  }
+
+  const fetchedAt = Date.now()
+  const promise = acrossCells(async (region) => {
     const admin = cellFor(region).createAdminClient()
     return membershipTeamIdsInCell(admin, userId).then((teamIds) =>
       teamIds.map((teamId) => ({ teamId, region })),
     )
+  }).then(({ items, degradedRegions }) => ({
+    memberships: items,
+    degradedRegions,
+  }))
+
+  // The in-flight promise is cached too, so the burst of parallel server
+  // actions after a page load or team switch collapses into one fan-out.
+  // Failures are evicted rather than cached.
+  directoryCache.set(userId, { promise, fetchedAt })
+  promise.catch(() => {
+    if (directoryCache.get(userId)?.promise === promise) {
+      directoryCache.delete(userId)
+    }
   })
-  return { memberships: items, degradedRegions }
+  return promise
+}
+
+// Membership reads back most server actions, so a fan-out per action call
+// adds two queries per cell before any real work. Same staleness model as
+// proxy-auth's authz cache: this IS authorization state, so it's cached for
+// one bounded minute, never indefinitely. Callers whose correctness depends
+// on a fresh read (billing fails closed on degraded cells) pass maxAgeMs: 0.
+const DIRECTORY_CACHE_TTL_MS = 60_000
+const directoryCache = new Map<
+  string,
+  { promise: Promise<MembershipDirectory>; fetchedAt: number }
+>()
+
+/** Evict a user's cached membership directory (e.g. after creating a team). */
+export function invalidateMembershipDirectory(userId: string): void {
+  directoryCache.delete(userId)
+}
+
+/** @internal — for tests, which reuse user ids across cases. */
+export function clearMembershipDirectoryCache(): void {
+  directoryCache.clear()
+}
+
+/**
+ * Whether the user is authorized for one specific team in one specific cell
+ * — the membership lookup scoped to a single region, for callers that
+ * already know the target (e.g. validating a team switch) and shouldn't pay
+ * the every-cell fan-out. Always a fresh read: it guards writes.
+ */
+export async function membershipExistsInCell(
+  region: string,
+  userId: string,
+  teamId: string,
+): Promise<boolean> {
+  const admin = cellFor(region).createAdminClient()
+  const teamIds = await membershipTeamIdsInCell(admin, userId)
+  return teamIds.includes(teamId)
 }
 
 /**

--- a/apps/console/src/lib/api/teams-actions.test.ts
+++ b/apps/console/src/lib/api/teams-actions.test.ts
@@ -93,16 +93,40 @@ vi.mock("@/lib/cells", () => ({
   },
 }))
 
+let directoryTeams: Array<{ id: string; name: string; region: string }> = []
 vi.mock("@/lib/api/team-directory", () => ({
-  listTeamsForUser: async () => [],
+  listTeamsForUser: async () => directoryTeams,
+  listTeamMembershipsForUser: async () =>
+    directoryTeams.map((t) => ({ teamId: t.id, region: t.region })),
 }))
 
-import { createTeamAction, listTeamsAction } from "./teams-actions"
+// Cookie store stub capturing active-team writes.
+let cookieValue: string | undefined
+const cookieSets: Array<{ name: string; value: string }> = []
+vi.mock("next/headers", () => ({
+  cookies: async () => ({
+    get: (name: string) =>
+      cookieValue !== undefined ? { name, value: cookieValue } : undefined,
+    set: (name: string, value: string) => {
+      cookieSets.push({ name, value })
+      cookieValue = value
+    },
+  }),
+}))
+
+import {
+  createTeamAction,
+  listTeamsAction,
+  setActiveTeamAction,
+} from "./teams-actions"
 
 describe("createTeamAction", () => {
   beforeEach(() => {
     regions = ["use", "usw"]
     allowedRegions = null
+    directoryTeams = []
+    cookieValue = undefined
+    cookieSets.length = 0
     cellClients = {
       use: recordingCellClient(),
       usw: recordingCellClient(),
@@ -136,6 +160,11 @@ describe("createTeamAction", () => {
 
     // Nothing leaked into the default cell.
     expect(cellClients.use.from).not.toHaveBeenCalled()
+
+    // The creator lands in the new team.
+    expect(cookieSets).toEqual([
+      { name: "ss-active-team", value: "usw:team-new" },
+    ])
   })
 
   it("defaults to the default region when none is given", async () => {
@@ -178,5 +207,45 @@ describe("multi-cell allowlist enforcement", () => {
     allowedRegions = ["use"]
     const { regions: visible } = await listTeamsAction()
     expect(visible).toEqual(["use"])
+  })
+})
+
+describe("active team", () => {
+  beforeEach(() => {
+    regions = ["use", "usw"]
+    allowedRegions = null
+    cookieValue = undefined
+    cookieSets.length = 0
+    directoryTeams = [
+      { id: "team-a", name: "alpha", region: "use" },
+      { id: "team-w", name: "west", region: "usw" },
+    ]
+  })
+
+  it("directory marks the cookie's team active", async () => {
+    cookieValue = "usw:team-w"
+    const { activeTeamId, activeRegion } = await listTeamsAction()
+    expect(activeTeamId).toBe("team-w")
+    expect(activeRegion).toBe("usw")
+  })
+
+  it("directory falls back to the first team without a cookie", async () => {
+    const { activeTeamId, activeRegion } = await listTeamsAction()
+    expect(activeTeamId).toBe("team-a")
+    expect(activeRegion).toBe("use")
+  })
+
+  it("setActiveTeamAction stores a verified membership", async () => {
+    await setActiveTeamAction("team-w", "usw")
+    expect(cookieSets).toEqual([
+      { name: "ss-active-team", value: "usw:team-w" },
+    ])
+  })
+
+  it("setActiveTeamAction rejects a team the user is not in", async () => {
+    await expect(setActiveTeamAction("intruder", "usw")).rejects.toThrow(
+      "not a member",
+    )
+    expect(cookieSets).toEqual([])
   })
 })

--- a/apps/console/src/lib/api/teams-actions.test.ts
+++ b/apps/console/src/lib/api/teams-actions.test.ts
@@ -98,8 +98,12 @@ vi.mock("@/lib/cells", () => ({
 let directoryTeams: Array<{ id: string; name: string; region: string }> = []
 vi.mock("@/lib/api/team-directory", () => ({
   listTeamsForUser: async () => directoryTeams,
-  listTeamMembershipsForUser: async () =>
-    directoryTeams.map((t) => ({ teamId: t.id, region: t.region })),
+  membershipExistsInCell: async (
+    region: string,
+    _userId: string,
+    teamId: string,
+  ) => directoryTeams.some((t) => t.id === teamId && t.region === region),
+  invalidateMembershipDirectory: () => {},
 }))
 
 // Cookie store stub capturing active-team writes.

--- a/apps/console/src/lib/api/teams-actions.test.ts
+++ b/apps/console/src/lib/api/teams-actions.test.ts
@@ -13,6 +13,7 @@ vi.mock("@/lib/supabase/server", () => ({
 // Per-test knobs read lazily by the cells mock.
 let regions: string[] = ["use", "usw"]
 let allowedRegions: string[] | null = null
+let switchingAllowed = true
 let cellClients: Record<string, ReturnType<typeof recordingCellClient>> = {}
 
 // Records every write per table so tests can assert the full create chain
@@ -81,6 +82,7 @@ vi.mock("@/lib/cells", () => ({
   DEFAULT_REGION: "use",
   configuredRegions: () => regions,
   creatableRegions: () => allowedRegions ?? regions,
+  multiCellUiEnabled: () => switchingAllowed,
   cellFor: (region: string) => {
     if (!regions.includes(region)) {
       throw new Error(`Region ${region} is not configured`)
@@ -214,6 +216,7 @@ describe("active team", () => {
   beforeEach(() => {
     regions = ["use", "usw"]
     allowedRegions = null
+    switchingAllowed = true
     cookieValue = undefined
     cookieSets.length = 0
     directoryTeams = [
@@ -247,5 +250,19 @@ describe("active team", () => {
       "not a member",
     )
     expect(cookieSets).toEqual([])
+  })
+
+  it("setActiveTeamAction requires the multi-cell UI allowlist", async () => {
+    switchingAllowed = false
+    await expect(setActiveTeamAction("team-w", "usw")).rejects.toThrow(
+      "not enabled",
+    )
+    expect(cookieSets).toEqual([])
+  })
+
+  it("directory reports switching availability", async () => {
+    switchingAllowed = false
+    const { switchingEnabled } = await listTeamsAction()
+    expect(switchingEnabled).toBe(false)
   })
 })

--- a/apps/console/src/lib/api/teams-actions.ts
+++ b/apps/console/src/lib/api/teams-actions.ts
@@ -13,7 +13,12 @@ import {
   listTeamMembershipsForUser,
   listTeamsForUser,
 } from "@/lib/api/team-directory"
-import { cellFor, creatableRegions, DEFAULT_REGION } from "@/lib/cells"
+import {
+  cellFor,
+  creatableRegions,
+  DEFAULT_REGION,
+  multiCellUiEnabled,
+} from "@/lib/cells"
 import { createServerClient } from "@/lib/supabase/server"
 
 // Role granted to a team's creator. Seeded by the control-plane RBAC
@@ -37,6 +42,9 @@ export interface TeamDirectoryResponse {
   // two cells at once, and only one of them is active.
   activeTeamId: string | null
   activeRegion: string | null
+  // Whether this user may switch teams. Rolls out with the multi-cell UI
+  // allowlist, person by person, like region choice.
+  switchingEnabled: boolean
 }
 
 export async function listTeamsAction(): Promise<TeamDirectoryResponse> {
@@ -61,6 +69,7 @@ export async function listTeamsAction(): Promise<TeamDirectoryResponse> {
     regions: creatableRegions(user.email),
     activeTeamId: active?.teamId ?? null,
     activeRegion: active?.region ?? null,
+    switchingEnabled: multiCellUiEnabled(user.email),
   }
 }
 
@@ -89,6 +98,12 @@ export async function setActiveTeamAction(
     data: { user },
   } = await supabase.auth.getUser()
   if (!user) throw new Error("Not authenticated")
+
+  // Server-side enforcement, not just UI hiding: switching rolls out with
+  // the multi-cell allowlist (internal-first), like region choice.
+  if (!multiCellUiEnabled(user.email)) {
+    throw new Error("Team switching is not enabled for your account")
+  }
 
   const memberships = await listTeamMembershipsForUser(user.id)
   const match = memberships.find(

--- a/apps/console/src/lib/api/teams-actions.ts
+++ b/apps/console/src/lib/api/teams-actions.ts
@@ -10,11 +10,13 @@ import {
   type TeamSelection,
 } from "@/lib/api/active-team"
 import {
-  listTeamMembershipsForUser,
+  invalidateMembershipDirectory,
   listTeamsForUser,
+  membershipExistsInCell,
 } from "@/lib/api/team-directory"
 import {
   cellFor,
+  configuredRegions,
   creatableRegions,
   DEFAULT_REGION,
   multiCellUiEnabled,
@@ -105,11 +107,14 @@ export async function setActiveTeamAction(
     throw new Error("Team switching is not enabled for your account")
   }
 
-  const memberships = await listTeamMembershipsForUser(user.id)
-  const match = memberships.find(
-    (m) => m.teamId === teamId && m.region === region,
-  )
-  if (!match) throw new Error("You are not a member of that team")
+  // The target names its cell, so validate the membership there alone — the
+  // every-cell fan-out buys nothing here and doubles the action's latency.
+  if (
+    !configuredRegions().includes(region) ||
+    !(await membershipExistsInCell(region, user.id, teamId))
+  ) {
+    throw new Error("You are not a member of that team")
+  }
 
   await storeTeamSelection({ region, teamId })
 }
@@ -242,6 +247,10 @@ export async function createTeamAction(
       { cause: chainErr },
     )
   }
+
+  // The user just gained a membership; drop their cached directory so the
+  // very next read sees the new team instead of waiting out the TTL.
+  invalidateMembershipDirectory(user.id)
 
   // Land the creator in the team they just made — the reason to create a
   // team is almost always to start working in it.

--- a/apps/console/src/lib/api/teams-actions.ts
+++ b/apps/console/src/lib/api/teams-actions.ts
@@ -1,6 +1,18 @@
 "use server"
 
-import { listTeamsForUser } from "@/lib/api/team-directory"
+import { cookies } from "next/headers"
+
+import {
+  ACTIVE_TEAM_COOKIE,
+  pickActiveTeam,
+  readTeamSelection,
+  serializeTeamSelection,
+  type TeamSelection,
+} from "@/lib/api/active-team"
+import {
+  listTeamMembershipsForUser,
+  listTeamsForUser,
+} from "@/lib/api/team-directory"
 import { cellFor, creatableRegions, DEFAULT_REGION } from "@/lib/cells"
 import { createServerClient } from "@/lib/supabase/server"
 
@@ -20,6 +32,11 @@ export interface TeamDirectoryResponse {
   // configured AND the user is on the multi-cell UI allowlist — which is
   // what gates the region select in the UI.
   regions: string[]
+  // The team every dashboard surface operates on. Identified by id AND
+  // region: during a cross-cell migration the same team id can appear in
+  // two cells at once, and only one of them is active.
+  activeTeamId: string | null
+  activeRegion: string | null
 }
 
 export async function listTeamsAction(): Promise<TeamDirectoryResponse> {
@@ -29,8 +46,57 @@ export async function listTeamsAction(): Promise<TeamDirectoryResponse> {
   } = await supabase.auth.getUser()
   if (!user) throw new Error("Not authenticated")
 
-  const teams = await listTeamsForUser(user.id)
-  return { teams, regions: creatableRegions(user.email) }
+  const [teams, selection] = await Promise.all([
+    listTeamsForUser(user.id),
+    readTeamSelection(),
+  ])
+  // Resolve the active team from the same list the UI renders, so the
+  // directory can never mark a team it doesn't show.
+  const active = pickActiveTeam(
+    teams.map((t) => ({ teamId: t.id, region: t.region })),
+    selection,
+  )
+  return {
+    teams,
+    regions: creatableRegions(user.email),
+    activeTeamId: active?.teamId ?? null,
+    activeRegion: active?.region ?? null,
+  }
+}
+
+async function storeTeamSelection(selection: TeamSelection): Promise<void> {
+  const store = await cookies()
+  store.set(ACTIVE_TEAM_COOKIE, serializeTeamSelection(selection), {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 60 * 60 * 24 * 365,
+  })
+}
+
+/**
+ * Switch the dashboard to another of the user's teams. Membership is
+ * verified before the cookie is written; reads re-verify on every request,
+ * so the cookie only ever narrows which valid membership is used.
+ */
+export async function setActiveTeamAction(
+  teamId: string,
+  region: string,
+): Promise<void> {
+  const supabase = await createServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) throw new Error("Not authenticated")
+
+  const memberships = await listTeamMembershipsForUser(user.id)
+  const match = memberships.find(
+    (m) => m.teamId === teamId && m.region === region,
+  )
+  if (!match) throw new Error("You are not a member of that team")
+
+  await storeTeamSelection({ region, teamId })
 }
 
 /**
@@ -161,6 +227,10 @@ export async function createTeamAction(
       { cause: chainErr },
     )
   }
+
+  // Land the creator in the team they just made — the reason to create a
+  // team is almost always to start working in it.
+  await storeTeamSelection({ region: targetRegion, teamId: team.id as string })
 
   return {
     id: team.id as string,

--- a/apps/console/src/lib/format.ts
+++ b/apps/console/src/lib/format.ts
@@ -36,6 +36,16 @@ export function formatTime(date: Date): { relative: string; absolute: string } {
   return { relative, absolute }
 }
 
+const REGION_LABELS: Record<string, string> = {
+  use: "US East",
+  usw: "US West",
+}
+
+/** Human label for a cell region code; unknown codes pass through as-is. */
+export function regionLabel(region: string): string {
+  return REGION_LABELS[region] ?? region
+}
+
 /** Compact duration label (s/m/h/d) for timeout and auto-delete windows. */
 export function formatTimeout(seconds: number): string {
   if (seconds < 60) return `${seconds}s`

--- a/apps/console/src/middleware.ts
+++ b/apps/console/src/middleware.ts
@@ -41,7 +41,10 @@ export async function middleware(request: NextRequest) {
 export const config = {
   matcher: [
     // Skip Next internals and common static assets so getUser() isn't called
-    // on every font/css/js request.
-    "/((?!_next/static|_next/image|favicon\\.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|woff|woff2|ttf|otf|css|js|map)$).*)",
+    // on every font/css/js request. /api is skipped too: every API route
+    // authenticates its own request (and answers JSON, not a redirect to the
+    // signin page), so the middleware getUser() was a second Supabase auth
+    // round-trip on every API call — including the 10s sandbox list poll.
+    "/((?!api/|_next/static|_next/image|favicon\\.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|woff|woff2|ttf|otf|css|js|map)$).*)",
   ],
 }

--- a/packages/ui/src/components/menu.tsx
+++ b/packages/ui/src/components/menu.tsx
@@ -24,6 +24,7 @@ function MenuPopup({
         sideOffset={sideOffset}
         side={side}
         align={align}
+        className="z-50"
       >
         <MenuPrimitive.Popup
           className={cn(

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -34,15 +34,34 @@ function SelectTrigger({
 function SelectPopup({
   className,
   children,
+  dropdown = false,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.Popup>) {
+}: React.ComponentProps<typeof SelectPrimitive.Popup> & {
+  /**
+   * Position like a menu — always below the trigger. The default overlays
+   * the popup so the selected item aligns with the trigger (native-select
+   * feel); near a viewport edge that reads as "opening upward". Use
+   * dropdown for triggers at the top of a layout surface.
+   */
+  dropdown?: boolean
+}) {
   return (
     <SelectPrimitive.Portal>
       {/* z-index must sit on the Positioner — the fixed-position element that
           competes at body level. On the Popup alone it only wins inside the
           Positioner's stacking context, so the popup paints under elevated
           app surfaces (e.g. a z-40 sidebar) that overlap its anchor. */}
-      <SelectPrimitive.Positioner className="z-50">
+      <SelectPrimitive.Positioner
+        className="z-50"
+        {...(dropdown
+          ? {
+              alignItemWithTrigger: false,
+              side: "bottom",
+              align: "start",
+              sideOffset: 4,
+            }
+          : {})}
+      >
         <SelectPrimitive.Popup
           className={cn(
             "ss-select-popup z-50 max-h-72 min-w-[8rem] overflow-auto border border-dashed border-border bg-surface/80 p-1 backdrop-blur-xl",

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -38,7 +38,11 @@ function SelectPopup({
 }: React.ComponentProps<typeof SelectPrimitive.Popup>) {
   return (
     <SelectPrimitive.Portal>
-      <SelectPrimitive.Positioner>
+      {/* z-index must sit on the Positioner — the fixed-position element that
+          competes at body level. On the Popup alone it only wins inside the
+          Positioner's stacking context, so the popup paints under elevated
+          app surfaces (e.g. a z-40 sidebar) that overlap its anchor. */}
+      <SelectPrimitive.Positioner className="z-50">
         <SelectPrimitive.Popup
           className={cn(
             "ss-select-popup z-50 max-h-72 min-w-[8rem] overflow-auto border border-dashed border-border bg-surface/80 p-1 backdrop-blur-xl",

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -28,7 +28,7 @@ function TooltipPopup({
 }) {
   return (
     <TooltipPrimitive.Portal>
-      <TooltipPrimitive.Positioner sideOffset={sideOffset}>
+      <TooltipPrimitive.Positioner sideOffset={sideOffset} className="z-50">
         <TooltipPrimitive.Popup
           className={cn(
             "ss-tooltip-popup z-50 bg-foreground px-2 py-1 text-xs text-background",


### PR DESCRIPTION
## Summary
Adds a team switcher to the console. The active team lives in an httpOnly cookie (`region:teamId`) and every dashboard surface — sandboxes, templates, snapshots, secrets, activity/audit, API keys, billing, quota, team management — resolves it server-side, so switching re-scopes the whole product. Until now everything pinned to the first membership a directory read returned, which is nondeterministic for multi-team users and blocks working with a team in a second region. Part of the multi-region rollout.

## Technical decisions
- **Cookie is a preference, not an authorization**: every read validates it against live memberships and falls back deterministically (cell order, then team id) when stale. `setActiveTeamAction` verifies membership before writing it.
- **Proxy keys are now derived per user per team** (`PROXY_KEY_VERSION` v2). The old per-user key had a single `api_key` row pointing at one team (`ON CONFLICT DO NOTHING` — never re-pointed), so a switcher would silently keep proxying the old team. Per-team derivation gives each team its own row in its own cell; v1 rows are inert leftovers. Proxy caches key on user+selection so a switch applies within the request, not after the 60s TTL.
- The active team is identified by **id AND region**: mid-migration the same team id can exist in two cells at once.
- Switcher sits at the top of the sidebar (hidden for single-team users); the settings teams directory shows the active team and can switch; creating a team switches to it. Switching clears the React Query cache and refreshes the router.
- Billing/quota keep failing closed on degraded directory reads, but multi-team accounts no longer error out — they resolve the active team like everything else.

## Testing
- New `active-team` unit tests: cookie parsing, selection-vs-membership validation, deterministic fallback ordering.
- Updated proxy-auth tests for per-team derivation; new teams-actions tests for the directory's active marker, switch validation, and create-switches-to-new-team.
- Full console suite: 409 tests pass; typecheck, oxlint, oxfmt clean.