### PR TITLE
console: provision full RBAC chain on first-login team auto-create

### DIFF
--- a/apps/console/src/lib/api/api-keys-actions.ts
+++ b/apps/console/src/lib/api/api-keys-actions.ts
@@ -3,7 +3,11 @@
 import crypto from "node:crypto"
 
 import { resolveActiveTeam } from "@/lib/api/active-team"
-import type { TeamMembership } from "@/lib/api/team-directory"
+import {
+  invalidateMembershipDirectory,
+  type TeamMembership,
+} from "@/lib/api/team-directory"
+import { provisionTeam } from "@/lib/api/team-provisioning"
 import { cellFor, DEFAULT_REGION } from "@/lib/cells"
 import { createServerClient } from "@/lib/supabase/server"
 
@@ -94,26 +98,12 @@ async function getOrCreateTeamForUser(
   const active = await resolveActiveTeam(userId)
   if (active) return active
 
-  // No team — create one in the default cell and add user as owner
-  const admin = cellFor(DEFAULT_REGION).createAdminClient()
-  const { data: team, error: teamErr } = await admin
-    .from("team")
-    .insert({ name: email })
-    .select("id")
-    .single()
-
-  if (teamErr) throw new Error(`Failed to create team: ${teamErr.message}`)
-
-  const { error: memberErr } = await admin.from("team_member").insert({
-    team_id: team.id,
-    profile_id: userId,
-    role: "owner",
-  })
-
-  if (memberErr)
-    throw new Error(`Failed to add team member: ${memberErr.message}`)
-
-  return { teamId: team.id as string, region: DEFAULT_REGION }
+  // No team yet — provision one through the full RBAC chain (same helper the
+  // create-team and proxy-auth paths use), so a first API-key action can't
+  // leave the user with a legacy-only team the control plane rejects.
+  const team = await provisionTeam(DEFAULT_REGION, userId, email, email)
+  invalidateMembershipDirectory(userId)
+  return { teamId: team.id, region: DEFAULT_REGION }
 }
 
 export async function listApiKeysAction() {

--- a/apps/console/src/lib/api/proxy-auth.test.ts
+++ b/apps/console/src/lib/api/proxy-auth.test.ts
@@ -32,9 +32,22 @@ vi.mock("@/lib/api/team-directory", () => ({
   listTeamMembershipsForUser: vi.fn(async () => [
     { teamId: "team-west", region: "usw" },
   ]),
+  invalidateMembershipDirectory: vi.fn(),
+}))
+
+// A user with no membership is provisioned a full team via this helper; the
+// new-user test asserts getTeamForUser routes through it instead of writing a
+// legacy-only team the control plane would reject.
+vi.mock("@/lib/api/team-provisioning", () => ({
+  provisionTeam: vi.fn(async () => ({
+    id: "team-new",
+    name: "new@example.com",
+    region: "use",
+  })),
 }))
 
 const uswApiKeyUpserts: Array<Record<string, unknown>> = []
+const useApiKeyUpserts: Array<Record<string, unknown>> = []
 vi.mock("@/lib/cells", () => ({
   DEFAULT_REGION: "use",
   configuredRegions: () => ["use", "usw"],
@@ -53,17 +66,25 @@ vi.mock("@/lib/cells", () => ({
             }),
           }
         : {
-            // ensureProfile only reads: the profile already exists.
-            from: () => ({
+            // ensureProfile reads (profile exists); the proxy key upsert for a
+            // freshly provisioned default-cell team is captured too.
+            from: (table: string) => ({
               select: () => ({
                 eq: () => ({
                   single: async () => ({ data: { id: "u1" }, error: null }),
                 }),
               }),
+              upsert: async (row: Record<string, unknown>) => {
+                useApiKeyUpserts.push({ table, ...row })
+                return { error: null }
+              },
             }),
           },
   }),
 }))
+
+import { listTeamMembershipsForUser } from "@/lib/api/team-directory"
+import { provisionTeam } from "@/lib/api/team-provisioning"
 
 import {
   deriveRawKey,
@@ -177,5 +198,43 @@ describe("proxy-auth cell targeting", () => {
     expect(await getApiBaseUrlForUser(user as never)).toBe(
       "https://api-usw.test",
     )
+  })
+})
+
+describe("proxy-auth new-user provisioning", () => {
+  beforeEach(() => {
+    process.env.CONSOLE_PROXY_SECRET =
+      "test-secret-must-be-at-least-thirty-two-chars-long-abcdef"
+    useApiKeyUpserts.length = 0
+  })
+
+  it("provisions a full RBAC team when the user has no memberships", async () => {
+    vi.mocked(listTeamMembershipsForUser).mockResolvedValueOnce([])
+
+    const key = await getAuthApiKeyForUser({
+      id: "brand-new",
+      email: "new@example.com",
+    } as never)
+
+    // The fix: a memberless user is provisioned through provisionTeam (full
+    // RBAC chain), not a legacy-only team the control plane would 403.
+    expect(provisionTeam).toHaveBeenCalledWith(
+      "use",
+      "brand-new",
+      "new@example.com",
+      "new@example.com",
+    )
+    expect(key).toMatch(/^ss_live_/)
+    // Proxy key row lands in the newly provisioned team's home (default) cell.
+    expect(useApiKeyUpserts).toEqual([
+      {
+        table: "api_key",
+        team_id: "team-new",
+        key_hash: hashKey(key as string),
+        name: "__console_proxy__",
+        scopes: [],
+        created_by: "brand-new",
+      },
+    ])
   })
 })

--- a/apps/console/src/lib/api/proxy-auth.ts
+++ b/apps/console/src/lib/api/proxy-auth.ts
@@ -9,9 +9,11 @@ import {
 } from "@/lib/api/active-team"
 import { getProxySecret, hashKey } from "@/lib/api/proxy-secret"
 import {
+  invalidateMembershipDirectory,
   listTeamMembershipsForUser,
   type TeamMembership,
 } from "@/lib/api/team-directory"
+import { provisionTeam } from "@/lib/api/team-provisioning"
 import { cellFor, DEFAULT_REGION } from "@/lib/cells"
 import { createServerClient } from "@/lib/supabase/server"
 
@@ -111,25 +113,17 @@ async function getTeamForUser(
     return membership
   }
 
-  const admin = cellFor(DEFAULT_REGION).createAdminClient()
-  const { data: team, error: teamErr } = await admin
-    .from("team")
-    .insert({ name: email })
-    .select("id")
-    .single()
+  // First login: no membership yet. Provision a team through the same full
+  // RBAC chain the create-team action uses — a legacy-only team (team +
+  // team_member, no team_memberships/role assignment) is one the console
+  // lists but the control plane 403s, so the user's first request fails.
+  const team = await provisionTeam(DEFAULT_REGION, userId, email, email)
 
-  if (teamErr) throw new Error(`Failed to create team: ${teamErr.message}`)
+  // The empty membership list we just read may be cached; drop it so other
+  // surfaces (billing, quota, directory) see the new team immediately.
+  invalidateMembershipDirectory(userId)
 
-  const { error: memberErr } = await admin.from("team_member").insert({
-    team_id: team.id,
-    profile_id: userId,
-    role: "owner",
-  })
-
-  if (memberErr)
-    throw new Error(`Failed to add team member: ${memberErr.message}`)
-
-  const created = { teamId: team.id as string, region: DEFAULT_REGION }
+  const created = { teamId: team.id, region: DEFAULT_REGION }
   setFresh(teamCache, cacheKey, created)
   return created
 }

--- a/apps/console/src/lib/api/team-provisioning.test.ts
+++ b/apps/console/src/lib/api/team-provisioning.test.ts
@@ -1,0 +1,124 @@
+/**
+ * team-provisioning — the single correct way to create a team.
+ *
+ * The control plane authorizes through the RBAC chain (team_memberships +
+ * user_role_assignments), so a team is only usable if the whole chain landed.
+ * These tests pin two things:
+ *  - the happy path writes every row into the target cell, and
+ *  - a mid-chain failure unwinds in reverse dependency order, so a half-
+ *    written team the console lists but the control plane rejects can't linger.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+let clients: Record<string, ReturnType<typeof recordingClient>> = {}
+
+// Records writes and deletes per table, and can be told to fail one table's
+// insert so the unwind path is exercised.
+function recordingClient(failTable?: string) {
+  const writes: Record<string, Array<Record<string, unknown>>> = {}
+  const deletes: string[] = []
+  const record = (table: string, row: Record<string, unknown>) => {
+    writes[table] = [...(writes[table] ?? []), row]
+  }
+  const result = (table: string) =>
+    failTable === table
+      ? { error: { message: `boom ${table}` } }
+      : { error: null }
+
+  const from = (table: string) => ({
+    upsert: async (row: Record<string, unknown>) => {
+      record(table, row)
+      return result(table)
+    },
+    insert: (row: Record<string, unknown>) => {
+      record(table, row)
+      if (table === "team") {
+        return {
+          select: () => ({
+            single: async () => ({
+              data: { id: "team-new", name: row.name },
+              error: result(table).error,
+            }),
+          }),
+        }
+      }
+      return Promise.resolve(result(table))
+    },
+    select: () => ({
+      eq: () => ({
+        single: async () => ({ data: { id: "role-owner" }, error: null }),
+      }),
+    }),
+    delete: () => ({
+      eq: async () => {
+        deletes.push(table)
+        return { error: null }
+      },
+    }),
+  })
+  return { from, writes, deletes }
+}
+
+vi.mock("@/lib/cells", () => ({
+  cellFor: (region: string) => ({
+    region,
+    createAdminClient: () => clients[region],
+  }),
+}))
+
+import { provisionTeam } from "./team-provisioning"
+
+describe("provisionTeam", () => {
+  beforeEach(() => {
+    clients = { use: recordingClient(), usw: recordingClient() }
+  })
+
+  it("writes the full RBAC chain into the target cell", async () => {
+    const team = await provisionTeam(
+      "usw",
+      "u1",
+      "user@example.com",
+      "west pilot",
+    )
+
+    expect(team).toEqual({ id: "team-new", name: "west pilot", region: "usw" })
+
+    const { writes } = clients.usw
+    expect(writes.profile).toEqual([{ id: "u1", email: "user@example.com" }])
+    expect(writes.team).toEqual([{ name: "west pilot", home_region: "usw" }])
+    expect(writes.team_member).toEqual([
+      { team_id: "team-new", profile_id: "u1", role: "owner" },
+    ])
+    expect(writes.team_memberships).toEqual([
+      { team_id: "team-new", user_id: "u1", status: "active" },
+    ])
+    expect(writes.user_role_assignments).toEqual([
+      {
+        user_id: "u1",
+        role_id: "role-owner",
+        scope_type: "team",
+        team_id: "team-new",
+      },
+    ])
+
+    // Nothing touched a cell other than the target.
+    expect(clients.use.writes).toEqual({})
+  })
+
+  it("unwinds in reverse dependency order when a chain write fails", async () => {
+    clients = { use: recordingClient("team_memberships") }
+
+    await expect(
+      provisionTeam("use", "u1", "user@example.com", "east team"),
+    ).rejects.toThrow(/boom team_memberships.*\(team team-new\)/)
+
+    // Reverse dependency order so nothing is deleted before its dependents.
+    expect(clients.use.deletes).toEqual([
+      "user_role_assignments",
+      "team_memberships",
+      "team_member",
+      "team",
+    ])
+  })
+})

--- a/apps/console/src/lib/api/team-provisioning.ts
+++ b/apps/console/src/lib/api/team-provisioning.ts
@@ -1,0 +1,134 @@
+import { cellFor } from "@/lib/cells"
+
+// Role granted to a team's creator. Seeded by the control-plane RBAC
+// migration in every cell; looked up by name so the id can differ per cell.
+const TEAM_OWNER_ROLE = "team_owner"
+
+export interface ProvisionedTeam {
+  id: string
+  name: string
+  region: string
+}
+
+/**
+ * Create a team homed in `region` and write everything the control plane
+ * needs to authorize `userId` as its owner, all in that cell: the profile
+ * row (auth is global but profile rows are per-cell), the team with
+ * home_region, the legacy team_member row the console's own lookups read,
+ * and the RBAC chain (active membership + team_owner assignment). Without the
+ * RBAC chain the console can list the team but the control plane rejects
+ * every request for it.
+ *
+ * This is the ONLY correct way to create a team: both the explicit
+ * create-team action and the first-login auto-provision route through it, so
+ * a new user can never end up with a legacy-only team the control plane 403s.
+ *
+ * Postgrest calls aren't a transaction, so a failure mid-chain is unwound in
+ * reverse dependency order — a partial team the console lists but the control
+ * plane rejects is worse than no team. A per-cell RPC doing the whole chain
+ * in one transaction is the durable replacement.
+ *
+ * ponytail: best-effort compensating unwind, not a real transaction —
+ * replace with a per-cell RPC if half-written teams start showing up.
+ *
+ * The caller owns authorization (who may create where) and cache
+ * invalidation; this only writes the rows.
+ */
+export async function provisionTeam(
+  region: string,
+  userId: string,
+  email: string,
+  name: string,
+): Promise<ProvisionedTeam> {
+  const admin = cellFor(region).createAdminClient()
+
+  // The user may have never touched this cell before; upsert so a concurrent
+  // create can't fail on the unique id.
+  const { error: profileErr } = await admin
+    .from("profile")
+    .upsert({ id: userId, email }, { onConflict: "id", ignoreDuplicates: true })
+  if (profileErr) {
+    throw new Error(`Failed to create profile: ${profileErr.message}`)
+  }
+
+  const { data: team, error: teamErr } = await admin
+    .from("team")
+    .insert({ name, home_region: region })
+    .select("id, name")
+    .single()
+  if (teamErr) throw new Error(`Failed to create team: ${teamErr.message}`)
+
+  try {
+    const { error: memberErr } = await admin.from("team_member").insert({
+      team_id: team.id,
+      profile_id: userId,
+      role: "owner",
+    })
+    if (memberErr) {
+      throw new Error(`Failed to add team member: ${memberErr.message}`)
+    }
+
+    // Membership must exist (and be active) before the role assignment — the
+    // control-plane schema enforces that ordering with a trigger.
+    const { error: membershipErr } = await admin
+      .from("team_memberships")
+      .insert({ team_id: team.id, user_id: userId, status: "active" })
+    if (membershipErr) {
+      throw new Error(
+        `Failed to create team membership: ${membershipErr.message}`,
+      )
+    }
+
+    const { data: role, error: roleErr } = await admin
+      .from("roles")
+      .select("id")
+      .eq("name", TEAM_OWNER_ROLE)
+      .single()
+    if (roleErr || !role) {
+      throw new Error(
+        `Failed to look up ${TEAM_OWNER_ROLE} role: ${roleErr?.message ?? "not found"}`,
+      )
+    }
+
+    const { error: assignErr } = await admin
+      .from("user_role_assignments")
+      .insert({
+        user_id: userId,
+        role_id: role.id,
+        scope_type: "team",
+        team_id: team.id,
+      })
+    if (assignErr) {
+      throw new Error(
+        `Failed to assign ${TEAM_OWNER_ROLE}: ${assignErr.message}`,
+      )
+    }
+  } catch (chainErr) {
+    // Best-effort unwind in reverse dependency order, so a mid-chain failure
+    // can't leave a team the console lists but the control plane rejects.
+    // Failures here are logged and the original error is surfaced with the
+    // team id for manual repair.
+    for (const [table, column] of [
+      ["user_role_assignments", "team_id"],
+      ["team_memberships", "team_id"],
+      ["team_member", "team_id"],
+      ["team", "id"],
+    ] as const) {
+      const { error: unwindErr } = await admin
+        .from(table)
+        .delete()
+        .eq(column, team.id)
+      if (unwindErr) {
+        console.error(
+          `provision-team unwind: failed to delete from ${table} for team ${team.id}: ${unwindErr.message}`,
+        )
+      }
+    }
+    throw new Error(
+      `${chainErr instanceof Error ? chainErr.message : String(chainErr)} (team ${team.id})`,
+      { cause: chainErr },
+    )
+  }
+
+  return { id: team.id as string, name: team.name as string, region }
+}

--- a/apps/console/src/lib/api/teams-actions.ts
+++ b/apps/console/src/lib/api/teams-actions.ts
@@ -14,18 +14,14 @@ import {
   listTeamsForUser,
   membershipExistsInCell,
 } from "@/lib/api/team-directory"
+import { provisionTeam } from "@/lib/api/team-provisioning"
 import {
-  cellFor,
   configuredRegions,
   creatableRegions,
   DEFAULT_REGION,
   multiCellUiEnabled,
 } from "@/lib/cells"
 import { createServerClient } from "@/lib/supabase/server"
-
-// Role granted to a team's creator. Seeded by the control-plane RBAC
-// migration in every cell; looked up by name so the id can differ per cell.
-const TEAM_OWNER_ROLE = "team_owner"
 
 export interface TeamSummary {
   id: string
@@ -120,12 +116,9 @@ export async function setActiveTeamAction(
 }
 
 /**
- * Create a team homed in the given cell. Everything the control plane needs
- * to authorize the creator is written in that cell: profile (auth is global
- * but profile rows are per-cell), team with home_region, the legacy
- * team_member row the console's own lookups read, and the RBAC chain
- * (active membership + team_owner assignment) — without which the control
- * plane rejects every request for the team.
+ * Create a team homed in the given cell. The full RBAC chain the control
+ * plane needs is written by `provisionTeam`; this action only enforces who
+ * may create where, then lands the creator in the new team.
  */
 export async function createTeamAction(
   name: string,
@@ -147,106 +140,12 @@ export async function createTeamAction(
     throw new Error(`Region ${targetRegion} is not available`)
   }
 
-  const admin = cellFor(targetRegion).createAdminClient()
-
-  // The user may have never touched this cell before; upsert so a concurrent
-  // create can't fail on the unique id.
-  const { error: profileErr } = await admin
-    .from("profile")
-    .upsert(
-      { id: user.id, email: user.email ?? user.id },
-      { onConflict: "id", ignoreDuplicates: true },
-    )
-  if (profileErr) {
-    throw new Error(`Failed to create profile: ${profileErr.message}`)
-  }
-
-  const { data: team, error: teamErr } = await admin
-    .from("team")
-    .insert({ name: trimmed, home_region: targetRegion })
-    .select("id, name")
-    .single()
-  if (teamErr) throw new Error(`Failed to create team: ${teamErr.message}`)
-
-  // Postgrest calls aren't a transaction, so a failure mid-chain would leave
-  // a team the console can list but the control plane rejects (no RBAC
-  // chain). Compensate by unwinding what was written; a per-cell RPC that
-  // does the whole chain in one transaction is the durable replacement.
-  try {
-    const { error: memberErr } = await admin.from("team_member").insert({
-      team_id: team.id,
-      profile_id: user.id,
-      role: "owner",
-    })
-    if (memberErr) {
-      throw new Error(`Failed to add team member: ${memberErr.message}`)
-    }
-
-    // Membership must exist (and be active) before the role assignment — the
-    // control-plane schema enforces that ordering with a trigger.
-    const { error: membershipErr } = await admin
-      .from("team_memberships")
-      .insert({
-        team_id: team.id,
-        user_id: user.id,
-        status: "active",
-      })
-    if (membershipErr) {
-      throw new Error(
-        `Failed to create team membership: ${membershipErr.message}`,
-      )
-    }
-
-    const { data: role, error: roleErr } = await admin
-      .from("roles")
-      .select("id")
-      .eq("name", TEAM_OWNER_ROLE)
-      .single()
-    if (roleErr || !role) {
-      throw new Error(
-        `Failed to look up ${TEAM_OWNER_ROLE} role: ${roleErr?.message ?? "not found"}`,
-      )
-    }
-
-    const { error: assignErr } = await admin
-      .from("user_role_assignments")
-      .insert({
-        user_id: user.id,
-        role_id: role.id,
-        scope_type: "team",
-        team_id: team.id,
-      })
-    if (assignErr) {
-      throw new Error(
-        `Failed to assign ${TEAM_OWNER_ROLE}: ${assignErr.message}`,
-      )
-    }
-  } catch (chainErr) {
-    // Best-effort unwind in reverse dependency order, so a mid-chain failure
-    // can't leave a team the console lists but the control plane rejects.
-    // Failures here are logged and the original error is surfaced with the
-    // team id for manual repair.
-    for (const [table, column] of [
-      ["user_role_assignments", "team_id"],
-      ["team_memberships", "team_id"],
-      ["team_member", "team_id"],
-      ["team", "id"],
-    ] as const) {
-      const { error: unwindErr } = await admin
-        .from(table)
-        .delete()
-        .eq(column, team.id)
-      if (unwindErr) {
-        console.error(
-          `create-team unwind: failed to delete from ${table} for team ${team.id}: ${unwindErr.message}`,
-        )
-      }
-    }
-    throw new Error(
-      `${chainErr instanceof Error ? chainErr.message : String(chainErr)} (team ${team.id})`,
-      { cause: chainErr },
-    )
-  }
+  const team = await provisionTeam(
+    targetRegion,
+    user.id,
+    user.email ?? user.id,
+    trimmed,
+  )
 
   // The user just gained a membership; drop their cached directory so the
   // very next read sees the new team instead of waiting out the TTL.
@@ -254,11 +153,7 @@ export async function createTeamAction(
 
   // Land the creator in the team they just made — the reason to create a
   // team is almost always to start working in it.
-  await storeTeamSelection({ region: targetRegion, teamId: team.id as string })
+  await storeTeamSelection({ region: targetRegion, teamId: team.id })
 
-  return {
-    id: team.id as string,
-    name: team.name as string,
-    region: targetRegion,
-  }
+  return { id: team.id, name: team.name, region: targetRegion }
 }


### PR DESCRIPTION
## Problem

A brand-new user (e.g. Google OAuth first login) lands on `/sandboxes` and immediately hits **"Something went wrong — You do not have permission to perform this action."** The auth callback provisions nothing, so the user has zero memberships; the first server-side request is what creates their team.

Every auto-provision path wrote only `team` (without `home_region`) + the legacy `team_member` row — **not** the RBAC chain (`team_memberships` + `user_role_assignments`) the control plane authorizes against. The result is exactly what `createTeamAction`'s own comment warns about: *"a team the console can list but the control plane rejects (no RBAC chain)"* → 403 on the user's first request.

This isn't new to the team-switcher PR — the incomplete auto-provision predates it. It surfaces now that RBAC `team_memberships` is the console's authorization boundary, so legacy-only teams get rejected.

## Fix

The root cause was **three divergent team-creation code paths, only one correct**. Extracted the full, correct chain into a single `provisionTeam()` helper (`team-provisioning.ts`) and routed all three call sites through it:

- `createTeamAction` (`teams-actions.ts`) — behavior unchanged (same full chain + transactional unwind), just deduplicated (~120 lines removed).
- `getTeamForUser`'s first-login fallback (`proxy-auth.ts`) — the path the sandboxes 403 came from. Now writes the full RBAC chain + `home_region`, and invalidates the membership directory cache so other surfaces see the new team immediately.
- `getOrCreateTeamForUser` (`api-keys-actions.ts`) — the same legacy-only bug on the API-keys surface. Now delegates to the helper.

`provisionTeam` is now the only way to create a team, so a new user can't end up with a legacy-only team on any surface.

## Tests

- New `team-provisioning.test.ts`: full-chain write into the target cell, and the previously-untested mid-chain-failure **unwind in reverse dependency order**.
- `proxy-auth.test.ts`: new-user path asserts `getTeamForUser` routes a memberless user through `provisionTeam`.
- Full console suite green (428 tests), typecheck + oxlint clean.

## Not in scope

Users who already got a legacy-only team from the old path will keep 403-ing until their missing RBAC rows are backfilled — a one-time data fix, separate from this code change.

> Note: the failing `docs:check-nav` CI job is unrelated and pre-existing on `main` (OpenAPI `GET /activity` missing from docs nav).