### PR TITLE
Add usw region routing to the SDKs and console data plane

### DIFF
--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -48,7 +48,7 @@ jobs:
         working-directory: packages/mcp
         run: |
           set -euo pipefail
-          MIN_SDK_VERSION="0.7.8"
+          MIN_SDK_VERSION="0.8.0"
           SDK_VERSION="$(npm view @superserve/sdk version)"
           test -n "$SDK_VERSION"
           if [ "$(printf '%s\n%s\n' "$MIN_SDK_VERSION" "$SDK_VERSION" | sort -V | head -n1)" != "$MIN_SDK_VERSION" ]; then

--- a/apps/console/src/components/sandboxes/preview-section.tsx
+++ b/apps/console/src/components/sandboxes/preview-section.tsx
@@ -21,14 +21,12 @@ import {
 } from "@/hooks/use-preview-ports"
 import type { SandboxResponse } from "@/lib/api/types"
 import { SANDBOX_EVENTS } from "@/lib/posthog/events"
-
-const SANDBOX_HOST =
-  process.env.NEXT_PUBLIC_SANDBOX_HOST ?? "sandbox.superserve.ai"
+import { sandboxHostFor } from "@/lib/sandbox-host"
 
 const DEFAULT_PORT_SUGGESTION = "3000"
 
 function previewUrl(sandboxId: string, port: number): string {
-  return `https://${port}-${sandboxId}.${SANDBOX_HOST}`
+  return `https://${port}-${sandboxId}.${sandboxHostFor(sandboxId)}`
 }
 
 interface PreviewSectionProps {

--- a/apps/console/src/components/sandboxes/terminal.tsx
+++ b/apps/console/src/components/sandboxes/terminal.tsx
@@ -13,6 +13,7 @@ import { usePostHog } from "posthog-js/react"
 import { useCallback, useEffect, useRef, useState } from "react"
 
 import { TERMINAL_EVENTS } from "@/lib/posthog/events"
+import { sandboxHostFor } from "@/lib/sandbox-host"
 import {
   clearTerminalBuffer,
   loadTerminalBuffer,
@@ -34,8 +35,6 @@ export type TerminalConnectionStatus =
 
 const encoder = new TextEncoder()
 const TERMINAL_SUBPROTOCOL = "superserve.terminal.v1"
-const SANDBOX_HOST =
-  process.env.NEXT_PUBLIC_SANDBOX_HOST ?? "sandbox.superserve.ai"
 const RESIZE_DEBOUNCE_MS = 75
 const RECONNECT_BASE_MS = 500
 const RECONNECT_MAX_MS = 10_000
@@ -187,7 +186,7 @@ export function SandboxTerminal({
       setStatus("connecting")
 
       try {
-        const url = `wss://boxd-${sandboxId}.${SANDBOX_HOST}/terminal`
+        const url = `wss://boxd-${sandboxId}.${sandboxHostFor(sandboxId)}/terminal`
         const ws = new WebSocket(url, [
           TERMINAL_SUBPROTOCOL,
           `token.${accessToken}`,

--- a/apps/console/src/lib/api/files.ts
+++ b/apps/console/src/lib/api/files.ts
@@ -2,7 +2,8 @@
  * files — data-plane file operations for the sandbox file manager.
  *
  * Byte transfer (read/write/upload/download) talks directly to the per-sandbox
- * data plane (`boxd-{id}.{SANDBOX_HOST}/files`) with the `X-Access-Token`.
+ * data plane (`boxd-{id}.{host}/files`, host per the sandbox's region) with
+ * the `X-Access-Token`.
  * Directory listing is metadata, so it goes through the control-plane API
  * (`apiClient`) instead — see `listDir`.
  *
@@ -12,9 +13,7 @@
 
 import { apiClient } from "@/lib/api/client"
 import type { SandboxResponse } from "@/lib/api/types"
-
-const SANDBOX_HOST =
-  process.env.NEXT_PUBLIC_SANDBOX_HOST ?? "sandbox.superserve.ai"
+import { sandboxHostFor } from "@/lib/sandbox-host"
 
 /** A single entry in a directory listing. */
 export interface DirEntry {
@@ -33,7 +32,7 @@ export function filesUrl(
   path: string,
   params?: Record<string, string>,
 ): string {
-  let url = `https://boxd-${sandboxId}.${SANDBOX_HOST}/files?path=${encodeURIComponent(path)}`
+  let url = `https://boxd-${sandboxId}.${sandboxHostFor(sandboxId)}/files?path=${encodeURIComponent(path)}`
   for (const [key, value] of Object.entries(params ?? {})) {
     url += `&${encodeURIComponent(key)}=${encodeURIComponent(value)}`
   }

--- a/apps/console/src/lib/sandbox-host.test.ts
+++ b/apps/console/src/lib/sandbox-host.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest"
+
+import { regionFromSandboxId, sandboxHostFor } from "./sandbox-host"
+
+const UUID = "1b4e28ba-2fa1-11d2-883f-0016d3cca427"
+
+describe("regionFromSandboxId", () => {
+  it("extracts the region token from a prefixed id", () => {
+    expect(regionFromSandboxId(`sb-usw-${UUID}`)).toBe("usw")
+    expect(regionFromSandboxId(`sb-use-${UUID}`)).toBe("use")
+  })
+
+  it("returns undefined for legacy/bare ids", () => {
+    expect(regionFromSandboxId(UUID)).toBeUndefined()
+    expect(regionFromSandboxId("sbx-1")).toBeUndefined()
+  })
+})
+
+describe("sandboxHostFor", () => {
+  it("routes a usw sandbox to the usw data-plane host", () => {
+    expect(sandboxHostFor(`sb-usw-${UUID}`)).toBe("usw-sandbox.superserve.ai")
+  })
+
+  it("routes the default cell and legacy ids to the default host, never the usw host", () => {
+    const legacy = sandboxHostFor(UUID)
+    const use = sandboxHostFor(`sb-use-${UUID}`)
+    expect(use).toBe(legacy)
+    expect(use).not.toBe("usw-sandbox.superserve.ai")
+  })
+})

--- a/apps/console/src/lib/sandbox-host.test.ts
+++ b/apps/console/src/lib/sandbox-host.test.ts
@@ -27,4 +27,11 @@ describe("sandboxHostFor", () => {
     expect(use).toBe(legacy)
     expect(use).not.toBe("usw-sandbox.superserve.ai")
   })
+
+  it("does not resolve an inherited object property as a region", () => {
+    // `constructor` matches the region-token shape and would return
+    // Object.prototype.constructor from a plain-object map; the Map returns
+    // undefined, so it falls through to the default host.
+    expect(sandboxHostFor(`sb-constructor-${UUID}`)).toBe(sandboxHostFor(UUID))
+  })
 })

--- a/apps/console/src/lib/sandbox-host.ts
+++ b/apps/console/src/lib/sandbox-host.ts
@@ -17,9 +17,9 @@
  * `use-sandbox` form; add it here once it does.
  */
 
-const REGION_SANDBOX_HOSTS: Record<string, string> = {
-  usw: "usw-sandbox.superserve.ai",
-}
+const REGION_SANDBOX_HOSTS = new Map<string, string>([
+  ["usw", "usw-sandbox.superserve.ai"],
+])
 
 const DEFAULT_SANDBOX_HOST =
   process.env.NEXT_PUBLIC_SANDBOX_HOST ?? "sandbox.superserve.ai"
@@ -32,5 +32,8 @@ export function regionFromSandboxId(sandboxId: string): string | undefined {
 /** The data-plane host to reach a sandbox, derived from its id's region. */
 export function sandboxHostFor(sandboxId: string): string {
   const region = regionFromSandboxId(sandboxId)
-  return (region && REGION_SANDBOX_HOSTS[region]) ?? DEFAULT_SANDBOX_HOST
+  return (
+    (region ? REGION_SANDBOX_HOSTS.get(region) : undefined) ??
+    DEFAULT_SANDBOX_HOST
+  )
 }

--- a/apps/console/src/lib/sandbox-host.ts
+++ b/apps/console/src/lib/sandbox-host.ts
@@ -1,0 +1,36 @@
+/**
+ * Data-plane host resolution for a sandbox, keyed off the region token in its
+ * public id (`sb-<region>-<uuid>`).
+ *
+ * Public sandbox ids carry their home cell (`sb-usw-…`), so every data-plane
+ * URL (files, terminal, preview) can resolve the right proxy host from the id
+ * alone — no team/region prop-threading, and it works in pure modules that
+ * can't call hooks.
+ *
+ * The default cell (`use`, and legacy un-prefixed ids) keeps honoring
+ * `NEXT_PUBLIC_SANDBOX_HOST` so staging/dev can point at `staging-sandbox…`.
+ * Non-default cells resolve to their own host and ignore that override — a
+ * `usw` sandbox is never reachable via the `use` proxy.
+ *
+ * Mirrors the SDK's region map (packages/sdk/src/config.ts). `use` stays on
+ * the legacy `sandbox.superserve.ai` host until its proxy also accepts the
+ * `use-sandbox` form; add it here once it does.
+ */
+
+const REGION_SANDBOX_HOSTS: Record<string, string> = {
+  usw: "usw-sandbox.superserve.ai",
+}
+
+const DEFAULT_SANDBOX_HOST =
+  process.env.NEXT_PUBLIC_SANDBOX_HOST ?? "sandbox.superserve.ai"
+
+/** Region token from a public sandbox id (`sb-<region>-<uuid>`), else undefined. */
+export function regionFromSandboxId(sandboxId: string): string | undefined {
+  return /^sb-([a-z0-9]{1,17})-/.exec(sandboxId)?.[1]
+}
+
+/** The data-plane host to reach a sandbox, derived from its id's region. */
+export function sandboxHostFor(sandboxId: string): string {
+  const region = regionFromSandboxId(sandboxId)
+  return (region && REGION_SANDBOX_HOSTS[region]) ?? DEFAULT_SANDBOX_HOST
+}

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -256,6 +256,8 @@ export function createSdkClient(config: ClientConfig): SandboxClient {
   // Region-resolved endpoints (key prefix → cell), the single source the SDK
   // uses internally — so our direct preview/network calls hit the same cell
   // as the SDK-backed sandbox ops instead of defaulting to the primary.
+  // resolveConfig is exported as of @superserve/sdk 0.8.0 — the current
+  // MIN_SDK_VERSION floor in mcp-publish.yml (max across features).
   const resolved = resolveConfig({
     apiKey: config.apiKey,
     baseUrl: config.baseUrl,

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -16,6 +16,7 @@
 import {
   AuthenticationError,
   NotFoundError,
+  resolveConfig,
   Sandbox,
   SandboxError,
   Secret,
@@ -42,7 +43,7 @@ import {
   parseLsOutput,
   validateAbsolutePath,
 } from "./lib/listing.js"
-import { buildPreviewUrl, DEFAULT_BASE_URL } from "./lib/previewUrl.js"
+import { buildPreviewUrl } from "./lib/previewUrl.js"
 
 /** Hang guard for the direct control-plane network-log GET. */
 const NETWORK_LOG_TIMEOUT_MS = 30_000
@@ -252,6 +253,13 @@ function toSecretSummary(s: SecretInfo): SecretSummary {
 /** Real client backed by `@superserve/sdk`. */
 export function createSdkClient(config: ClientConfig): SandboxClient {
   const conn = { apiKey: config.apiKey, baseUrl: config.baseUrl }
+  // Region-resolved endpoints (key prefix → cell), the single source the SDK
+  // uses internally — so our direct preview/network calls hit the same cell
+  // as the SDK-backed sandbox ops instead of defaulting to the primary.
+  const resolved = resolveConfig({
+    apiKey: config.apiKey,
+    baseUrl: config.baseUrl,
+  })
 
   return {
     async create(input) {
@@ -340,7 +348,7 @@ export function createSdkClient(config: ClientConfig): SandboxClient {
 
     // Pure string construction; no resume, no network call.
     previewUrl(id, port) {
-      return buildPreviewUrl(id, port, config.baseUrl)
+      return buildPreviewUrl(id, port, resolved.sandboxHost)
     },
 
     // Direct control-plane GET so reading the audit log never activates
@@ -349,7 +357,7 @@ export function createSdkClient(config: ClientConfig): SandboxClient {
     // non-resuming static equivalent. Trusted control-plane endpoint, API-key
     // auth, bounded by `limit` and a request timeout.
     async networkLog(id, opts) {
-      const base = config.baseUrl ?? DEFAULT_BASE_URL
+      const base = resolved.baseUrl
       const url = new URL(`${base}/sandboxes/${encodeURIComponent(id)}/network`)
       if (opts.limit !== undefined)
         url.searchParams.set("limit", String(opts.limit))

--- a/packages/mcp/src/lib/previewUrl.ts
+++ b/packages/mcp/src/lib/previewUrl.ts
@@ -17,7 +17,10 @@ const DEFAULT_SANDBOX_HOST = "sandbox.superserve.ai"
 /** Sandbox ids are UUIDs; refuse anything that could escape the hostname. */
 const SANDBOX_ID_RE = /^[A-Za-z0-9-]+$/
 
-const MIN_PORT = 1
+// Privileged ports (< 1024) are refused by the edge proxy, so a preview URL
+// targeting one would never route — reject up front. Matches the SDK's
+// MIN_PREVIEW_PORT so both builders agree on what can be reached.
+const MIN_PORT = 1024
 const MAX_PORT = 65535
 
 /** Raised for an out-of-range port or a malformed sandbox id. */
@@ -34,8 +37,8 @@ export class PreviewUrlError extends Error {
  * `sandboxHost` is the sandbox's data-plane host (region-resolved by the SDK's
  * `resolveConfig`); it defaults to the prod apex for callers without one.
  *
- * @throws {PreviewUrlError} when the port is not an integer in [1, 65535] or the
- * sandbox id contains characters that are not URL-host-safe.
+ * @throws {PreviewUrlError} when the port is not an integer in [1024, 65535] or
+ * the sandbox id contains characters that are not URL-host-safe.
  */
 export function buildPreviewUrl(
   sandboxId: string,

--- a/packages/mcp/src/lib/previewUrl.ts
+++ b/packages/mcp/src/lib/previewUrl.ts
@@ -7,13 +7,11 @@
  * internet-exposed. This is pure string construction (no network call); the URL
  * only resolves while the sandbox is active and a process is bound to the port.
  *
- * The host map mirrors the SDK's `deriveSandboxHost` (packages/sdk/src/config.ts)
- * — the data plane is `boxd-{id}.{host}`, previews are `{port}-{id}.{host}`. Keep
- * the two in sync if the platform host mapping ever changes.
+ * The data plane is `boxd-{id}.{host}` and previews are `{port}-{id}.{host}`,
+ * on the same `{host}` — the sandbox's region-resolved data-plane host, which
+ * the caller passes in (the SDK's `resolveConfig` is the single source for it).
  */
 
-/** Default control-plane base URL (mirrors the SDK). */
-export const DEFAULT_BASE_URL = "https://api.superserve.ai"
 const DEFAULT_SANDBOX_HOST = "sandbox.superserve.ai"
 
 /** Sandbox ids are UUIDs; refuse anything that could escape the hostname. */
@@ -31,26 +29,10 @@ export class PreviewUrlError extends Error {
 }
 
 /**
- * Derive the data-plane sandbox host from the control-plane base URL.
- * Mirrors the SDK so a preview URL lands on the same apex as the data plane.
- */
-export function deriveSandboxHost(baseUrl: string): string {
-  try {
-    const host = new URL(baseUrl).hostname
-    if (host === "api-staging.superserve.ai") {
-      return "staging-sandbox.superserve.ai"
-    }
-    if (host === "api.superserve.ai") {
-      return "sandbox.superserve.ai"
-    }
-  } catch {
-    // Invalid URL — fall through to the safe default.
-  }
-  return DEFAULT_SANDBOX_HOST
-}
-
-/**
  * Build the public preview URL for `port` on `sandboxId`.
+ *
+ * `sandboxHost` is the sandbox's data-plane host (region-resolved by the SDK's
+ * `resolveConfig`); it defaults to the prod apex for callers without one.
  *
  * @throws {PreviewUrlError} when the port is not an integer in [1, 65535] or the
  * sandbox id contains characters that are not URL-host-safe.
@@ -58,7 +40,7 @@ export function deriveSandboxHost(baseUrl: string): string {
 export function buildPreviewUrl(
   sandboxId: string,
   port: number,
-  baseUrl: string = DEFAULT_BASE_URL,
+  sandboxHost: string = DEFAULT_SANDBOX_HOST,
 ): string {
   if (!Number.isInteger(port) || port < MIN_PORT || port > MAX_PORT) {
     throw new PreviewUrlError(
@@ -68,5 +50,5 @@ export function buildPreviewUrl(
   if (!SANDBOX_ID_RE.test(sandboxId)) {
     throw new PreviewUrlError(`Invalid sandbox id: ${sandboxId}`)
   }
-  return `https://${port}-${sandboxId}.${deriveSandboxHost(baseUrl)}`
+  return `https://${port}-${sandboxId}.${sandboxHost}`
 }

--- a/packages/mcp/tests/previewUrl.test.ts
+++ b/packages/mcp/tests/previewUrl.test.ts
@@ -1,28 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import {
-  buildPreviewUrl,
-  deriveSandboxHost,
-  PreviewUrlError,
-} from "../src/lib/previewUrl.js"
-
-describe("deriveSandboxHost", () => {
-  it("maps prod and staging control planes to their sandbox apex", () => {
-    expect(deriveSandboxHost("https://api.superserve.ai")).toBe(
-      "sandbox.superserve.ai",
-    )
-    expect(deriveSandboxHost("https://api-staging.superserve.ai")).toBe(
-      "staging-sandbox.superserve.ai",
-    )
-  })
-
-  it("falls back to the prod sandbox host for unknown or invalid base URLs", () => {
-    expect(deriveSandboxHost("https://example.test")).toBe(
-      "sandbox.superserve.ai",
-    )
-    expect(deriveSandboxHost("not-a-url")).toBe("sandbox.superserve.ai")
-  })
-})
+import { buildPreviewUrl, PreviewUrlError } from "../src/lib/previewUrl.js"
 
 describe("buildPreviewUrl", () => {
   it("builds {port}-{id}.{host} on the default (prod) host", () => {
@@ -31,10 +9,13 @@ describe("buildPreviewUrl", () => {
     )
   })
 
-  it("uses the staging apex when given the staging base URL", () => {
+  it("uses the host it is given (region-resolved by the caller)", () => {
     expect(
-      buildPreviewUrl("a1b2c3", 4000, "https://api-staging.superserve.ai"),
+      buildPreviewUrl("a1b2c3", 4000, "staging-sandbox.superserve.ai"),
     ).toBe("https://4000-a1b2c3.staging-sandbox.superserve.ai")
+    expect(
+      buildPreviewUrl("sb-usw-a1b2c3", 3000, "usw-sandbox.superserve.ai"),
+    ).toBe("https://3000-sb-usw-a1b2c3.usw-sandbox.superserve.ai")
   })
 
   it("rejects out-of-range and non-integer ports", () => {

--- a/packages/mcp/tests/previewUrl.test.ts
+++ b/packages/mcp/tests/previewUrl.test.ts
@@ -25,12 +25,23 @@ describe("buildPreviewUrl", () => {
     expect(() => buildPreviewUrl("id", -1)).toThrow(PreviewUrlError)
   })
 
+  // Privileged ports (< 1024) are refused by the edge proxy, so a URL to one
+  // would never route — reject up front, matching the SDK's builder.
+  it("rejects privileged ports (< 1024)", () => {
+    expect(() => buildPreviewUrl("id", 80)).toThrow(PreviewUrlError)
+    expect(() => buildPreviewUrl("id", 1023)).toThrow(PreviewUrlError)
+    expect(buildPreviewUrl("id", 1024)).toBe(
+      "https://1024-id.sandbox.superserve.ai",
+    )
+  })
+
   // A sandbox id is caller-controlled; a `.`/`/`/`@` could re-point the host.
+  // Use a valid (>=1024) port so the id check is what rejects, not the port.
   it("rejects a sandbox id that is not host-safe", () => {
-    expect(() => buildPreviewUrl("evil.example.com", 80)).toThrow(
+    expect(() => buildPreviewUrl("evil.example.com", 8080)).toThrow(
       PreviewUrlError,
     )
-    expect(() => buildPreviewUrl("id/../../x", 80)).toThrow(PreviewUrlError)
-    expect(() => buildPreviewUrl("a@b", 80)).toThrow(PreviewUrlError)
+    expect(() => buildPreviewUrl("id/../../x", 8080)).toThrow(PreviewUrlError)
+    expect(() => buildPreviewUrl("a@b", 8080)).toThrow(PreviewUrlError)
   })
 })

--- a/packages/python-sdk/src/superserve/_config.py
+++ b/packages/python-sdk/src/superserve/_config.py
@@ -176,6 +176,7 @@ def _derive_sandbox_host(base_url: str) -> str:
 
     https://api.superserve.ai         -> sandbox.superserve.ai
     https://api-staging.superserve.ai -> staging-sandbox.superserve.ai
+    https://api-usw.superserve.ai     -> usw-sandbox.superserve.ai
     Any other URL                      -> sandbox.superserve.ai (safe default)
     """
     try:
@@ -183,6 +184,8 @@ def _derive_sandbox_host(base_url: str) -> str:
         host = parsed.hostname or ""
         if host == "api-staging.superserve.ai":
             return "staging-sandbox.superserve.ai"
+        if host == "api-usw.superserve.ai":
+            return "usw-sandbox.superserve.ai"
         if host == "api.superserve.ai":
             return DEFAULT_SANDBOX_HOST
     except ValueError:

--- a/packages/python-sdk/src/superserve/_config.py
+++ b/packages/python-sdk/src/superserve/_config.py
@@ -65,7 +65,12 @@ def resolve_config(
             "Missing API key. Pass `api_key` or set the "
             "SUPERSERVE_API_KEY environment variable."
         )
-    resolved_url = base_url or os.environ.get("SUPERSERVE_BASE_URL")
+    # A set-but-empty/whitespace override (SUPERSERVE_BASE_URL="" or "  ") is
+    # treated as unset, so it falls through to region derivation instead of
+    # becoming a broken empty base URL / silently bypassing region derivation
+    # for a region-tagged key.
+    _override = base_url or os.environ.get("SUPERSERVE_BASE_URL")
+    resolved_url = _override.strip() if _override and _override.strip() else None
     if resolved_url is not None:
         sandbox_host = _derive_sandbox_host(resolved_url)
     else:
@@ -83,7 +88,11 @@ def resolve_config(
     )
 
 
-# Sandbox hosts where the proxy supports shared-host routing.
+# Sandbox hosts where the proxy supports shared-host routing (shared origin +
+# X-Superserve-Sandbox-Id, server-side only). ``usw-sandbox.superserve.ai`` is
+# intentionally omitted for now: usw sandboxes route via the per-sandbox
+# subdomain (verified working) until the usw proxy's shared-host path is
+# confirmed — add it here once it is.
 _SUPPORTED_SHARED_HOSTS: frozenset[str] = frozenset(
     {
         "sandbox.superserve.ai",
@@ -174,20 +183,23 @@ def _region_from_api_key(api_key: str) -> str | None:
 def _derive_sandbox_host(base_url: str) -> str:
     """Derive the data-plane sandbox host from the control-plane base URL.
 
-    https://api.superserve.ai         -> sandbox.superserve.ai
+    Cells are matched off ``_KNOWN_REGIONS`` (which already pairs each base URL
+    with its sandbox host), so a new cell needs only its map entry -- no second
+    edit here. Staging is the one host that isn't a region cell, so it stays
+    special.
+
+    https://api.superserve.ai         -> sandbox.superserve.ai      (map: use)
+    https://api-usw.superserve.ai     -> usw-sandbox.superserve.ai  (map: usw)
     https://api-staging.superserve.ai -> staging-sandbox.superserve.ai
-    https://api-usw.superserve.ai     -> usw-sandbox.superserve.ai
     Any other URL                      -> sandbox.superserve.ai (safe default)
     """
     try:
-        parsed = urlparse(base_url)
-        host = parsed.hostname or ""
+        host = urlparse(base_url).hostname or ""
         if host == "api-staging.superserve.ai":
             return "staging-sandbox.superserve.ai"
-        if host == "api-usw.superserve.ai":
-            return "usw-sandbox.superserve.ai"
-        if host == "api.superserve.ai":
-            return DEFAULT_SANDBOX_HOST
+        for cell_base, cell_sandbox_host in _KNOWN_REGIONS.values():
+            if urlparse(cell_base).hostname == host:
+                return cell_sandbox_host
     except ValueError:
         pass
     return DEFAULT_SANDBOX_HOST

--- a/packages/python-sdk/src/superserve/_config.py
+++ b/packages/python-sdk/src/superserve/_config.py
@@ -19,8 +19,8 @@ DEFAULT_SANDBOX_HOST = "sandbox.superserve.ai"
 # API — DNS resolving is not the bar: superserve.ai has a catch-all wildcard,
 # so every derived hostname resolves and answers with a valid-TLS 404 from
 # the wrong infrastructure. Verify with a live /health check, not dig.
-# ``usw`` will be added once https://api-usw.superserve.ai /
-# usw-sandbox.superserve.ai serve their cell.
+# ``usw`` was added once https://api-usw.superserve.ai /
+# usw-sandbox.superserve.ai served their cell end-to-end.
 #
 # Legacy keys (``ss_live_<random>``) can never be misread as region-tagged:
 # both key formats embed the same fixed-length 32-char base64url random tail
@@ -31,6 +31,7 @@ DEFAULT_SANDBOX_HOST = "sandbox.superserve.ai"
 # regardless of how many regions ``_KNOWN_REGIONS`` ends up containing.
 _KNOWN_REGIONS: dict[str, tuple[str, str]] = {
     "use": ("https://api.superserve.ai", "sandbox.superserve.ai"),
+    "usw": ("https://api-usw.superserve.ai", "usw-sandbox.superserve.ai"),
 }
 
 # Region token in ``ss_live_<region>_<random>``: 1-17 lowercase alphanumeric

--- a/packages/python-sdk/tests/test_config.py
+++ b/packages/python-sdk/tests/test_config.py
@@ -74,9 +74,14 @@ class TestRegionDerivation:
         assert cfg.base_url == "https://api.superserve.ai"
         assert cfg.sandbox_host == "sandbox.superserve.ai"
 
-    def test_unknown_region_falls_back_to_default(self) -> None:
-        # `usw` won't enter the known-regions map until its DNS is live.
+    def test_usw_region_key_resolves_mapped_endpoints(self) -> None:
         cfg = resolve_config(api_key=f"ss_live_usw_{_TAIL}")
+        assert cfg.base_url == "https://api-usw.superserve.ai"
+        assert cfg.sandbox_host == "usw-sandbox.superserve.ai"
+
+    def test_unconfigured_region_falls_back_to_default(self) -> None:
+        # A syntactically valid region token that isn't in _KNOWN_REGIONS.
+        cfg = resolve_config(api_key=f"ss_live_apac_{_TAIL}")
         assert cfg.base_url == DEFAULT_BASE_URL
         assert cfg.sandbox_host == DEFAULT_SANDBOX_HOST
 

--- a/packages/python-sdk/tests/test_config.py
+++ b/packages/python-sdk/tests/test_config.py
@@ -167,6 +167,12 @@ class TestDeriveSandboxHost:
             == "staging-sandbox.superserve.ai"
         )
 
+    def test_usw(self) -> None:
+        assert (
+            _derive_sandbox_host("https://api-usw.superserve.ai")
+            == "usw-sandbox.superserve.ai"
+        )
+
     def test_other(self) -> None:
         assert (
             _derive_sandbox_host("https://custom.example.com") == DEFAULT_SANDBOX_HOST

--- a/packages/python-sdk/tests/test_config.py
+++ b/packages/python-sdk/tests/test_config.py
@@ -113,6 +113,20 @@ class TestRegionDerivation:
         cfg = resolve_config(api_key=f"ss_live_use_{_TAIL}")
         assert cfg.base_url == "https://env.example.com"
 
+    def test_empty_env_base_url_is_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A whitespace-only override must not shadow region derivation.
+        monkeypatch.setenv("SUPERSERVE_BASE_URL", "   ")
+        cfg = resolve_config(api_key=f"ss_live_usw_{_TAIL}")
+        assert cfg.base_url == "https://api-usw.superserve.ai"
+        assert cfg.sandbox_host == "usw-sandbox.superserve.ai"
+
+    def test_empty_explicit_base_url_is_unset(self) -> None:
+        cfg = resolve_config(api_key=f"ss_live_use_{_TAIL}", base_url="")
+        assert cfg.base_url == "https://api.superserve.ai"
+        assert cfg.sandbox_host == "sandbox.superserve.ai"
+
     def test_region_key_sourced_from_env_var(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superserve/sdk",
-  "version": "0.7.8",
+  "version": "0.8.0",
   "description": "TypeScript SDK for the Superserve sandbox API",
   "keywords": [
     "firecracker",

--- a/packages/sdk/src/config.ts
+++ b/packages/sdk/src/config.ts
@@ -199,6 +199,7 @@ export function previewUrl(
  *
  * `https://api.superserve.ai`         → `sandbox.superserve.ai`
  * `https://api-staging.superserve.ai` → `staging-sandbox.superserve.ai`
+ * `https://api-usw.superserve.ai`     → `usw-sandbox.superserve.ai`
  * Any other URL                        → `sandbox.superserve.ai` (safe default)
  */
 function deriveSandboxHost(baseUrl: string): string {
@@ -207,6 +208,9 @@ function deriveSandboxHost(baseUrl: string): string {
     const host = url.hostname
     if (host === "api-staging.superserve.ai") {
       return "staging-sandbox.superserve.ai"
+    }
+    if (host === "api-usw.superserve.ai") {
+      return "usw-sandbox.superserve.ai"
     }
     if (host === "api.superserve.ai") {
       return "sandbox.superserve.ai"

--- a/packages/sdk/src/config.ts
+++ b/packages/sdk/src/config.ts
@@ -18,8 +18,8 @@ const DEFAULT_SANDBOX_HOST = "sandbox.superserve.ai"
  * API — DNS resolving is not the bar: superserve.ai has a catch-all
  * wildcard, so every derived hostname resolves and answers with a
  * valid-TLS 404 from the wrong infrastructure. Verify with a live /health
- * check, not dig. `usw` will be added once `https://api-usw.superserve.ai`
- * / `usw-sandbox.superserve.ai` serve their cell.
+ * check, not dig. `usw` was added once `https://api-usw.superserve.ai`
+ * / `usw-sandbox.superserve.ai` served their cell end-to-end.
  *
  * Legacy keys (`ss_live_<random>`) can never be misread as region-tagged:
  * both key formats embed the same fixed-length 32-char base64url random
@@ -38,6 +38,13 @@ const KNOWN_REGIONS: ReadonlyMap<
     {
       baseUrl: "https://api.superserve.ai",
       sandboxHost: "sandbox.superserve.ai",
+    },
+  ],
+  [
+    "usw",
+    {
+      baseUrl: "https://api-usw.superserve.ai",
+      sandboxHost: "usw-sandbox.superserve.ai",
     },
   ],
 ])

--- a/packages/sdk/src/config.ts
+++ b/packages/sdk/src/config.ts
@@ -80,7 +80,12 @@ export function resolveConfig(opts?: {
       "Missing API key. Pass `apiKey` or set the SUPERSERVE_API_KEY environment variable.",
     )
   }
-  const overrideUrl = opts?.baseUrl ?? process.env.SUPERSERVE_BASE_URL
+  // A set-but-empty/whitespace override (e.g. SUPERSERVE_BASE_URL="") is treated
+  // as unset, so it falls through to region derivation instead of becoming a
+  // real override that yields an empty base URL (which throws in `new URL`) and
+  // silently bypasses region derivation for a region-tagged key.
+  const rawOverride = opts?.baseUrl ?? process.env.SUPERSERVE_BASE_URL
+  const overrideUrl = rawOverride?.trim() || undefined
   if (overrideUrl !== undefined) {
     return {
       apiKey,
@@ -114,7 +119,11 @@ function regionFromApiKey(apiKey: string): string | undefined {
   return REGION_KEY_RE.exec(apiKey)?.[1]
 }
 
-// Sandbox hosts where the proxy supports shared-host routing.
+// Sandbox hosts where the proxy supports shared-host routing (shared origin +
+// X-Superserve-Sandbox-Id, server-side only). `usw-sandbox.superserve.ai` is
+// intentionally omitted for now: usw sandboxes route via the per-sandbox
+// subdomain (verified working) until the usw proxy's shared-host path is
+// confirmed — add it here once it is.
 const SUPPORTED_SHARED_HOSTS: ReadonlySet<string> = new Set([
   "sandbox.superserve.ai",
   "staging-sandbox.superserve.ai",
@@ -197,23 +206,25 @@ export function previewUrl(
 /**
  * Derive the data-plane sandbox host from the control-plane base URL.
  *
- * `https://api.superserve.ai`         → `sandbox.superserve.ai`
+ * Cells are matched off `KNOWN_REGIONS` (which already pairs each base URL with
+ * its sandbox host), so a new cell needs only its map entry — no second edit
+ * here. Staging is the one host that isn't a region cell, so it stays special.
+ *
+ * `https://api.superserve.ai`         → `sandbox.superserve.ai`      (map: use)
+ * `https://api-usw.superserve.ai`     → `usw-sandbox.superserve.ai`  (map: usw)
  * `https://api-staging.superserve.ai` → `staging-sandbox.superserve.ai`
- * `https://api-usw.superserve.ai`     → `usw-sandbox.superserve.ai`
  * Any other URL                        → `sandbox.superserve.ai` (safe default)
  */
 function deriveSandboxHost(baseUrl: string): string {
   try {
-    const url = new URL(baseUrl)
-    const host = url.hostname
+    const host = new URL(baseUrl).hostname
     if (host === "api-staging.superserve.ai") {
       return "staging-sandbox.superserve.ai"
     }
-    if (host === "api-usw.superserve.ai") {
-      return "usw-sandbox.superserve.ai"
-    }
-    if (host === "api.superserve.ai") {
-      return "sandbox.superserve.ai"
+    for (const cell of KNOWN_REGIONS.values()) {
+      if (new URL(cell.baseUrl).hostname === host) {
+        return cell.sandboxHost
+      }
     }
   } catch {
     // Invalid URL — use default

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -2,7 +2,13 @@
  * Superserve SDK — sandbox infrastructure for running code in isolated cloud environments.
  */
 
-export { MAX_PREVIEW_PORT, MIN_PREVIEW_PORT, previewUrl } from "./config.js"
+export {
+  MAX_PREVIEW_PORT,
+  MIN_PREVIEW_PORT,
+  previewUrl,
+  resolveConfig,
+} from "./config.js"
+export type { ResolvedConfig } from "./config.js"
 export {
   AuthenticationError,
   BuildError,

--- a/packages/sdk/tests/config.test.ts
+++ b/packages/sdk/tests/config.test.ts
@@ -87,6 +87,14 @@ describe("resolveConfig", () => {
     expect(cfg.sandboxHost).toBe("staging-sandbox.superserve.ai")
   })
 
+  it("derives sandboxHost for an explicit usw base URL", () => {
+    const cfg = resolveConfig({
+      apiKey: "k",
+      baseUrl: "https://api-usw.superserve.ai",
+    })
+    expect(cfg.sandboxHost).toBe("usw-sandbox.superserve.ai")
+  })
+
   it("derives sandboxHost falls back to default for unknown URL", () => {
     const cfg = resolveConfig({
       apiKey: "k",

--- a/packages/sdk/tests/config.test.ts
+++ b/packages/sdk/tests/config.test.ts
@@ -173,6 +173,19 @@ describe("resolveConfig", () => {
     expect(cfg.baseUrl).toBe("https://env.example.com")
   })
 
+  it("treats an empty/whitespace SUPERSERVE_BASE_URL as unset (region still wins)", () => {
+    vi.stubEnv("SUPERSERVE_BASE_URL", "   ")
+    const cfg = resolveConfig({ apiKey: `ss_live_usw_${TAIL}` })
+    expect(cfg.baseUrl).toBe("https://api-usw.superserve.ai")
+    expect(cfg.sandboxHost).toBe("usw-sandbox.superserve.ai")
+  })
+
+  it("treats an explicit empty baseUrl option as unset", () => {
+    const cfg = resolveConfig({ apiKey: `ss_live_use_${TAIL}`, baseUrl: "" })
+    expect(cfg.baseUrl).toBe("https://api.superserve.ai")
+    expect(cfg.sandboxHost).toBe("sandbox.superserve.ai")
+  })
+
   it("derives endpoints from a region key sourced from SUPERSERVE_API_KEY", () => {
     vi.stubEnv("SUPERSERVE_API_KEY", `ss_live_use_${TAIL}`)
     const cfg = resolveConfig()

--- a/packages/sdk/tests/config.test.ts
+++ b/packages/sdk/tests/config.test.ts
@@ -101,9 +101,15 @@ describe("resolveConfig", () => {
     expect(cfg.sandboxHost).toBe("sandbox.superserve.ai")
   })
 
-  it("falls back to defaults for an unknown region", () => {
-    // `usw` won't enter the known-regions map until its DNS is live.
+  it("derives endpoints from the usw region key", () => {
     const cfg = resolveConfig({ apiKey: `ss_live_usw_${TAIL}` })
+    expect(cfg.baseUrl).toBe("https://api-usw.superserve.ai")
+    expect(cfg.sandboxHost).toBe("usw-sandbox.superserve.ai")
+  })
+
+  it("falls back to defaults for an unconfigured region", () => {
+    // A syntactically valid region token that isn't in KNOWN_REGIONS.
+    const cfg = resolveConfig({ apiKey: `ss_live_apac_${TAIL}` })
     expect(cfg.baseUrl).toBe("https://api.superserve.ai")
     expect(cfg.sandboxHost).toBe("sandbox.superserve.ai")
   })


### PR DESCRIPTION
Makes west-cell (`usw`) teams work from all three clients: SDKs, console, and MCP. Before this, a west team's key/console/MCP calls landed on the primary (us-east) cell, so their sandboxes were unreachable.

**SDKs** — add `usw` → `{api-usw.superserve.ai, usw-sandbox.superserve.ai}` to the known-regions map (TS + Python). A `usw`-prefixed key now self-routes to the west cell with no config; the endpoints were verified serving end-to-end (control plane, data plane, and the wrong-region 401). Legacy keys and pinned `base_url` are unchanged. Also exports `resolveConfig` so other packages can reuse the region resolution.

**Console** — data-plane URLs (terminal, files, preview) previously hardcoded `sandbox.superserve.ai`, so west sandboxes were unreachable from the UI. New `sandboxHostFor(sandboxId)` derives the host from the region in the public id (`sb-usw-…`). The default cell and legacy ids keep honoring `NEXT_PUBLIC_SANDBOX_HOST` (staging unaffected).

**MCP** — preview URLs and the network-log call went through the raw `config.baseUrl` and defaulted to the primary cell, so a `usw` key hit central. They now use the SDK's region-resolved endpoints, and MCP's duplicate host-derivation is deleted (single source of truth in the SDK).

**Review follow-ups in this PR:** bump `@superserve/sdk` to 0.8.0 and `MIN_SDK_VERSION` together (guards the new `resolveConfig` export so an MCP release can't ship against an older published SDK); normalize an empty/whitespace `SUPERSERVE_BASE_URL` to unset (was becoming a broken empty override); derive the explicit-base-URL → sandbox-host mapping from the region map so a new cell needs only its map entry; and align MCP's preview-port floor to the proxy's 1024 minimum.

Tests: SDK, Python, MCP, and console suites green; typecheck clean.