### PR TITLE
python-sdk: bump to 0.8.0 to match the TS SDK region release

### DIFF
--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "superserve"
-version = "0.7.8"
+version = "0.8.0"
 description = "Python SDK for the Superserve sandbox API"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## Summary
One version alignment left over from #275 (the `MIN_SDK_VERSION` bump to 0.8.0 already landed there): the Python SDK bumps to 0.8.0, since it ships the same new region-routing code as the TS SDK's 0.8.0 and a PyPI release can't go out on the old version.

## Testing
Version metadata only; no code paths change.