### PR TITLE
sdk: usw joins the shared-host data-plane path

### DIFF
--- a/packages/python-sdk/src/superserve/_config.py
+++ b/packages/python-sdk/src/superserve/_config.py
@@ -90,13 +90,11 @@ def resolve_config(
 
 # Sandbox hosts where the proxy supports shared-host routing (shared origin +
 # X-Superserve-Sandbox-Id, server-side only). ``usw-sandbox.superserve.ai`` is
-# intentionally omitted for now: usw sandboxes route via the per-sandbox
-# subdomain (verified working) until the usw proxy's shared-host path is
-# confirmed — add it here once it is.
 _SUPPORTED_SHARED_HOSTS: frozenset[str] = frozenset(
     {
         "sandbox.superserve.ai",
         "staging-sandbox.superserve.ai",
+        "usw-sandbox.superserve.ai",
     }
 )
 

--- a/packages/python-sdk/tests/test_config.py
+++ b/packages/python-sdk/tests/test_config.py
@@ -203,6 +203,16 @@ class TestDataPlaneTarget:
         assert target.url == "https://sandbox.superserve.ai"
         assert target.headers["X-Superserve-Sandbox-Id"] == "abc-123"
 
+    def test_every_launched_region_uses_shared_origin(self) -> None:
+        # Extend per cell launch: a region resolvable from a key must also
+        # take the pooled shared-origin path server-side, or its data-plane
+        # traffic silently downgrades to per-sandbox TLS origins.
+        for region in ("use", "usw"):
+            config = resolve_config(api_key=f"ss_live_{region}_{'a' * 32}")
+            target = data_plane_target("abc-123", config.sandbox_host)
+            assert target.url == f"https://{config.sandbox_host}"
+            assert target.headers["X-Superserve-Sandbox-Id"] == "abc-123"
+
     def test_shared_host_on_staging(self) -> None:
         target = data_plane_target("xyz", "staging-sandbox.superserve.ai")
         assert target.url == "https://staging-sandbox.superserve.ai"

--- a/packages/sdk/src/config.ts
+++ b/packages/sdk/src/config.ts
@@ -121,12 +121,10 @@ function regionFromApiKey(apiKey: string): string | undefined {
 
 // Sandbox hosts where the proxy supports shared-host routing (shared origin +
 // X-Superserve-Sandbox-Id, server-side only). `usw-sandbox.superserve.ai` is
-// intentionally omitted for now: usw sandboxes route via the per-sandbox
-// subdomain (verified working) until the usw proxy's shared-host path is
-// confirmed — add it here once it is.
 const SUPPORTED_SHARED_HOSTS: ReadonlySet<string> = new Set([
   "sandbox.superserve.ai",
   "staging-sandbox.superserve.ai",
+  "usw-sandbox.superserve.ai",
 ])
 
 const SANDBOX_ID_HEADER = "X-Superserve-Sandbox-Id"

--- a/packages/sdk/tests/config.test.ts
+++ b/packages/sdk/tests/config.test.ts
@@ -207,6 +207,20 @@ describe("dataPlaneTarget", () => {
     expect(target.headers["X-Superserve-Sandbox-Id"]).toBe("xyz")
   })
 
+  it("routes every launched region's sandbox host via the shared origin", () => {
+    // Extend per cell launch: a region resolvable from a key must also take
+    // the pooled shared-origin path server-side, or its data-plane traffic
+    // silently downgrades to per-sandbox TLS origins.
+    for (const region of ["use", "usw"]) {
+      const { sandboxHost } = resolveConfig({
+        apiKey: `ss_live_${region}_${"a".repeat(32)}`,
+      })
+      const target = dataPlaneTarget("abc-123", sandboxHost)
+      expect(target.url).toBe(`https://${sandboxHost}`)
+      expect(target.headers["X-Superserve-Sandbox-Id"]).toBe("abc-123")
+    }
+  })
+
   it("falls back to per-sandbox subdomain on unsupported host", () => {
     const target = dataPlaneTarget("abc", "self-hosted.example.org")
     expect(target.url).toBe("https://boxd-abc.self-hosted.example.org")


### PR DESCRIPTION
## Summary
Adds `usw-sandbox.superserve.ai` to both SDKs' shared-host sets, so server-side data-plane traffic for usw sandboxes uses the pooled shared origin + routing header instead of a distinct TLS origin per sandbox. The comment guarding this entry asked for the usw proxy's shared-host path to be confirmed first — that's now done:

- **Root cause of it not working before**: the data-plane LB's host rule `*.usw-sandbox.superserve.ai` doesn't match the apex hostname, so shared-host requests fell through to the default (use) backend and got its "invalid sandbox URL". Fixed by adding explicit apex host rules to the URL map (also made the use/legacy apexes explicit rather than relying on the default backend coincidentally being right).
- **Verification**: header-routed `POST /exec` with `X-Superserve-Sandbox-Id` against a running usw sandbox via `https://usw-sandbox.superserve.ai` returns the command output end-to-end.

## Technical decisions
Rather than exporting the private region map for an invariant test, both SDKs pin the behavior through the public API: for every launched region, a key of that region must resolve to a sandbox host that `dataPlaneTarget` routes via the shared origin. The test list extends per cell launch.

## Testing
TS SDK: 221 tests green (13 files). Python SDK: 54 green. Live shared-origin exec verified against the usw cell as above.