### PR TITLE
console: render plan-usage charts with dither-kit area charts

### DIFF
--- a/apps/console/components.json
+++ b/apps/console/components.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "src/app/globals.css",
+    "baseColor": "neutral",
+    "cssVariables": true
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  }
+}

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -32,7 +32,10 @@
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
+    "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "d3-scale": "^4.0.2",
+    "d3-shape": "^3.2.0",
     "motion": "^12.0.0",
     "next": "^16.1.6",
     "posthog-js": "^1.353.0",
@@ -40,6 +43,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "resend": "^6.9.2",
+    "tailwind-merge": "^3.6.0",
     "zod": "^3.25.67"
   },
   "devDependencies": {
@@ -49,6 +53,8 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
+    "@types/d3-scale": "^4.0.9",
+    "@types/d3-shape": "^3.1.7",
     "@types/node": "^25.2.3",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/apps/console/src/app/(dashboard)/plan-usage/page-client.tsx
+++ b/apps/console/src/app/(dashboard)/plan-usage/page-client.tsx
@@ -17,6 +17,12 @@ import { useRouter } from "next/navigation"
 import { useMemo, useState } from "react"
 
 import { DateRangeFilter, type DateRange } from "@/components/date-range-filter"
+import { Area } from "@/components/dither-kit/area"
+import { AreaChart } from "@/components/dither-kit/area-chart"
+import { Grid } from "@/components/dither-kit/grid"
+import { Tooltip } from "@/components/dither-kit/tooltip"
+import { XAxis } from "@/components/dither-kit/x-axis"
+import { YAxis } from "@/components/dither-kit/y-axis"
 import { EmptyState } from "@/components/empty-state"
 import { ErrorState } from "@/components/error-state"
 import { PageHeader } from "@/components/page-header"
@@ -249,7 +255,6 @@ export function PlanUsagePageClient() {
               periodEnd={chartPeriod.end}
               bucket={chartBucket}
               valueLabel="vCPU"
-              strokeClassName="text-success"
               metric="vcpu"
             />
             <UsageChartCard
@@ -260,7 +265,6 @@ export function PlanUsagePageClient() {
               periodEnd={chartPeriod.end}
               bucket={chartBucket}
               valueLabel="GiB"
-              strokeClassName="text-success"
               metric="memory"
             />
             <UsageChartCard
@@ -271,7 +275,6 @@ export function PlanUsagePageClient() {
               periodEnd={chartPeriod.end}
               bucket={chartBucket}
               valueLabel="GiB"
-              strokeClassName="text-success"
               metric="storage"
             />
           </div>
@@ -281,11 +284,13 @@ export function PlanUsagePageClient() {
   )
 }
 
-function formatChartTick(value: string): string {
-  return new Date(value).toLocaleString("en-US", {
-    month: "short",
-    day: "numeric",
-  })
+function formatBucketLabel(value: string, bucketLabel: string): string {
+  return new Date(value).toLocaleString(
+    "en-US",
+    bucketLabel.includes("hour")
+      ? { month: "short", day: "numeric", hour: "numeric", hour12: true }
+      : { month: "short", day: "numeric" },
+  )
 }
 
 function UsageChartCard({
@@ -296,7 +301,6 @@ function UsageChartCard({
   periodEnd,
   bucket,
   valueLabel,
-  strokeClassName,
   metric,
 }: {
   title: string
@@ -306,43 +310,19 @@ function UsageChartCard({
   periodEnd: string
   bucket: UsageChartBucket
   valueLabel: string
-  strokeClassName: string
   metric: UsageMetric
 }) {
-  const width = 360
-  const height = 190
-  const padding = { top: 16, right: 12, bottom: 34, left: 44 }
-  const plotWidth = width - padding.left - padding.right
-  const plotHeight = height - padding.top - padding.bottom
-  const periodStartMs = new Date(periodStart).getTime()
-  const periodEndMs = new Date(periodEnd).getTime()
-  const periodMs = Math.max(periodEndMs - periodStartMs, 1)
-  const chartPoints = buildUsageChartPoints({
+  const chartData = buildUsageChartPoints({
     rows,
     periodStart,
     periodEnd,
     metric,
     bucketMs: bucket.ms,
-  })
-  const values = chartPoints.map((point) => point.value)
-  const maxValue = Math.max(...values, 0)
-  const yMax = maxValue > 0 ? maxValue : 1
-  const yTicks = [yMax, yMax / 2, 0]
-
-  const points = chartPoints.map((point) => {
-    const value = point.value
-    const bucketStartMs = new Date(point.bucket_start).getTime()
-    const x =
-      padding.left +
-      Math.min(Math.max((bucketStartMs - periodStartMs) / periodMs, 0), 1) *
-        plotWidth
-    const y = padding.top + (1 - value / yMax) * plotHeight
-    return { x, y, value, bucketStart: point.bucket_start }
-  })
-  const path = points
-    .map((point, index) => `${index === 0 ? "M" : "L"} ${point.x} ${point.y}`)
-    .join(" ")
-  const latestPoint = points[points.length - 1]
+  }).map((point) => ({
+    value: point.value,
+    label: formatBucketLabel(point.bucket_start, bucket.label),
+  }))
+  const latestPoint = chartData[chartData.length - 1]
 
   return (
     <Card>
@@ -359,88 +339,22 @@ function UsageChartCard({
             Latest {valueLabel}
           </p>
         </div>
-        <svg
-          className={`h-48 w-full overflow-visible ${strokeClassName}`}
-          viewBox={`0 0 ${width} ${height}`}
-          aria-label={`${title} ${bucket.label} line graph`}
-        >
-          <title>{`${title} ${bucket.label} line graph`}</title>
-          {yTicks.map((tick) => {
-            const y = padding.top + (1 - tick / yMax) * plotHeight
-            return (
-              <g key={tick}>
-                <line
-                  x1={padding.left}
-                  x2={width - padding.right}
-                  y1={y}
-                  y2={y}
-                  className="stroke-border"
-                  strokeDasharray="3 4"
-                />
-                <text
-                  x={padding.left - 10}
-                  y={y + 4}
-                  textAnchor="end"
-                  className="fill-muted font-mono text-[10px]"
-                >
-                  {formatNumber(tick)}
-                </text>
-              </g>
-            )
-          })}
-          <line
-            x1={padding.left}
-            x2={padding.left}
-            y1={padding.top}
-            y2={height - padding.bottom}
-            className="stroke-border"
-          />
-          <line
-            x1={padding.left}
-            x2={width - padding.right}
-            y1={height - padding.bottom}
-            y2={height - padding.bottom}
-            className="stroke-border"
-          />
-          {path && (
-            <path
-              d={path}
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          )}
-          {latestPoint && (
-            <circle
-              cx={latestPoint.x}
-              cy={latestPoint.y}
-              r="4"
-              fill="currentColor"
-              stroke="var(--color-surface)"
-              strokeWidth="2"
-            />
-          )}
-          <text
-            x={padding.left}
-            y={height - 8}
-            textAnchor="start"
-            className="fill-muted font-mono text-[10px]"
-            suppressHydrationWarning
+        <div className="h-48" aria-label={`${title} ${bucket.label} chart`}>
+          <AreaChart
+            data={chartData}
+            config={{ value: { label: valueLabel, color: "green" } }}
+            bloom="low"
           >
-            {formatChartTick(periodStart)}
-          </text>
-          <text
-            x={width - padding.right}
-            y={height - 8}
-            textAnchor="end"
-            className="fill-muted font-mono text-[10px]"
-            suppressHydrationWarning
-          >
-            {formatChartTick(periodEnd)}
-          </text>
-        </svg>
+            <Grid />
+            <XAxis dataKey="label" maxTicks={4} />
+            <YAxis tickFormatter={formatNumber} />
+            <Tooltip
+              labelKey="label"
+              valueFormatter={(value) => formatNumber(value)}
+            />
+            <Area dataKey="value" variant="gradient" />
+          </AreaChart>
+        </div>
       </CardContent>
     </Card>
   )

--- a/apps/console/src/app/(dashboard)/plan-usage/page-client.tsx
+++ b/apps/console/src/app/(dashboard)/plan-usage/page-client.tsx
@@ -321,6 +321,10 @@ function UsageChartCard({
   }).map((point) => ({
     value: point.value,
     label: formatBucketLabel(point.bucket_start, bucket.label),
+    day: new Date(point.bucket_start).toLocaleString("en-US", {
+      month: "short",
+      day: "numeric",
+    }),
   }))
   const latestPoint = chartData[chartData.length - 1]
 
@@ -346,7 +350,7 @@ function UsageChartCard({
             bloom="low"
           >
             <Grid />
-            <XAxis dataKey="label" maxTicks={4} />
+            <XAxis dataKey="day" maxTicks={4} />
             <YAxis tickFormatter={formatNumber} />
             <Tooltip
               labelKey="label"

--- a/apps/console/src/app/(dashboard)/plan-usage/page-client.tsx
+++ b/apps/console/src/app/(dashboard)/plan-usage/page-client.tsx
@@ -20,6 +20,7 @@ import { DateRangeFilter, type DateRange } from "@/components/date-range-filter"
 import { Area } from "@/components/dither-kit/area"
 import { AreaChart } from "@/components/dither-kit/area-chart"
 import { Grid } from "@/components/dither-kit/grid"
+import { Sparkline } from "@/components/dither-kit/sparkline"
 import { Tooltip } from "@/components/dither-kit/tooltip"
 import { XAxis } from "@/components/dither-kit/x-axis"
 import { YAxis } from "@/components/dither-kit/y-axis"
@@ -143,6 +144,14 @@ export function PlanUsagePageClient() {
   )
   const estimateLabel =
     data?.billing_mode === "active" ? "Estimated spend" : "Preview estimate"
+  const sparkFor = (metric: UsageMetric) =>
+    buildUsageChartPoints({
+      rows,
+      periodStart: chartPeriod.start,
+      periodEnd: chartPeriod.end,
+      metric,
+      bucketMs: chartBucket.ms,
+    }).map((point) => point.value)
 
   return (
     <div className="flex h-full flex-col">
@@ -207,6 +216,7 @@ export function PlanUsagePageClient() {
               rate={`${formatRate(pricing.cpu_vcpu_hour_usd)} / vCPU-hour`}
               estimateLabel={estimateLabel}
               estimate={formatCurrency(estimates.cpuUsd)}
+              spark={sparkFor("vcpu")}
             />
             <UsageCard
               title="Memory Usage"
@@ -214,6 +224,7 @@ export function PlanUsagePageClient() {
               rate={`${formatRate(pricing.memory_gib_hour_usd)} / GiB-hour`}
               estimateLabel={estimateLabel}
               estimate={formatCurrency(estimates.memoryUsd)}
+              spark={sparkFor("memory")}
             />
             <UsageCard
               title="Active Storage"
@@ -221,6 +232,7 @@ export function PlanUsagePageClient() {
               rate={`${formatRate(pricing.storage_gib_hour_usd)} / GiB-hour`}
               estimateLabel={estimateLabel}
               estimate={formatCurrency(estimates.storageUsd)}
+              spark={sparkFor("storage")}
             />
           </div>
 
@@ -370,12 +382,14 @@ function UsageCard({
   rate,
   estimateLabel,
   estimate,
+  spark,
 }: {
   title: string
   usage: string
   rate: string
   estimateLabel: string
   estimate: string
+  spark: number[]
 }) {
   return (
     <Card>
@@ -388,6 +402,11 @@ function UsageCard({
         <p className="text-sm text-foreground">
           {estimateLabel}: <span className="font-mono text-lg">{estimate}</span>
         </p>
+        {spark.length > 1 && (
+          <div className="h-8" aria-hidden>
+            <Sparkline data={spark} color="green" bloomOnHover bloom="low" />
+          </div>
+        )}
       </CardContent>
     </Card>
   )

--- a/apps/console/src/app/(dashboard)/plan-usage/page-client.tsx
+++ b/apps/console/src/app/(dashboard)/plan-usage/page-client.tsx
@@ -20,7 +20,6 @@ import { DateRangeFilter, type DateRange } from "@/components/date-range-filter"
 import { Area } from "@/components/dither-kit/area"
 import { AreaChart } from "@/components/dither-kit/area-chart"
 import { Grid } from "@/components/dither-kit/grid"
-import { Sparkline } from "@/components/dither-kit/sparkline"
 import { Tooltip } from "@/components/dither-kit/tooltip"
 import { XAxis } from "@/components/dither-kit/x-axis"
 import { YAxis } from "@/components/dither-kit/y-axis"
@@ -144,14 +143,6 @@ export function PlanUsagePageClient() {
   )
   const estimateLabel =
     data?.billing_mode === "active" ? "Estimated spend" : "Preview estimate"
-  const sparkFor = (metric: UsageMetric) =>
-    buildUsageChartPoints({
-      rows,
-      periodStart: chartPeriod.start,
-      periodEnd: chartPeriod.end,
-      metric,
-      bucketMs: chartBucket.ms,
-    }).map((point) => point.value)
 
   return (
     <div className="flex h-full flex-col">
@@ -216,7 +207,6 @@ export function PlanUsagePageClient() {
               rate={`${formatRate(pricing.cpu_vcpu_hour_usd)} / vCPU-hour`}
               estimateLabel={estimateLabel}
               estimate={formatCurrency(estimates.cpuUsd)}
-              spark={sparkFor("vcpu")}
             />
             <UsageCard
               title="Memory Usage"
@@ -224,7 +214,6 @@ export function PlanUsagePageClient() {
               rate={`${formatRate(pricing.memory_gib_hour_usd)} / GiB-hour`}
               estimateLabel={estimateLabel}
               estimate={formatCurrency(estimates.memoryUsd)}
-              spark={sparkFor("memory")}
             />
             <UsageCard
               title="Active Storage"
@@ -232,7 +221,6 @@ export function PlanUsagePageClient() {
               rate={`${formatRate(pricing.storage_gib_hour_usd)} / GiB-hour`}
               estimateLabel={estimateLabel}
               estimate={formatCurrency(estimates.storageUsd)}
-              spark={sparkFor("storage")}
             />
           </div>
 
@@ -382,14 +370,12 @@ function UsageCard({
   rate,
   estimateLabel,
   estimate,
-  spark,
 }: {
   title: string
   usage: string
   rate: string
   estimateLabel: string
   estimate: string
-  spark: number[]
 }) {
   return (
     <Card>
@@ -402,11 +388,6 @@ function UsageCard({
         <p className="text-sm text-foreground">
           {estimateLabel}: <span className="font-mono text-lg">{estimate}</span>
         </p>
-        {spark.length > 1 && (
-          <div className="h-8" aria-hidden>
-            <Sparkline data={spark} color="green" bloomOnHover bloom="low" />
-          </div>
-        )}
       </CardContent>
     </Card>
   )

--- a/apps/console/src/components/dither-background.tsx
+++ b/apps/console/src/components/dither-background.tsx
@@ -81,19 +81,11 @@ void main() {
   float dithered = step(threshold, n * 0.7);
 
   // Charcoal dots shifting toward brand mint (#b2fab4) inside the pockets
-  vec3 mint = vec3(0.698, 0.980, 0.706);
   vec3 greyDot = vec3(0.16);
-  vec3 dotColor = mix(greyDot, mint * 0.5, glow);
-  vec3 color = vec3(0.015) + dithered * dotColor;
+  vec3 mintDot = vec3(0.698, 0.980, 0.706) * 0.5;
+  vec3 dotColor = mix(greyDot, mintDot, glow);
 
-  // Winking sparkles, like the chart stars: rare cells of the same dither
-  // grid glint mint, each on its own phase
-  vec2 cell = floor(gl_FragCoord.xy / 3.0);
-  float h = fract(sin(dot(cell, vec2(127.1, 311.7))) * 43758.5453);
-  float wink = (sin(u_time * 1.5 + h * 6283.185) + 1.0) * 0.5;
-  color += mint * step(0.9998, h) * wink * wink * 0.8;
-
-  fragColor = vec4(color, 1.0);
+  fragColor = vec4(vec3(0.015) + dithered * dotColor, 1.0);
 }
 `
 

--- a/apps/console/src/components/dither-background.tsx
+++ b/apps/console/src/components/dither-background.tsx
@@ -72,13 +72,20 @@ void main() {
   // Slow-moving gradient via noise
   float n = snoise(uv * 2.0 + t) * 0.5 + 0.5;
 
+  // Second, slower field carves drifting pockets where dots turn mint
+  float glow = snoise(uv * 1.3 - t * 0.6 + 7.0) * 0.5 + 0.5;
+  glow = smoothstep(0.5, 0.95, glow);
+
   // Dither the gradient with Bayer matrix — scale up for visible dots
   float threshold = bayer8(floor(gl_FragCoord.xy / 3.0));
   float dithered = step(threshold, n * 0.7);
 
-  // Background base with dithered highlights
-  float brightness = 0.015 + dithered * 0.18;
-  fragColor = vec4(vec3(brightness), 1.0);
+  // Charcoal dots shifting toward brand mint (#b2fab4) inside the pockets
+  vec3 greyDot = vec3(0.16);
+  vec3 mintDot = vec3(0.698, 0.980, 0.706) * 0.5;
+  vec3 dotColor = mix(greyDot, mintDot, glow);
+
+  fragColor = vec4(vec3(0.015) + dithered * dotColor, 1.0);
 }
 `
 
@@ -92,6 +99,7 @@ function createShader(
   gl.shaderSource(shader, source)
   gl.compileShader(shader)
   if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    console.error("DitherBackground shader:", gl.getShaderInfoLog(shader))
     gl.deleteShader(shader)
     return null
   }

--- a/apps/console/src/components/dither-background.tsx
+++ b/apps/console/src/components/dither-background.tsx
@@ -81,11 +81,19 @@ void main() {
   float dithered = step(threshold, n * 0.7);
 
   // Charcoal dots shifting toward brand mint (#b2fab4) inside the pockets
+  vec3 mint = vec3(0.698, 0.980, 0.706);
   vec3 greyDot = vec3(0.16);
-  vec3 mintDot = vec3(0.698, 0.980, 0.706) * 0.5;
-  vec3 dotColor = mix(greyDot, mintDot, glow);
+  vec3 dotColor = mix(greyDot, mint * 0.5, glow);
+  vec3 color = vec3(0.015) + dithered * dotColor;
 
-  fragColor = vec4(vec3(0.015) + dithered * dotColor, 1.0);
+  // Winking sparkles, like the chart stars: rare cells of the same dither
+  // grid glint mint, each on its own phase
+  vec2 cell = floor(gl_FragCoord.xy / 3.0);
+  float h = fract(sin(dot(cell, vec2(127.1, 311.7))) * 43758.5453);
+  float wink = (sin(u_time * 1.5 + h * 6283.185) + 1.0) * 0.5;
+  color += mint * step(0.9998, h) * wink * wink * 0.8;
+
+  fragColor = vec4(color, 1.0);
 }
 `
 

--- a/apps/console/src/components/dither-kit/area-chart.tsx
+++ b/apps/console/src/components/dither-kit/area-chart.tsx
@@ -1,0 +1,22 @@
+"use client"
+
+import { CartesianCanvas } from "./cartesian-canvas"
+import { type CartesianChartProps, CartesianRoot } from "./cartesian-root"
+
+type Row = Record<string, unknown>
+
+/** Composable dither **area** chart. Compose `<Area>`, `<Grid>`, axes, … inside. */
+export function AreaChart<TData extends Row>(
+  props: CartesianChartProps<TData>,
+) {
+  return <CartesianRoot chartType="area" Canvas={CartesianCanvas} {...props} />
+}
+
+/** Composable dither **line** chart — `<Line>` series with a glow under the line. */
+export function LineChart<TData extends Row>(
+  props: CartesianChartProps<TData>,
+) {
+  return <CartesianRoot chartType="line" Canvas={CartesianCanvas} {...props} />
+}
+
+export type AreaChartProps<TData extends Row> = CartesianChartProps<TData>

--- a/apps/console/src/components/dither-kit/area.tsx
+++ b/apps/console/src/components/dither-kit/area.tsx
@@ -1,0 +1,103 @@
+"use client"
+
+import { type ReactNode, useEffect } from "react"
+
+import {
+  type AreaVariant,
+  type SeriesKind,
+  type StrokeVariant,
+  useChartPart,
+} from "./chart-context"
+import { SeriesContext } from "./series-context"
+
+export type SeriesProps = {
+  dataKey: string
+  variant?: AreaVariant
+  strokeVariant?: StrokeVariant
+  isClickable?: boolean
+  children?: ReactNode
+}
+
+/**
+ * Shared implementation for the continuous series (`<Area>`, `<Line>`). The
+ * dithered fill/line is painted on the canvas; this registers the series so the
+ * canvas knows how to draw it, wires click-to-select via a transparent band
+ * polygon, and exposes the series to child `<Dot>`/`<ActiveDot>` markers.
+ */
+function CartesianSeries({
+  part,
+  kind,
+  dataKey,
+  variant = "gradient",
+  strokeVariant = "solid",
+  isClickable = false,
+  children,
+}: SeriesProps & { part: string; kind: SeriesKind }) {
+  const ctx = useChartPart(part, kind === "line" ? "line" : "area")
+  const { registerSeries, unregisterSeries } = ctx
+
+  if (process.env.NODE_ENV !== "production" && !ctx.config[dataKey]) {
+    console.warn(
+      `<${part} dataKey="${dataKey}" />: "${dataKey}" is not in the chart \`config\`. Add it so the series has a colour and label.`,
+    )
+  }
+
+  useEffect(() => {
+    registerSeries({ dataKey, kind, variant, strokeVariant })
+    return () => unregisterSeries(dataKey)
+  }, [dataKey, kind, variant, strokeVariant, registerSeries, unregisterSeries])
+
+  const band = ctx.bands[dataKey]
+  if (!ctx.ready || !band) return null
+
+  const seed = ctx.seedOf(dataKey)
+  const emphasis = ctx.selectedDataKey ?? ctx.focusDataKey
+  const dimmed = emphasis !== null && emphasis !== dataKey
+  const onClick = isClickable
+    ? () => ctx.selectDataKey(ctx.selectedDataKey === dataKey ? null : dataKey)
+    : undefined
+
+  // Transparent hit polygon tracing the series' own band, so clicking a series
+  // selects *that* series. The Legend offers the same toggle accessibly.
+  // One pass out along the top edge, one pass back along the floor.
+  let hitPath: string | null = null
+  if (isClickable) {
+    const parts: string[] = []
+    band.forEach((b, i) => {
+      parts.push(`${i === 0 ? "M" : "L"}${ctx.xCenter(i)},${ctx.y(b[1])}`)
+    })
+    for (let i = band.length - 1; i >= 0; i -= 1) {
+      parts.push(`L${ctx.xCenter(i)},${ctx.y(band[i][0])}`)
+    }
+    hitPath = `${parts.join(" ")} Z`
+  }
+
+  return (
+    <>
+      {hitPath && (
+        // biome-ignore lint/a11y/noStaticElementInteractions: progressive enhancement; the Legend offers the same toggle accessibly
+        <path
+          d={hitPath}
+          fill="transparent"
+          style={{ cursor: "pointer" }}
+          onClick={onClick}
+        />
+      )}
+      <SeriesContext value={{ dataKey, seed, dimmed }}>
+        {children}
+      </SeriesContext>
+    </>
+  )
+}
+
+export type AreaProps = SeriesProps
+
+/** One area series — dithered fill from the value line down to its floor. */
+export function Area(props: AreaProps) {
+  return <CartesianSeries part="Area" kind="area" {...props} />
+}
+
+/** One line series — bright line with a thin dither glow hugging it. */
+export function Line(props: AreaProps) {
+  return <CartesianSeries part="Line" kind="line" {...props} />
+}

--- a/apps/console/src/components/dither-kit/cartesian-canvas.tsx
+++ b/apps/console/src/components/dither-kit/cartesian-canvas.tsx
@@ -1,0 +1,395 @@
+"use client"
+
+import { type RefObject, useEffect, useRef } from "react"
+
+import { type ChartContextValue, useChart } from "./chart-context"
+import {
+  backingSize,
+  bloomLayerStyle,
+  easeInOutCubic,
+  paintColumn,
+  prefersReducedMotion,
+  resample,
+} from "./dither-paint"
+import { rgb } from "./palette"
+
+type Star = { key: string; xi: number; depth: number; phase: number }
+type Surface = { top: number[]; floor: number[] }
+
+type LoopArgs = {
+  canvas: HTMLCanvasElement
+  bloomCanvas: HTMLCanvasElement | null
+  cols: number
+  rows: number
+  state: RefObject<ChartContextValue>
+  targets: RefObject<Record<string, Surface>>
+  stars: RefObject<Star[]>
+}
+
+/**
+ * The requestAnimationFrame paint loop — eases each series toward its target
+ * surface, paints the dither fill (with the entrance reveal), then layers the
+ * crosshair marker and winking stars on top. Lives outside the component so the
+ * component stays small and the closure is free of compiler constraints.
+ * Returns a cleanup that cancels the loop.
+ */
+function startCartesianLoop({
+  canvas,
+  bloomCanvas,
+  cols,
+  rows,
+  state,
+  targets,
+  stars,
+}: LoopArgs): (() => void) | undefined {
+  const c = canvas.getContext("2d")
+  if (!c || cols <= 0 || rows <= 0) return undefined
+  canvas.width = cols
+  canvas.height = rows
+
+  const off = document.createElement("canvas")
+  off.width = cols
+  off.height = rows
+  const octx = off.getContext("2d")
+  if (!octx) return undefined
+
+  // Bloom layer: a blurred, additive copy of the crisp canvas.
+  const bloomCtx = bloomCanvas?.getContext("2d") ?? null
+  if (bloomCanvas) {
+    bloomCanvas.width = cols
+    bloomCanvas.height = rows
+  }
+
+  const reduce = prefersReducedMotion()
+  const EASE = reduce ? 1 : 0.18
+  const animate = state.current.animate && !reduce
+  const duration = state.current.animationDuration
+  const current: Record<string, Surface> = {}
+
+  // `reveal` (0–1) sweeps the fill in left-to-right on first paint.
+  const paintFill = (intensity: number, reveal: number) => {
+    octx.clearRect(0, 0, cols, rows)
+    const s = state.current
+    const stacked = s.stackType === "stacked" || s.stackType === "percent"
+    const revealCols = Math.ceil(reveal * cols)
+    s.configKeys.forEach((key, si) => {
+      const cur = current[key]
+      if (!cur) return
+      const seed = s.seedOf(key)
+      const variant = s.seriesSpecs[key]?.variant ?? "gradient"
+      const isLine =
+        (s.seriesSpecs[key]?.kind ??
+          (s.chartType === "line" ? "line" : "area")) === "line"
+      const emphasis = s.selectedDataKey ?? s.focusDataKey
+      const dim = emphasis !== null && emphasis !== key ? 0.3 : 1
+      // Overlapping (non-stacked) layers thin out front-to-back so they
+      // read as distinct layers instead of a muddy blend.
+      const sparse = stacked ? 0 : si * 0.14
+      for (let x = 0; x < cols; x++) {
+        if (x > revealCols) break
+        paintColumn(octx, x, cur.top[x] ?? 0, cur.floor[x] ?? 0, seed, {
+          variant,
+          intensity,
+          dim,
+          stacked: stacked && !isLine,
+          sparse,
+        })
+      }
+    })
+  }
+
+  let raf = 0
+  let tick = 0
+  let last = 0
+  let animStart = 0
+  let lastProg = -1
+  let lastRevision = state.current.revision
+  let entranceReported = !animate
+  let intensity = 0
+  let needsFill = true
+  let lastPaintSig = ""
+  let lastSelected: string | null | undefined = Symbol() as never
+
+  const draw = (now: number) => {
+    raf = requestAnimationFrame(draw)
+    const s = state.current
+    if (!s.ready) return
+    // Keep the bloom layer in sync with the crisp canvas while it's active.
+    if (bloomCtx) {
+      const on =
+        s.bloom !== "off" && (!s.bloomOnHover || s.isMouseInChart || s.hovered)
+      if (on) {
+        bloomCtx.clearRect(0, 0, cols, rows)
+        bloomCtx.drawImage(canvas, 0, 0)
+      }
+    }
+    const tgt = targets.current
+    if (s.revision !== lastRevision) {
+      lastRevision = s.revision
+      animStart = 0 // re-play the entrance on data change / replay
+      lastProg = -1
+      entranceReported = false
+    }
+    if (!animStart) animStart = now
+    const prog = animate ? Math.min(1, (now - animStart) / duration) : 1
+    const progChanged = prog !== lastProg
+    // Tell the context the reveal is done so DOM markers fade in in sync.
+    if (prog >= 1 && !entranceReported) {
+      entranceReported = true
+      s.markEntranceDone()
+    }
+
+    let moving = false
+    for (const key of s.configKeys) {
+      const t = tgt[key]
+      if (!t) continue
+      const cur = current[key]
+      if (!cur || cur.top.length !== cols) {
+        current[key] = { top: t.top.slice(), floor: t.floor.slice() }
+        needsFill = true
+        continue
+      }
+      for (let x = 0; x < cols; x++) {
+        const dt = t.top[x] - cur.top[x]
+        const df = t.floor[x] - cur.floor[x]
+        if (Math.abs(dt) > 0.01 || Math.abs(df) > 0.01) {
+          cur.top[x] += dt * EASE
+          cur.floor[x] += df * EASE
+          moving = true
+        } else {
+          cur.top[x] = t.top[x]
+          cur.floor[x] = t.floor[x]
+        }
+      }
+    }
+    for (const key of Object.keys(current)) {
+      if (!tgt[key]) {
+        delete current[key]
+        needsFill = true
+      }
+    }
+    if (moving) needsFill = true
+    const emphasisNow = s.selectedDataKey ?? s.focusDataKey
+    if (emphasisNow !== lastSelected) {
+      lastSelected = emphasisNow
+      needsFill = true
+    }
+
+    const itTarget = s.isMouseInChart || s.hovered ? 1 : 0
+    let settling = false
+    if (Math.abs(intensity - itTarget) > 0.001) {
+      intensity += (itTarget - intensity) * 0.16
+      settling = true
+      needsFill = true
+    } else intensity = itTarget
+
+    // Live hover wins; the controlled markerIndex (e.g. a committed point)
+    // is the fallback shown when nothing is hovered.
+    const marker = s.hoverIndex != null ? s.hoverIndex : s.markerIndex
+    const winkDue = !reduce && now - last >= 100
+    // Repaint when a tweak-driven paint input changes (variant, stacking) so
+    // the panel updates the fill live — without resetting the entrance reveal.
+    const paintSig = `${s.stackType}|${s.configKeys
+      .map((k) => s.seriesSpecs[k]?.variant ?? "")
+      .join(",")}`
+    const sigChanged = paintSig !== lastPaintSig
+    if (sigChanged) {
+      lastPaintSig = paintSig
+      needsFill = true
+    }
+    if (
+      !(
+        moving ||
+        settling ||
+        winkDue ||
+        marker != null ||
+        progChanged ||
+        sigChanged
+      )
+    )
+      return
+    if (progChanged) {
+      lastProg = prog
+      needsFill = true
+    }
+    if (winkDue) {
+      last = now
+      tick += 1
+    }
+
+    // Reveal front (left-to-right) — stars + crosshair stay behind it so
+    // they don't float over the not-yet-drawn area during the entrance.
+    const reveal = animate ? easeInOutCubic(prog) : 1
+    const revealCols = reveal * cols
+
+    if (needsFill) {
+      paintFill(intensity, reveal)
+      needsFill = false
+    }
+    c.clearRect(0, 0, cols, rows)
+    c.drawImage(off, 0, 0)
+
+    const mx =
+      marker != null && s.dataLength > 1
+        ? Math.round((marker / (s.dataLength - 1)) * (cols - 1))
+        : -1
+    if (mx >= 0 && mx <= revealCols) {
+      for (const key of s.configKeys) {
+        const cur = current[key]
+        if (!cur) continue
+        const seed = s.seedOf(key)
+        const my = Math.round(cur.top[mx] ?? 0)
+        // Full-height column + a chunky marker block at the point — the
+        // series colour at higher opacity, so it reads on either theme.
+        c.fillStyle = rgb(seed.fill, 1, 0.55)
+        for (let y = my; y < rows; y++) c.fillRect(mx, y, 1, 1)
+        c.fillStyle = rgb(seed.fill)
+        c.fillRect(mx - 1, my - 1, 3, 3)
+      }
+    }
+
+    for (const star of stars.current) {
+      const cur = current[star.key]
+      if (!cur) continue
+      const sx = Math.round(
+        (star.xi / Math.max(s.dataLength - 1, 1)) * (cols - 1),
+      )
+      if (sx > revealCols) continue // behind the reveal front
+      const top = cur.top[sx] ?? 0
+      const floor = cur.floor[sx] ?? rows - 1
+      const sy = Math.round(top + star.depth * (floor - top))
+      const tw = reduce ? 0.85 : (Math.sin((tick + star.phase) * 0.35) + 1) / 2
+      const lift = tw * (0.7 + 0.3 * intensity)
+      if (lift < 0.55 || sy < 0 || sy >= rows) continue
+      // Sparkles glint in the series colour via opacity (the `lift` wink)
+      // rather than a lighter shade — so they never read as stray white
+      // pixels on a light background.
+      const starColor = s.seedOf(star.key).fill
+      c.fillStyle = rgb(starColor, 1, lift)
+      c.fillRect(sx, sy, 1, 1)
+      // At the peak of a wink the star flares into a 4-point glint.
+      if (tw > 0.9) {
+        c.fillStyle = rgb(starColor, 1, lift * 0.6 * (tw - 0.9) * 10)
+        c.fillRect(sx - 1, sy, 1, 1)
+        c.fillRect(sx + 1, sy, 1, 1)
+        c.fillRect(sx, sy - 1, 1, 1)
+        c.fillRect(sx, sy + 1, 1, 1)
+      }
+    }
+  }
+
+  raf = requestAnimationFrame(draw)
+  return () => cancelAnimationFrame(raf)
+}
+
+/**
+ * Continuous dither canvas for area and line charts. Each series is reduced to a
+ * `[top, floor]` band per backing column: areas fill from their value line down
+ * to their floor; lines fill only a thin glow band hugging the line. The shared
+ * {@link paintColumn} renders the ordered-dither scatter, capped by the bright
+ * series line, with winking stars + scrub crosshair on top.
+ */
+export function CartesianCanvas() {
+  const ctx = useChart()
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const bloomRef = useRef<HTMLCanvasElement>(null)
+
+  const { width, height } = ctx.plot
+  const { cols, rows } = backingSize(width, height)
+
+  // Per-series target [top, floor] rows, resampled to `cols`. React Compiler
+  // memoizes this against the exact ctx fields it reads.
+  const targets = (() => {
+    const out: Record<string, Surface> = {}
+    if (!ctx.ready) return out
+    const h = height || 1
+    const glow = Math.max(6, Math.round(rows * 0.16))
+    const defaultKind = ctx.chartType === "line" ? "line" : "area"
+    for (const key of ctx.configKeys) {
+      const band = ctx.bands[key]
+      if (!band) continue
+      const line = (ctx.seriesSpecs[key]?.kind ?? defaultKind) === "line"
+      const top = band.map((b) => (ctx.y(b[1]) / h) * (rows - 1))
+      const floor = band.map((b, i) =>
+        line
+          ? Math.min(rows - 1, top[i] + glow)
+          : (ctx.y(b[0]) / h) * (rows - 1),
+      )
+      out[key] = { top: resample(top, cols), floor: resample(floor, cols) }
+    }
+    return out
+  })()
+
+  const stars = (() => {
+    const out: Star[] = []
+    const per = Math.max(4, Math.round(cols / 14))
+    ctx.configKeys.forEach((key, k) => {
+      for (let i = 0; i < per; i++) {
+        const seed = i * 67 + 13 + k * 131
+        out.push({
+          key,
+          xi: seed % Math.max(ctx.dataLength, 1),
+          depth: ((seed * 53 + 7) % 100) / 100,
+          phase: (seed * 41) % 360,
+        })
+      }
+    })
+    return out
+  })()
+
+  // The RAF loop reads these through refs so it always sees the latest values
+  // without re-subscribing. Refs are written in an effect (never during
+  // render) so the component stays compiler-friendly.
+  const stateRef = useRef(ctx)
+  const targetsRef = useRef(targets)
+  const starsRef = useRef(stars)
+  useEffect(() => {
+    stateRef.current = ctx
+    targetsRef.current = targets
+    starsRef.current = stars
+  })
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    return startCartesianLoop({
+      canvas,
+      bloomCanvas: bloomRef.current,
+      cols,
+      rows,
+      state: stateRef,
+      targets: targetsRef,
+      stars: starsRef,
+    })
+  }, [cols, rows])
+
+  const bloomActive = ctx.bloomOnHover
+    ? ctx.isMouseInChart || ctx.hovered
+    : true
+  const bloom = bloomLayerStyle(ctx.bloom, bloomActive)
+  const pos = {
+    left: ctx.margins.left,
+    top: ctx.margins.top,
+    width,
+    height,
+  } as const
+
+  return (
+    <>
+      <canvas
+        ref={canvasRef}
+        className="pointer-events-none absolute"
+        style={{ ...pos, imageRendering: "pixelated" }}
+      />
+      <canvas
+        ref={bloomRef}
+        className="pointer-events-none absolute"
+        style={{
+          ...pos,
+          transition: "opacity 220ms ease",
+          ...(bloom ?? { opacity: 0 }),
+        }}
+      />
+    </>
+  )
+}

--- a/apps/console/src/components/dither-kit/cartesian-root.tsx
+++ b/apps/console/src/components/dither-kit/cartesian-root.tsx
@@ -1,0 +1,189 @@
+"use client"
+
+import {
+  Children,
+  type ComponentType,
+  isValidElement,
+  type ReactNode,
+} from "react"
+
+import {
+  type ChartConfig,
+  ChartContext,
+  type ChartType,
+  type Margins,
+  useChartController,
+} from "./chart-context"
+import { CommonChartContext } from "./common-context"
+import type { BloomInput } from "./dither-paint"
+import { cn } from "./lib"
+import type { StackType } from "./scales"
+import { useChartDimensions } from "./use-chart-dimensions"
+
+type Row = Record<string, unknown>
+
+const DEFAULT_MARGINS: Margins = {
+  top: 10,
+  right: 12,
+  bottom: 22,
+  left: 36,
+}
+
+export type CartesianChartProps<TData extends Row> = {
+  data: TData[]
+  config: ChartConfig
+  children: ReactNode
+  stackType?: StackType
+  margins?: Partial<Margins>
+  className?: string
+  animate?: boolean
+  animationDuration?: number
+  replayToken?: number // change to re-play the entrance without remounting
+  /** Set false for a decorative sparkline: keeps the hover lift but no scrub
+   * crosshair / tooltip. */
+  interactive?: boolean
+  /** Controlled crosshair position (e.g. a committed point) — overrides the
+   * internal hover when set. */
+  markerIndex?: number | null
+  /** Parent-driven hover (e.g. the whole card/row) — lifts the fill. */
+  hovered?: boolean
+  /** Glow on the dither fill. */
+  bloom?: BloomInput
+  /** Only bloom while the chart is hovered. */
+  bloomOnHover?: boolean
+  /** Fires with the scrubbed index as the pointer moves (null on leave). */
+  onHoverChange?: (index: number | null) => void
+  defaultSelectedDataKey?: string | null
+  onSelectionChange?: (key: string | null) => void
+}
+
+/** Which render layer a composed part targets — defaults to the front SVG. */
+function layerOf(node: ReactNode): "back" | "dom" | "svg" {
+  if (!isValidElement(node) || typeof node.type === "string") return "svg"
+  return (node.type as { chartLayer?: "back" | "dom" }).chartLayer ?? "svg"
+}
+
+/**
+ * Shared root for the cartesian dither charts (area, line, bar). Owns the
+ * measured size, the shared context, and pointer interaction; every visual is
+ * composed as children. Back chrome (grid) sits behind the dither canvas; the
+ * canvas paints the fill/line/bars + stars; front chrome (axes, dots) and DOM
+ * legend/tooltip layer on top. `chartType` drives the scales/interaction and the
+ * `Canvas` prop supplies the family's painter (continuous for area/line, bars for
+ * bar) — so each chart ships only its own canvas.
+ */
+export function CartesianRoot<TData extends Row>({
+  chartType,
+  Canvas,
+  data,
+  config,
+  children,
+  stackType = "default",
+  margins: marginsProp,
+  className,
+  animate = true,
+  animationDuration = 900,
+  replayToken = 0,
+  interactive = true,
+  markerIndex = null,
+  hovered = false,
+  bloom = "off",
+  bloomOnHover = false,
+  onHoverChange,
+  defaultSelectedDataKey = null,
+  onSelectionChange,
+}: CartesianChartProps<TData> & {
+  chartType: ChartType
+  Canvas: ComponentType
+}) {
+  const { ref, size } = useChartDimensions<HTMLDivElement>()
+  const margins = { ...DEFAULT_MARGINS, ...marginsProp }
+
+  const ctx = useChartController({
+    chartType,
+    data,
+    config,
+    stackType,
+    dimensions: size,
+    margins,
+    animate,
+    animationDuration,
+    replayToken,
+    markerIndex,
+    hovered,
+    bloom,
+    bloomOnHover,
+    defaultSelectedDataKey,
+    onSelectionChange,
+  })
+
+  const backChildren: ReactNode[] = []
+  const svgChildren: ReactNode[] = []
+  const domChildren: ReactNode[] = []
+  Children.forEach(children, (child) => {
+    const layer = layerOf(child)
+    if (layer === "back") backChildren.push(child)
+    else if (layer === "dom") domChildren.push(child)
+    else svgChildren.push(child)
+  })
+
+  const onMove = (clientX: number) => {
+    const el = ref.current
+    if (!el) return
+    const rect = el.getBoundingClientRect()
+    const px = clientX - rect.left - margins.left
+    const index = ctx.indexAtX(px)
+    ctx.setHoverIndex(index)
+    ctx.setCursorX(clientX - rect.left)
+    onHoverChange?.(index)
+  }
+
+  return (
+    <ChartContext value={ctx}>
+      <CommonChartContext value={ctx.common}>
+        <div
+          ref={ref}
+          className={cn("relative h-full w-full", className)}
+          onPointerEnter={() => ctx.setMouseInChart(true)}
+          onPointerMove={interactive ? (e) => onMove(e.clientX) : undefined}
+          onPointerLeave={() => {
+            ctx.setMouseInChart(false)
+            ctx.setHoverIndex(null)
+            onHoverChange?.(null)
+          }}
+        >
+          {ctx.ready && backChildren.length > 0 && (
+            <svg
+              width={size.width}
+              height={size.height}
+              className="absolute inset-0 overflow-visible"
+              aria-hidden
+              role="presentation"
+            >
+              <g transform={`translate(${margins.left},${margins.top})`}>
+                {backChildren}
+              </g>
+            </svg>
+          )}
+          <Canvas />
+          {ctx.ready && (
+            <svg
+              width={size.width}
+              height={size.height}
+              className="absolute inset-0 overflow-visible"
+              role="img"
+              aria-label="Chart"
+            >
+              <g transform={`translate(${margins.left},${margins.top})`}>
+                {svgChildren}
+              </g>
+            </svg>
+          )}
+          {domChildren}
+        </div>
+      </CommonChartContext>
+    </ChartContext>
+  )
+}
+
+export type AreaChartProps<TData extends Row> = CartesianChartProps<TData>

--- a/apps/console/src/components/dither-kit/chart-context.tsx
+++ b/apps/console/src/components/dither-kit/chart-context.tsx
@@ -1,0 +1,382 @@
+"use client"
+
+import type { ScaleLinear } from "d3-scale"
+import { createContext, use, useState } from "react"
+
+import type { CommonChart } from "./common-context"
+import type { BloomInput } from "./dither-paint"
+import type { DitherColor, Seed } from "./palette"
+import { seedOfColor } from "./palette"
+import {
+  buildBandScale,
+  buildXScale,
+  buildYScale,
+  computeBands,
+  indexAtBand,
+  nearestIndex,
+  type StackType,
+} from "./scales"
+import type { Dimensions } from "./use-chart-dimensions"
+
+/** Which chart root a part is composed under — drives the boundary guards. */
+export type ChartType = "area" | "bar" | "line" | "pie" | "radar"
+
+export type ChartConfig = Record<string, { label?: string; color: DitherColor }>
+
+export type Margins = {
+  top: number
+  right: number
+  bottom: number
+  left: number
+}
+
+type Row = Record<string, unknown>
+
+export type AreaVariant = "gradient" | "dotted" | "hatched" | "solid"
+export type StrokeVariant = "solid" | "dashed"
+export type SeriesKind = "area" | "line" | "bar"
+
+/** What each series part (<Area />, <Line />, <Bar />) registers so the canvas
+ * knows which series to paint and how. */
+export type SeriesSpec = {
+  dataKey: string
+  kind: SeriesKind
+  variant: AreaVariant
+  strokeVariant: StrokeVariant
+}
+
+export type ChartContextValue = {
+  chartType: ChartType // which root this part is under
+  config: ChartConfig
+  configKeys: string[] // series order — drives stacking + legend
+  data: Row[]
+  dataLength: number
+  stackType: StackType
+
+  margins: Margins
+  plot: { width: number; height: number } // inner drawing area
+  ready: boolean // true once measured (width > 0)
+
+  xCenter: (index: number) => number // category centre px within the plot
+  bandwidth: number // category slot width (0 for point/area scales)
+  indexAtX: (px: number) => number // nearest category for a pointer x
+  // Bar geometry in plot px — one source of truth for the canvas + click rects.
+  barSlot: (
+    index: number,
+    seriesIndex: number,
+    seriesCount: number,
+  ) => { x: number; width: number }
+  y: ScaleLinear<number, number> // value → px within the plot
+  bands: Record<string, [number, number][]> // per-series [y0, y1] per row
+  max: number
+
+  // Interaction state, shared by every part.
+  selectedDataKey: string | null
+  selectDataKey: (key: string | null) => void
+  /** Legend-hover spotlight — dims every series but this one while set. */
+  focusDataKey: string | null
+  setFocusDataKey: (key: string | null) => void
+  hoverIndex: number | null
+  setHoverIndex: (index: number | null) => void
+  markerIndex: number | null // controlled crosshair override (e.g. committed point)
+  cursorX: number
+  setCursorX: (px: number) => void
+  isMouseInChart: boolean
+  setMouseInChart: (over: boolean) => void
+  hovered: boolean // parent-driven hover (e.g. the whole card) — lifts the fill
+  bloom: BloomInput // glow on the dither canvas
+  bloomOnHover: boolean // only bloom while hovered
+
+  // Series register themselves so the canvas knows what (and how) to paint.
+  seriesSpecs: Record<string, SeriesSpec>
+  registerSeries: (spec: SeriesSpec) => void
+  unregisterSeries: (dataKey: string) => void
+
+  // Entrance animation (prop-driven). `revision` bumps when the data changes or
+  // the replay token advances, so the canvas can re-play its entrance.
+  animate: boolean
+  animationDuration: number
+  revision: number
+  entranceDone: boolean // true once the entrance has played — gates SVG markers
+  markEntranceDone: () => void // the canvas calls this when its reveal completes
+
+  // Helpers.
+  seedOf: (key: string) => Seed
+  common: CommonChart // shared surface for <Legend> / <Tooltip>
+}
+
+const ChartContext = createContext<ChartContextValue | null>(null)
+
+const ROOT_OF: Record<ChartType, string> = {
+  area: "<AreaChart />",
+  bar: "<BarChart />",
+  line: "<LineChart />",
+  pie: "<PieChart />",
+  radar: "<RadarChart />",
+}
+
+/** Generic accessor for internal layers (canvas/overlay) that work for any root. */
+export function useChart() {
+  const ctx = use(ChartContext)
+  if (!ctx) {
+    throw new Error(
+      "Chart parts must be used within a chart root (e.g. <AreaChart />).",
+    )
+  }
+  return ctx
+}
+
+/**
+ * Boundary guard for a composable part. Throws a precise error when used outside
+ * a root, or inside the wrong chart type — e.g. `<Bar />` placed in an area
+ * chart. `kind` omitted means the part works under any root (grid, axes, …).
+ */
+export function useChartPart(
+  part: string,
+  kind?: ChartType | ChartType[],
+): ChartContextValue {
+  const ctx = use(ChartContext)
+  if (!ctx) {
+    const where = kind
+      ? ROOT_OF[Array.isArray(kind) ? kind[0] : kind]
+      : "a chart root"
+    throw new Error(`<${part} /> must be used within ${where}.`)
+  }
+  if (kind) {
+    const allowed = Array.isArray(kind) ? kind : [kind]
+    if (!allowed.includes(ctx.chartType)) {
+      throw new Error(
+        `<${part} /> is not valid inside ${ROOT_OF[ctx.chartType]} — it belongs in ${allowed
+          .map((k) => ROOT_OF[k])
+          .join(" or ")}.`,
+      )
+    }
+  }
+  return ctx
+}
+
+export { ChartContext }
+
+/** A counter that advances whenever `data` changes identity or `token` advances
+ * — drives entrance replays without remounting. Uses the adjust-state-during-
+ * render pattern (https://react.dev/reference/react/useState) instead of refs,
+ * so React Compiler can reason about it. */
+export function useRevision(data: unknown, token: number) {
+  const [prev, setPrev] = useState({ data, token, revision: 0 })
+  if (prev.data !== data || prev.token !== token) {
+    const next = { data, token, revision: prev.revision + 1 }
+    setPrev(next)
+    return next.revision
+  }
+  return prev.revision
+}
+
+/**
+ * Builds the shared context value: resolves the plot rect from the measured
+ * size minus margins, computes the x/y scales and the per-series stack bands,
+ * and owns the selection + hover state every part reads.
+ */
+export function useChartController({
+  chartType,
+  data,
+  config,
+  stackType,
+  dimensions,
+  margins,
+  animate = true,
+  animationDuration = 900,
+  replayToken = 0,
+  markerIndex = null,
+  hovered = false,
+  bloom = "off",
+  bloomOnHover = false,
+  defaultSelectedDataKey = null,
+  onSelectionChange,
+}: {
+  chartType: ChartType
+  data: Row[]
+  config: ChartConfig
+  stackType: StackType
+  dimensions: Dimensions
+  margins: Margins
+  animate?: boolean
+  animationDuration?: number
+  replayToken?: number
+  markerIndex?: number | null
+  hovered?: boolean
+  bloom?: BloomInput
+  bloomOnHover?: boolean
+  defaultSelectedDataKey?: string | null
+  onSelectionChange?: (key: string | null) => void
+}): ChartContextValue {
+  // React Compiler memoizes every render-scope value below — no manual
+  // useMemo/useCallback wrappers needed.
+  const configKeys = Object.keys(config)
+  const revision = useRevision(data, replayToken)
+
+  const [selectedDataKey, setSelectedDataKey] = useState<string | null>(
+    defaultSelectedDataKey,
+  )
+  const [focusDataKey, setFocusDataKey] = useState<string | null>(null)
+  const [hoverIndex, setHoverIndex] = useState<number | null>(null)
+  const [cursorX, setCursorX] = useState(0)
+  const [isMouseInChart, setMouseInChart] = useState(false)
+  const [seriesSpecs, setSeriesSpecs] = useState<Record<string, SeriesSpec>>({})
+
+  const registerSeries = (spec: SeriesSpec) => {
+    setSeriesSpecs((prev) => {
+      const cur = prev[spec.dataKey]
+      return cur &&
+        cur.kind === spec.kind &&
+        cur.variant === spec.variant &&
+        cur.strokeVariant === spec.strokeVariant
+        ? prev
+        : { ...prev, [spec.dataKey]: spec }
+    })
+  }
+  const unregisterSeries = (dataKey: string) => {
+    setSeriesSpecs((prev) => {
+      if (!(dataKey in prev)) return prev
+      const next = { ...prev }
+      delete next[dataKey]
+      return next
+    })
+  }
+
+  const selectDataKey = (key: string | null) => {
+    setSelectedDataKey(key)
+    onSelectionChange?.(key)
+  }
+
+  const plotWidth = Math.max(0, dimensions.width - margins.left - margins.right)
+  const plotHeight = Math.max(
+    0,
+    dimensions.height - margins.top - margins.bottom,
+  )
+  const ready = plotWidth > 0 && plotHeight > 0
+
+  // The entrance gate flips true when the canvas reveal completes (via
+  // `markEntranceDone`) so DOM markers fade in with the fill, and re-arms on
+  // each replay. Adjust-state-during-render instead of an effect, so the reset
+  // lands in the same render as the revision bump.
+  const [entrance, setEntrance] = useState({ revision, done: !animate })
+  if (entrance.revision !== revision) {
+    setEntrance({ revision, done: !animate })
+  }
+  const entranceDone = entrance.revision === revision ? entrance.done : !animate
+  const markEntranceDone = () => setEntrance({ revision, done: true })
+
+  const { bands, max } = computeBands(data, configKeys, stackType)
+
+  const isBar = chartType === "bar"
+  const xPoint = buildXScale(data.length, plotWidth)
+  const xBand = buildBandScale(data.length, plotWidth)
+  const bandwidth = isBar ? xBand.bandwidth() : 0
+  const xCenter = (i: number) =>
+    isBar ? (xBand(i) ?? 0) + xBand.bandwidth() / 2 : (xPoint(i) ?? 0)
+  const indexAtX = (px: number) =>
+    isBar
+      ? indexAtBand(px, data.length, plotWidth)
+      : nearestIndex(px, data.length, plotWidth)
+  const stacked = stackType === "stacked" || stackType === "percent"
+  const barSlot = (i: number, si: number, n: number) => {
+    const center = xCenter(i)
+    if (stacked) {
+      const w = bandwidth * 0.9
+      return { x: center - w / 2, width: w }
+    }
+    const slot = bandwidth / Math.max(n, 1)
+    return {
+      x: center - bandwidth / 2 + si * slot + slot * 0.08,
+      width: slot * 0.84,
+    }
+  }
+  const y = buildYScale(max, plotHeight)
+
+  const seedOf = (key: string) => seedOfColor(config[key]?.color ?? "grey")
+
+  const common: CommonChart = {
+    names: configKeys,
+    labelOf: (n) => config[n]?.label ?? n,
+    seedOf,
+    selectedDataKey,
+    selectDataKey,
+    focusDataKey,
+    setFocusDataKey,
+    hoverIndex,
+    ready,
+    tooltipLeft: Math.max(48, Math.min(plotWidth + margins.left - 48, cursorX)),
+    // Follow the highest hovered node so the card rides the data path, but
+    // keep enough headroom that the upward-lifted card never clips the top.
+    tooltipTop: (() => {
+      const floor = margins.top + 44
+      if (hoverIndex == null) return floor
+      let minY = Number.POSITIVE_INFINITY
+      for (const key of configKeys) {
+        const b = bands[key]?.[hoverIndex]
+        if (b) minY = Math.min(minY, y(b[1]))
+      }
+      if (!Number.isFinite(minY)) return floor
+      return Math.max(floor, margins.top + minY)
+    })(),
+    heading: (i, labelKey) =>
+      labelKey ? String(data[i]?.[labelKey] ?? "") : null,
+    itemsAt: (i) =>
+      configKeys.map((name) => {
+        const raw = data[i]?.[name]
+        return {
+          name,
+          label: config[name]?.label ?? name,
+          value: typeof raw === "number" ? raw : 0,
+          seed: seedOf(name),
+          dimmed: (() => {
+            const emphasis = selectedDataKey ?? focusDataKey
+            return emphasis !== null && emphasis !== name
+          })(),
+        }
+      }),
+  }
+
+  return {
+    chartType,
+    config,
+    configKeys,
+    data,
+    dataLength: data.length,
+    stackType,
+    margins,
+    plot: { width: plotWidth, height: plotHeight },
+    ready,
+    xCenter,
+    bandwidth,
+    indexAtX,
+    barSlot,
+    y,
+    bands,
+    max,
+    selectedDataKey,
+    selectDataKey,
+    focusDataKey,
+    setFocusDataKey,
+    hoverIndex,
+    setHoverIndex,
+    markerIndex,
+    cursorX,
+    setCursorX,
+    isMouseInChart,
+    setMouseInChart,
+    hovered,
+    bloom,
+    bloomOnHover,
+    seriesSpecs,
+    registerSeries,
+    unregisterSeries,
+    animate,
+    animationDuration,
+    revision,
+    entranceDone,
+    markEntranceDone,
+    seedOf,
+    common,
+  }
+}

--- a/apps/console/src/components/dither-kit/common-context.tsx
+++ b/apps/console/src/components/dither-kit/common-context.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import { createContext, use } from "react"
+
+import type { Seed } from "./palette"
+
+/** A single tooltip row — one series (cartesian/radar) or one slice (pie). */
+export type TooltipItem = {
+  name: string
+  label: string
+  value: number
+  seed: Seed
+  dimmed: boolean
+}
+
+/**
+ * The minimal surface shared by every chart family, so `<Legend>` and
+ * `<Tooltip>` work identically whether they sit in a cartesian, bar, or polar
+ * root. Each root publishes one of these alongside its family-specific context.
+ */
+export type CommonChart = {
+  names: string[] // legend entries — series keys (cartesian) or slice names (pie)
+  labelOf: (name: string) => string
+  seedOf: (name: string) => Seed
+  selectedDataKey: string | null
+  selectDataKey: (key: string | null) => void
+  /** Transient legend-hover emphasis — spotlights one series (others dim)
+   * while the pointer rests on its legend entry. Selection still wins. */
+  focusDataKey: string | null
+  setFocusDataKey: (key: string | null) => void
+  hoverIndex: number | null
+  heading: (index: number, labelKey?: string) => string | null
+  itemsAt: (index: number) => TooltipItem[]
+  ready: boolean
+  tooltipLeft: number // clamped px for the floating tooltip
+  tooltipTop: number // px — follows the hovered node (cartesian) / cursor (polar)
+}
+
+export const CommonChartContext = createContext<CommonChart | null>(null)
+
+export function useCommonChart() {
+  const ctx = use(CommonChartContext)
+  if (!ctx) {
+    throw new Error(
+      "<Legend /> / <Tooltip /> must be used within a chart root.",
+    )
+  }
+  return ctx
+}

--- a/apps/console/src/components/dither-kit/dither-paint.ts
+++ b/apps/console/src/components/dither-kit/dither-paint.ts
@@ -1,0 +1,177 @@
+import type { AreaVariant } from "./chart-context"
+import { rgb, type Seed } from "./palette"
+
+// 4×4 ordered (Bayer) matrix, normalized to 0–1 thresholds — the exact matrix
+// the legacy chart dithers with.
+export const BAYER = [
+  [0, 8, 2, 10],
+  [12, 4, 14, 6],
+  [3, 11, 1, 9],
+  [15, 7, 13, 5],
+].map((row) => row.map((v) => (v + 0.5) / 16))
+
+export const CELL = 2 // css px per dither cell — chunky enough to read pixelated
+export const MAX_COLS = 520
+export const MAX_ROWS = 200
+// Opacity of the top border outline (just under solid, so it reads as a soft
+// edge rather than a hard line). See the note on colour vs opacity below.
+export const BORDER_ALPHA = 0.72
+// Opacity of a dither "off" cell relative to an "on" cell. The scatter modulates
+// between these two tiers of the *same* colour instead of leaving holes, so the
+// background never shows through as stark white on a light theme.
+export const OFF_TIER = 0.4
+
+export type PaintOpts = {
+  variant: AreaVariant
+  intensity: number // 0–1 hover lift
+  dim: number // selection dim multiplier (0.3 dimmed, 1 normal)
+  stacked: boolean // denser + solid floor when layers stack
+  sparse?: number // raise the dither threshold (thin out) — front layers
+}
+
+// Colour vs opacity — the guiding rule for the whole engine:
+//
+//   Work with opacities instead of different shades of the same color. This will
+//   make sure it looks good on both light and dark mode.
+//
+// So every pixel is the series' single `fill` colour and we vary only its alpha.
+// The old lighter `line` / near-white `star` shades were dropped: a shade that
+// pops on a dark background reads as a jarring bright speck on a light one, while
+// the same colour at a lower opacity simply blends into whatever sits behind it.
+
+/**
+ * Fill one backing-canvas column `x` from row `top` down to `floor` with the
+ * ordered-dither scatter — solid at the floor, dissolving upward so it *fades
+ * out toward the value line* — then cap the top with a soft border outline in
+ * the series colour. Density drives opacity (see the note above), so the fade
+ * reads correctly against both light and dark backgrounds. The single source of
+ * the dither look across area / line / bar.
+ */
+export function paintColumn(
+  octx: CanvasRenderingContext2D,
+  x: number,
+  top: number,
+  floor: number,
+  seed: Seed,
+  { variant, intensity, dim, stacked, sparse = 0 }: PaintOpts,
+) {
+  const t = Math.round(top)
+  const f = Math.round(floor)
+  const depth = f - t
+  if (depth <= 0) {
+    octx.fillStyle = rgb(seed.fill, 1, BORDER_ALPHA * dim)
+    octx.fillRect(x, t, 1, 1)
+    return
+  }
+  const bias = (variant === "dotted" ? 0.12 : 0) + (stacked ? 0.2 : 0) - sparse
+  for (let y = t; y < f; y++) {
+    // Inverted falloff: 0 at the top line, 1 at the floor — dense at the
+    // bottom, thinning as it rises toward the outline.
+    let density = (y - t) / depth
+    if (stacked) density = 0.5 + 0.5 * density
+    if (variant === "hatched" && ((x + y) & 3) >= 2) continue
+    const lit =
+      variant === "solid" ||
+      density > BAYER[y & 3][x & 3] - 0.1 * intensity - bias
+    // "dotted" keeps real gaps for its open look; every other variant covers
+    // the cell and lets the dither ride the alpha (on = full tier, off = a
+    // faint tint) so nothing shows the background through as white.
+    if (variant === "dotted" && !lit) continue
+    // Density → alpha (see the colour-vs-opacity note above).
+    const k = (0.3 + density * 0.7) * (1 + 0.22 * intensity)
+    const alpha = clamp01((lit ? k : k * OFF_TIER) * dim)
+    octx.fillStyle = rgb(seed.fill, 1, alpha)
+    octx.fillRect(x, y, 1, 1)
+  }
+  // Top border outline — the shape's edge now that the fill fades out here.
+  // Kept just under full opacity, with a faint feather row beneath, so it reads
+  // as a soft edge rather than a hard line floating over the fade.
+  octx.fillStyle = rgb(seed.fill, 1, BORDER_ALPHA * dim)
+  octx.fillRect(x, t, 1, 1)
+  if (depth > 1) {
+    octx.fillStyle = rgb(seed.fill, 1, BORDER_ALPHA * 0.5 * dim)
+    octx.fillRect(x, t + 1, 1, 1)
+  }
+}
+
+/** Linear-resample a per-index fraction array to `cols` columns. */
+export function resample(src: number[], cols: number): number[] {
+  const out: number[] = Array.from({ length: cols })
+  const last = Math.max(src.length - 1, 1)
+  for (let c = 0; c < cols; c++) {
+    const t = (c / Math.max(cols - 1, 1)) * last
+    const i = Math.floor(t)
+    const f = t - i
+    const a = src[i] ?? 0
+    const b = src[Math.min(i + 1, src.length - 1)] ?? a
+    out[c] = a + (b - a) * f
+  }
+  return out
+}
+
+/** Backing-canvas resolution for a plot rect — low-res, scaled up `pixelated`. */
+export function backingSize(width: number, height: number) {
+  return {
+    cols: Math.min(MAX_COLS, Math.max(8, Math.round(width / CELL))),
+    rows: Math.min(MAX_ROWS, Math.max(8, Math.round(height / CELL))),
+  }
+}
+
+// Bloom — a real "shader" glow that comes from the colours themselves: a blurred
+// copy of the rendered canvas, composited additively (`plus-lighter`) so each
+// hue blooms in its own colour instead of a grey wash. Lives on a second canvas
+// layered over the crisp one (which stays sharp/pixelated).
+export type BloomLevel = "off" | "low" | "high" | "aura"
+export type BloomBlend = "plus-lighter" | "screen" | "lighten"
+export type BloomConfig = {
+  blur: number // px
+  brightness: number // 1 = none
+  opacity: number // 0–1
+  /** Saturation of the glow — >1 keeps it vividly in the dither's colour
+   * instead of washing toward white. */
+  saturate?: number
+  blend?: BloomBlend // additive by default
+}
+/** A preset name, a full config, or "off". */
+export type BloomInput = BloomLevel | BloomConfig
+
+const PRESET: Record<Exclude<BloomLevel, "off">, BloomConfig> = {
+  low: { blur: 3, brightness: 1.35, opacity: 0.7, saturate: 1.4 },
+  high: { blur: 5, brightness: 1.5, opacity: 0.78, saturate: 1.5 },
+  aura: { blur: 15, brightness: 2.9, opacity: 0.1, saturate: 3 },
+}
+
+export type BloomStyle = {
+  filter: string
+  opacity: number
+  mixBlendMode: BloomBlend
+  imageRendering: "auto"
+}
+
+/** Style for the bloom *layer* canvas (a blurred, additive copy). null when off. */
+export function bloomLayerStyle(
+  input: BloomInput,
+  active: boolean,
+): BloomStyle | null {
+  if (!active || input === "off") return null
+  const cfg = typeof input === "string" ? PRESET[input] : input
+  return {
+    filter: `blur(${cfg.blur}px) brightness(${cfg.brightness}) saturate(${cfg.saturate ?? 1})`,
+    opacity: cfg.opacity,
+    mixBlendMode: cfg.blend ?? "plus-lighter",
+    imageRendering: "auto",
+  }
+}
+
+// Easing — gentle start + soft settle so entrances don't feel linear.
+export const easeInOutCubic = (t: number) =>
+  t < 0.5 ? 4 * t * t * t : 1 - (-2 * t + 2) ** 3 / 2
+export const easeOutCubic = (t: number) => 1 - (1 - t) ** 3
+export const clamp01 = (t: number) => (t < 0 ? 0 : t > 1 ? 1 : t)
+
+/** Whether the OS asks for reduced motion (snap + steady stars). */
+export function prefersReducedMotion() {
+  return (
+    window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ?? false
+  )
+}

--- a/apps/console/src/components/dither-kit/dot.tsx
+++ b/apps/console/src/components/dither-kit/dot.tsx
@@ -1,0 +1,90 @@
+"use client"
+
+import { useChart } from "./chart-context"
+import { rgb, type Seed } from "./palette"
+import { useSeries } from "./series-context"
+
+export type DotVariant = "border" | "colored-border" | "filled"
+
+function dotPaint(variant: DotVariant, seed: Seed) {
+  switch (variant) {
+    case "colored-border":
+      return {
+        fill: "var(--card, #0b0b0c)",
+        stroke: rgb(seed.line),
+        strokeWidth: 1.5,
+      }
+    case "filled":
+      return { fill: rgb(seed.star), stroke: rgb(seed.line), strokeWidth: 1 }
+    default:
+      return {
+        fill: "var(--card, #0b0b0c)",
+        stroke: rgb(seed.star, 0.8),
+        strokeWidth: 1,
+      }
+  }
+}
+
+/** A marker at every data point along the series' top line. */
+export function Dot({
+  variant = "border",
+  r = 2,
+}: {
+  variant?: DotVariant
+  r?: number
+}) {
+  const ctx = useChart()
+  const { dataKey, seed } = useSeries("Dot")
+  const band = ctx.bands[dataKey]
+  if (!ctx.ready || !band) return null
+  const paint = dotPaint(variant, seed)
+
+  return (
+    // Fade in once the fill has drawn so dots don't float over the entrance.
+    <g
+      style={{
+        opacity: ctx.entranceDone ? 1 : 0,
+        transition: "opacity 300ms ease",
+      }}
+    >
+      {band.map((b, i) => (
+        <circle
+          {...paint}
+          // biome-ignore lint/suspicious/noArrayIndexKey: index is the stable x position
+          key={i}
+          cx={ctx.xCenter(i) ?? 0}
+          cy={ctx.y(b[1])}
+          r={r}
+        />
+      ))}
+    </g>
+  )
+}
+
+/** A single marker at the hovered point — keys off the shared hover index. */
+export function ActiveDot({
+  variant = "colored-border",
+  r = 3,
+}: {
+  variant?: DotVariant
+  r?: number
+}) {
+  const ctx = useChart()
+  const { dataKey, seed } = useSeries("ActiveDot")
+  const band = ctx.bands[dataKey]
+  if (!ctx.ready || !band || ctx.hoverIndex == null || !ctx.entranceDone)
+    return null
+  const b = band[ctx.hoverIndex]
+  if (!b) return null
+  const paint = dotPaint(variant, seed)
+  const cx = ctx.xCenter(ctx.hoverIndex)
+  const cy = ctx.y(b[1])
+
+  return (
+    <g>
+      {/* Soft halo so the active point is unmistakable over the dither. */}
+      <circle cx={cx} cy={cy} r={r + 3} fill={rgb(seed.line, 1, 0.18)} />
+      <circle cx={cx} cy={cy} r={r} {...paint} strokeWidth={2} />
+    </g>
+  )
+}

--- a/apps/console/src/components/dither-kit/grid.tsx
+++ b/apps/console/src/components/dither-kit/grid.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import { useChartPart } from "./chart-context"
+
+export function Grid({
+  horizontal = true,
+  vertical = false,
+  strokeDasharray = "3 3",
+}: {
+  horizontal?: boolean
+  vertical?: boolean
+  strokeDasharray?: string
+}) {
+  const ctx = useChartPart("Grid")
+  if (!ctx.ready) return null
+  const { width } = ctx.plot
+
+  return (
+    <g className="stroke-border" strokeDasharray={strokeDasharray}>
+      {horizontal &&
+        ctx.y
+          .ticks(4)
+          .map((t) => (
+            <line
+              key={`h-${t}`}
+              x1={0}
+              x2={width}
+              y1={ctx.y(t)}
+              y2={ctx.y(t)}
+            />
+          ))}
+      {vertical &&
+        ctx.data.map((_, i) => (
+          <line
+            // biome-ignore lint/suspicious/noArrayIndexKey: index is the stable x position
+            key={`v-${i}`}
+            x1={ctx.xCenter(i) ?? 0}
+            x2={ctx.xCenter(i) ?? 0}
+            y1={0}
+            y2={ctx.plot.height}
+          />
+        ))}
+    </g>
+  )
+}
+
+// Render beneath the dither canvas so grid lines sit behind the fill.
+Grid.chartLayer = "back" as const

--- a/apps/console/src/components/dither-kit/legend.tsx
+++ b/apps/console/src/components/dither-kit/legend.tsx
@@ -1,0 +1,64 @@
+"use client"
+
+import { useCommonChart } from "./common-context"
+import { cn } from "./lib"
+import { rgb } from "./palette"
+
+/** Series/slice legend. With `isClickable`, each entry toggles its selection.
+ * Works in every chart family via the shared common context. */
+export function Legend({
+  isClickable = false,
+  align = "right",
+}: {
+  isClickable?: boolean
+  align?: "left" | "center" | "right"
+}) {
+  const chart = useCommonChart()
+
+  return (
+    <div
+      className={cn(
+        "pointer-events-none absolute inset-x-0 top-0 flex flex-wrap gap-3 px-1",
+        align === "right" && "justify-end",
+        align === "center" && "justify-center",
+        align === "left" && "justify-start",
+      )}
+    >
+      {chart.names.map((name) => {
+        const seed = chart.seedOf(name)
+        const emphasis = chart.selectedDataKey ?? chart.focusDataKey
+        const dimmed = emphasis !== null && emphasis !== name
+        return (
+          <button
+            key={name}
+            type="button"
+            disabled={!isClickable}
+            onClick={() =>
+              chart.selectDataKey(chart.selectedDataKey === name ? null : name)
+            }
+            // Hovering an entry spotlights its series so overlapping layers
+            // (e.g. two meshed radar polygons) can be told apart at a glance.
+            onPointerEnter={() => chart.setFocusDataKey(name)}
+            onPointerLeave={() => chart.setFocusDataKey(null)}
+            onFocus={() => chart.setFocusDataKey(name)}
+            onBlur={() => chart.setFocusDataKey(null)}
+            className={cn(
+              "text-muted-foreground flex items-center gap-1.5 font-mono text-[11px] transition-opacity",
+              isClickable &&
+                "pointer-events-auto cursor-pointer hover:text-foreground",
+              dimmed && "opacity-40",
+            )}
+          >
+            <span
+              className="size-2 rounded-[1px]"
+              style={{ backgroundColor: rgb(seed.fill) }}
+            />
+            {chart.labelOf(name)}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+Legend.chartLayer = "dom" as const

--- a/apps/console/src/components/dither-kit/legend.tsx
+++ b/apps/console/src/components/dither-kit/legend.tsx
@@ -43,7 +43,7 @@ export function Legend({
             onFocus={() => chart.setFocusDataKey(name)}
             onBlur={() => chart.setFocusDataKey(null)}
             className={cn(
-              "text-muted-foreground flex items-center gap-1.5 font-mono text-[11px] transition-opacity",
+              "flex items-center gap-1.5 font-mono text-[11px] text-muted-foreground transition-opacity",
               isClickable &&
                 "pointer-events-auto cursor-pointer hover:text-foreground",
               dimmed && "opacity-40",

--- a/apps/console/src/components/dither-kit/lib.ts
+++ b/apps/console/src/components/dither-kit/lib.ts
@@ -1,0 +1,8 @@
+import { type ClassValue, clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+/** Tailwind-aware className combiner — local copy so the chart pack is
+ * self-contained and portable as a registry. */
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/apps/console/src/components/dither-kit/palette.ts
+++ b/apps/console/src/components/dither-kit/palette.ts
@@ -1,0 +1,40 @@
+export type Rgb = [number, number, number]
+
+export type DitherColor =
+  | "green"
+  | "blue"
+  | "purple"
+  | "pink"
+  | "orange"
+  | "red"
+  | "grey"
+
+export type Seed = { fill: Rgb; line: Rgb; star: Rgb }
+
+// Each seed: the area-fill hue, the bright series line, and the star sparkle.
+export const PALETTE: Record<DitherColor, Seed> = {
+  green: { fill: [40, 210, 110], line: [150, 255, 180], star: [200, 255, 220] },
+  blue: { fill: [53, 143, 243], line: [150, 200, 255], star: [205, 228, 255] },
+  purple: {
+    fill: [150, 110, 255],
+    line: [200, 175, 255],
+    star: [225, 210, 255],
+  },
+  pink: { fill: [240, 90, 190], line: [255, 170, 220], star: [255, 205, 235] },
+  orange: {
+    fill: [255, 150, 50],
+    line: [255, 195, 130],
+    star: [255, 220, 175],
+  },
+  red: { fill: [240, 70, 70], line: [255, 150, 140], star: [255, 195, 185] },
+  // No-data: a muted grey so empty metrics read as "nothing here".
+  grey: { fill: [92, 92, 100], line: [140, 140, 150], star: [165, 165, 175] },
+}
+
+export const rgb = ([r, g, b]: Rgb, k = 1, a = 1) =>
+  `rgba(${Math.round(r * k)},${Math.round(g * k)},${Math.round(b * k)},${a})`
+
+export const seedOfColor = (color: DitherColor): Seed => PALETTE[color]
+
+export const isDitherColor = (value: unknown): value is DitherColor =>
+  typeof value === "string" && value in PALETTE

--- a/apps/console/src/components/dither-kit/polar-context.tsx
+++ b/apps/console/src/components/dither-kit/polar-context.tsx
@@ -1,0 +1,293 @@
+"use client"
+
+import { createContext, use, useState } from "react"
+
+import {
+  type AreaVariant,
+  type ChartConfig,
+  type ChartType,
+  type Margins,
+  useRevision,
+} from "./chart-context"
+import type { CommonChart } from "./common-context"
+import type { BloomInput } from "./dither-paint"
+import type { Seed } from "./palette"
+import { seedOfColor } from "./palette"
+import { type PieSlice, pieSlices, type RadarAxis, radarAxes } from "./polar"
+import type { Dimensions } from "./use-chart-dimensions"
+
+type Row = Record<string, unknown>
+
+const ROOT_OF: Record<string, string> = {
+  pie: "<PieChart />",
+  radar: "<RadarChart />",
+}
+
+export type PolarChartContextValue = {
+  chartType: ChartType
+  config: ChartConfig
+  configKeys: string[]
+  data: Row[]
+  dataLength: number
+  ready: boolean
+  plot: { width: number; height: number }
+  margins: Margins
+  center: { x: number; y: number }
+  outerRadius: number
+  innerRadius: number
+  animate: boolean
+  animationDuration: number
+  revision: number
+  bloom: BloomInput
+  bloomOnHover: boolean
+
+  seedOf: (key: string) => Seed
+  variantOf: (key: string) => AreaVariant
+  registerVariant: (key: string, variant: AreaVariant) => void
+  unregisterVariant: (key: string) => void
+
+  selectedDataKey: string | null
+  selectDataKey: (key: string | null) => void
+  /** Legend-hover spotlight — dims every series but this one while set. */
+  focusDataKey: string | null
+  setFocusDataKey: (key: string | null) => void
+  hoverIndex: number | null
+  setHoverIndex: (i: number | null) => void
+  setCursor: (px: number, py: number) => void
+  isMouseInChart: boolean
+  setMouseInChart: (over: boolean) => void
+
+  pie: PieSlice[] | null // present for pie charts
+  radar: { axes: RadarAxis[]; max: number } | null // present for radar charts
+
+  common: CommonChart
+}
+
+const PolarChartContext = createContext<PolarChartContextValue | null>(null)
+
+export function usePolarChart() {
+  const ctx = use(PolarChartContext)
+  if (!ctx) {
+    throw new Error("Polar chart parts must be used within a polar chart root.")
+  }
+  return ctx
+}
+
+/** Boundary guard for polar parts (`<Pie>`, `<Radar>`). */
+export function usePolarPart(part: string, kind: "pie" | "radar") {
+  const ctx = use(PolarChartContext)
+  if (!ctx) {
+    throw new Error(`<${part} /> must be used within ${ROOT_OF[kind]}.`)
+  }
+  if (ctx.chartType !== kind) {
+    throw new Error(
+      `<${part} /> is not valid inside ${ROOT_OF[ctx.chartType]} — it belongs in ${ROOT_OF[kind]}.`,
+    )
+  }
+  return ctx
+}
+
+export { PolarChartContext }
+
+export function usePolarController({
+  chartType,
+  data,
+  config,
+  dataKey,
+  nameKey,
+  innerRadiusRatio,
+  dimensions,
+  margins,
+  animate = true,
+  animationDuration = 900,
+  replayToken = 0,
+  bloom = "off",
+  bloomOnHover = false,
+  defaultSelectedDataKey = null,
+  onSelectionChange,
+}: {
+  chartType: "pie" | "radar"
+  data: Row[]
+  config: ChartConfig
+  dataKey: string
+  nameKey: string
+  innerRadiusRatio: number
+  dimensions: Dimensions
+  margins: Margins
+  animate?: boolean
+  animationDuration?: number
+  replayToken?: number
+  bloom?: BloomInput
+  bloomOnHover?: boolean
+  defaultSelectedDataKey?: string | null
+  onSelectionChange?: (key: string | null) => void
+}): PolarChartContextValue {
+  // React Compiler memoizes every render-scope value below — no manual
+  // useMemo/useCallback wrappers needed.
+  const configKeys = Object.keys(config)
+  const revision = useRevision(data, replayToken)
+
+  const [selectedDataKey, setSelectedDataKey] = useState<string | null>(
+    defaultSelectedDataKey,
+  )
+  const [focusDataKey, setFocusDataKey] = useState<string | null>(null)
+  const [hoverIndex, setHoverIndex] = useState<number | null>(null)
+  const [cursorX, setCursorX] = useState(0)
+  const [cursorY, setCursorY] = useState(0)
+  const [isMouseInChart, setMouseInChart] = useState(false)
+  const setCursor = (px: number, py: number) => {
+    setCursorX(px)
+    setCursorY(py)
+  }
+  const [variants, setVariants] = useState<Record<string, AreaVariant>>({})
+
+  const registerVariant = (key: string, variant: AreaVariant) => {
+    setVariants((prev) =>
+      prev[key] === variant ? prev : { ...prev, [key]: variant },
+    )
+  }
+  const unregisterVariant = (key: string) => {
+    setVariants((prev) => {
+      if (!(key in prev)) return prev
+      const next = { ...prev }
+      delete next[key]
+      return next
+    })
+  }
+
+  const selectDataKey = (key: string | null) => {
+    setSelectedDataKey(key)
+    onSelectionChange?.(key)
+  }
+
+  const plotWidth = Math.max(0, dimensions.width - margins.left - margins.right)
+  const plotHeight = Math.max(
+    0,
+    dimensions.height - margins.top - margins.bottom,
+  )
+  const ready = plotWidth > 0 && plotHeight > 0
+  const pad = chartType === "radar" ? 20 : 6
+  const outerRadius = Math.max(0, Math.min(plotWidth, plotHeight) / 2 - pad)
+  const innerRadius = chartType === "pie" ? outerRadius * innerRadiusRatio : 0
+  const centerX = plotWidth / 2
+  const centerY = plotHeight / 2
+
+  const seedOf = (key: string) => seedOfColor(config[key]?.color ?? "grey")
+  // "*" is the pie-wide variant set by <Pie>; radar registers per series key.
+  const variantOf = (key: string) =>
+    variants[key] ?? variants["*"] ?? "gradient"
+
+  const pie = chartType === "pie" ? pieSlices(data, dataKey, nameKey) : null
+
+  const radar = (() => {
+    if (chartType !== "radar") return null
+    let max = 0
+    for (const row of data) {
+      for (const key of configKeys) {
+        const v = Number(row[key]) || 0
+        if (v > max) max = v
+      }
+    }
+    return { axes: radarAxes(data, nameKey), max: max || 1 }
+  })()
+
+  const common: CommonChart = (() => {
+    const tooltipLeft = Math.max(
+      48,
+      Math.min(plotWidth + margins.left - 48, cursorX),
+    )
+    const tooltipTop = Math.max(margins.top + 44, cursorY)
+    const emphasis = selectedDataKey ?? focusDataKey
+    if (chartType === "pie" && pie) {
+      const names = pie.map((s) => s.name)
+      return {
+        names,
+        tooltipTop,
+        labelOf: (n) => config[n]?.label ?? n,
+        seedOf,
+        selectedDataKey,
+        selectDataKey,
+        focusDataKey,
+        setFocusDataKey,
+        hoverIndex,
+        ready,
+        tooltipLeft,
+        heading: (i) => pie[i]?.name ?? null,
+        itemsAt: (i) => {
+          const s = pie[i]
+          if (!s) return []
+          return [
+            {
+              name: s.name,
+              label: config[s.name]?.label ?? s.name,
+              value: s.value,
+              seed: seedOf(s.name),
+              dimmed: emphasis !== null && emphasis !== s.name,
+            },
+          ]
+        },
+      }
+    }
+    // radar
+    return {
+      names: configKeys,
+      tooltipTop,
+      labelOf: (n) => config[n]?.label ?? n,
+      seedOf,
+      selectedDataKey,
+      selectDataKey,
+      focusDataKey,
+      setFocusDataKey,
+      hoverIndex,
+      ready,
+      tooltipLeft,
+      heading: (i) => radar?.axes[i]?.label ?? null,
+      itemsAt: (i) =>
+        configKeys.map((name) => {
+          const raw = data[i]?.[name]
+          return {
+            name,
+            label: config[name]?.label ?? name,
+            value: typeof raw === "number" ? raw : 0,
+            seed: seedOf(name),
+            dimmed: emphasis !== null && emphasis !== name,
+          }
+        }),
+    }
+  })()
+
+  return {
+    chartType,
+    config,
+    configKeys,
+    data,
+    dataLength: data.length,
+    ready,
+    plot: { width: plotWidth, height: plotHeight },
+    margins,
+    center: { x: centerX, y: centerY },
+    outerRadius,
+    innerRadius,
+    animate,
+    animationDuration,
+    revision,
+    bloom,
+    bloomOnHover,
+    seedOf,
+    variantOf,
+    registerVariant,
+    unregisterVariant,
+    selectedDataKey,
+    selectDataKey,
+    focusDataKey,
+    setFocusDataKey,
+    hoverIndex,
+    setHoverIndex,
+    setCursor,
+    isMouseInChart,
+    setMouseInChart,
+    pie,
+    radar,
+    common,
+  }
+}

--- a/apps/console/src/components/dither-kit/polar-root.tsx
+++ b/apps/console/src/components/dither-kit/polar-root.tsx
@@ -1,0 +1,170 @@
+"use client"
+
+import {
+  Children,
+  type ComponentType,
+  isValidElement,
+  type ReactNode,
+} from "react"
+
+import type { ChartConfig, Margins } from "./chart-context"
+import { CommonChartContext } from "./common-context"
+import type { BloomInput } from "./dither-paint"
+import { cn } from "./lib"
+import { axisAtAngle, sliceAtAngle } from "./polar"
+import { PolarChartContext, usePolarController } from "./polar-context"
+import { useChartDimensions } from "./use-chart-dimensions"
+
+type Row = Record<string, unknown>
+
+const DEFAULT_POLAR_MARGINS: Margins = {
+  top: 22,
+  right: 14,
+  bottom: 14,
+  left: 14,
+}
+
+function layerOf(node: ReactNode): "back" | "dom" | "svg" {
+  if (!isValidElement(node) || typeof node.type === "string") return "svg"
+  return (node.type as { chartLayer?: "back" | "dom" }).chartLayer ?? "svg"
+}
+
+export type PolarRootProps<TData extends Row> = {
+  chartType: "pie" | "radar"
+  /** Family painter — `PieCanvas` or `RadarCanvas`; ships with each chart. */
+  Canvas: ComponentType
+  /** Extra back-layer SVG content (e.g. the radar frame). */
+  backDecoration?: ReactNode
+  data: TData[]
+  config: ChartConfig
+  children: ReactNode
+  dataKey: string
+  nameKey: string
+  innerRadius?: number // 0–1 ratio (donut); pie only
+  margins?: Partial<Margins>
+  className?: string
+  animate?: boolean
+  animationDuration?: number
+  replayToken?: number
+  bloom?: BloomInput
+  bloomOnHover?: boolean
+  defaultSelectedDataKey?: string | null
+  onSelectionChange?: (key: string | null) => void
+}
+
+export function PolarRoot<TData extends Row>({
+  chartType,
+  Canvas,
+  backDecoration,
+  data,
+  config,
+  children,
+  dataKey,
+  nameKey,
+  innerRadius = 0,
+  margins: marginsProp,
+  className,
+  animate = true,
+  animationDuration = 900,
+  replayToken = 0,
+  bloom = "off",
+  bloomOnHover = false,
+  defaultSelectedDataKey = null,
+  onSelectionChange,
+}: PolarRootProps<TData>) {
+  const { ref, size } = useChartDimensions<HTMLDivElement>()
+  const margins = { ...DEFAULT_POLAR_MARGINS, ...marginsProp }
+
+  const ctx = usePolarController({
+    chartType,
+    data,
+    config,
+    dataKey,
+    nameKey,
+    innerRadiusRatio: innerRadius,
+    dimensions: size,
+    margins,
+    animate,
+    animationDuration,
+    replayToken,
+    bloom,
+    bloomOnHover,
+    defaultSelectedDataKey,
+    onSelectionChange,
+  })
+
+  const backChildren: ReactNode[] = []
+  const svgChildren: ReactNode[] = []
+  const domChildren: ReactNode[] = []
+  Children.forEach(children, (child) => {
+    const layer = layerOf(child)
+    if (layer === "back") backChildren.push(child)
+    else if (layer === "dom") domChildren.push(child)
+    else svgChildren.push(child)
+  })
+
+  const onMove = (clientX: number, clientY: number) => {
+    const el = ref.current
+    if (!el) return
+    const rect = el.getBoundingClientRect()
+    const dx = clientX - rect.left - margins.left - ctx.center.x
+    const dy = clientY - rect.top - margins.top - ctx.center.y
+    const angle = Math.atan2(dy, dx)
+    const r = Math.hypot(dx, dy)
+    if (chartType === "pie" && ctx.pie) {
+      const inside = r <= ctx.outerRadius && r >= ctx.innerRadius
+      const i = inside ? sliceAtAngle(ctx.pie, angle) : -1
+      ctx.setHoverIndex(i >= 0 ? i : null)
+    } else if (ctx.radar) {
+      ctx.setHoverIndex(axisAtAngle(ctx.radar.axes, angle))
+    }
+    ctx.setCursor(clientX - rect.left, clientY - rect.top)
+  }
+
+  return (
+    <PolarChartContext value={ctx}>
+      <CommonChartContext value={ctx.common}>
+        <div
+          ref={ref}
+          className={cn("relative h-full w-full", className)}
+          onPointerEnter={() => ctx.setMouseInChart(true)}
+          onPointerMove={(e) => onMove(e.clientX, e.clientY)}
+          onPointerLeave={() => {
+            ctx.setMouseInChart(false)
+            ctx.setHoverIndex(null)
+          }}
+        >
+          {ctx.ready && (
+            <svg
+              width={size.width}
+              height={size.height}
+              className="absolute inset-0 overflow-visible"
+              aria-hidden
+              role="presentation"
+            >
+              <g transform={`translate(${margins.left},${margins.top})`}>
+                {backDecoration}
+                {backChildren}
+              </g>
+            </svg>
+          )}
+          <Canvas />
+          {ctx.ready && (
+            <svg
+              width={size.width}
+              height={size.height}
+              className="absolute inset-0 overflow-visible"
+              role="img"
+              aria-label="Chart"
+            >
+              <g transform={`translate(${margins.left},${margins.top})`}>
+                {svgChildren}
+              </g>
+            </svg>
+          )}
+          {domChildren}
+        </div>
+      </CommonChartContext>
+    </PolarChartContext>
+  )
+}

--- a/apps/console/src/components/dither-kit/polar.ts
+++ b/apps/console/src/components/dither-kit/polar.ts
@@ -1,0 +1,122 @@
+type Row = Record<string, unknown>
+
+const TOP = -Math.PI / 2
+const TAU = Math.PI * 2
+
+export type PieSlice = {
+  name: string
+  value: number
+  start: number // radians
+  end: number
+  mid: number
+}
+
+/** Slice angles from each data row's value under `dataKey`, named by `nameKey`. */
+export function pieSlices(
+  data: Row[],
+  dataKey: string,
+  nameKey: string,
+): PieSlice[] {
+  const vals = data.map((r) => Math.max(0, Number(r[dataKey]) || 0))
+  const total = vals.reduce((a, b) => a + b, 0) || 1
+  let a = TOP
+  return data.map((r, i) => {
+    const span = (vals[i] / total) * TAU
+    const slice = {
+      name: String(r[nameKey] ?? i),
+      value: vals[i],
+      start: a,
+      end: a + span,
+      mid: a + span / 2,
+    }
+    a += span
+    return slice
+  })
+}
+
+/** Which slice a pointer angle falls in (or -1). */
+export function sliceAtAngle(slices: PieSlice[], angle: number): number {
+  // Normalize so comparisons against [start, end) (which begin at TOP) work.
+  let a = angle
+  while (a < TOP) a += TAU
+  while (a >= TOP + TAU) a -= TAU
+  return slices.findIndex((s) => a >= s.start && a < s.end)
+}
+
+export type RadarAxis = { label: string; angle: number }
+
+/** Evenly-spaced spokes, one per data row, labelled by `nameKey`. */
+export function radarAxes(data: Row[], nameKey: string): RadarAxis[] {
+  const n = Math.max(data.length, 1)
+  return data.map((r, i) => ({
+    label: String(r[nameKey] ?? i),
+    angle: TOP + (i / n) * TAU,
+  }))
+}
+
+/** Nearest radar spoke to a pointer angle. */
+export function axisAtAngle(axes: RadarAxis[], angle: number): number {
+  let best = 0
+  let bestD = Infinity
+  axes.forEach((ax, i) => {
+    let d = Math.abs(((angle - ax.angle + Math.PI * 3) % TAU) - Math.PI)
+    d = Math.abs(d)
+    if (d < bestD) {
+      bestD = d
+      best = i
+    }
+  })
+  return best
+}
+
+export const polarX = (cx: number, r: number, angle: number) =>
+  cx + Math.cos(angle) * r
+export const polarY = (cy: number, r: number, angle: number) =>
+  cy + Math.sin(angle) * r
+
+/** Even-odd point-in-polygon test (polygon as flat [x0,y0,x1,y1,…]). */
+export function pointInPolygon(
+  px: number,
+  py: number,
+  poly: number[],
+): boolean {
+  let inside = false
+  const n = poly.length / 2
+  for (let i = 0, j = n - 1; i < n; j = i++) {
+    const xi = poly[i * 2]
+    const yi = poly[i * 2 + 1]
+    const xj = poly[j * 2]
+    const yj = poly[j * 2 + 1]
+    if (yi > py !== yj > py && px < ((xj - xi) * (py - yi)) / (yj - yi) + xi) {
+      inside = !inside
+    }
+  }
+  return inside
+}
+
+/** Distance from a point to the nearest edge of a polygon — drives the radial
+ * dither density (dense near the edge, thinning to the centre). */
+export function distToPolygonEdge(
+  px: number,
+  py: number,
+  poly: number[],
+): number {
+  let best = Infinity
+  const n = poly.length / 2
+  for (let i = 0, j = n - 1; i < n; j = i++) {
+    const xi = poly[i * 2]
+    const yi = poly[i * 2 + 1]
+    const xj = poly[j * 2]
+    const yj = poly[j * 2 + 1]
+    const dx = xj - xi
+    const dy = yj - yi
+    const len2 = dx * dx + dy * dy || 1
+    let t = ((px - xi) * dx + (py - yi) * dy) / len2
+    t = Math.max(0, Math.min(1, t))
+    const ex = xi + t * dx - px
+    const ey = yi + t * dy - py
+    const d = Math.hypot(ex, ey)
+    if (d < best) best = d
+  }
+  return best
+}

--- a/apps/console/src/components/dither-kit/scales.ts
+++ b/apps/console/src/components/dither-kit/scales.ts
@@ -1,0 +1,86 @@
+import { scaleBand, scaleLinear, scalePoint } from "d3-scale"
+import { stack as d3Stack, stackOffsetExpand } from "d3-shape"
+
+export type StackType = "default" | "stacked" | "percent"
+
+type Row = Record<string, unknown>
+
+const num = (v: unknown) =>
+  typeof v === "number" && Number.isFinite(v) ? v : 0
+
+/**
+ * Per-series [y0, y1] bands for every row. For `default` every series sits on
+ * the floor (y0 = 0); for `stacked`/`percent` they pile on top of each other
+ * via d3's stack layout. The shape `bands[key][i] = [y0, y1]` is what both the
+ * SVG area paths and the canvas overlay read from.
+ */
+export function computeBands(
+  data: Row[],
+  keys: string[],
+  stackType: StackType,
+): { bands: Record<string, [number, number][]>; max: number } {
+  if (stackType === "default") {
+    const bands: Record<string, [number, number][]> = {}
+    let max = 0
+    for (const key of keys) {
+      bands[key] = data.map((row) => {
+        const v = num(row[key])
+        if (v > max) max = v
+        return [0, v]
+      })
+    }
+    return { bands: bands, max: max || 1 }
+  }
+
+  const series = d3Stack<Row>()
+    .keys(keys)
+    .value((row, key) => num(row[key]))
+    .offset(stackType === "percent" ? stackOffsetExpand : (undefined as never))(
+    data,
+  )
+
+  const bands: Record<string, [number, number][]> = {}
+  let max = 0
+  series.forEach((layer) => {
+    bands[layer.key] = layer.map((point) => {
+      if (point[1] > max) max = point[1]
+      return [point[0], point[1]]
+    })
+  })
+  return { bands, max: max || 1 }
+}
+
+/** x positions for each row index, evenly spread across the plot width. */
+export function buildXScale(length: number, plotWidth: number) {
+  return scalePoint<number>()
+    .domain(Array.from({ length }, (_, i) => i))
+    .range([0, plotWidth])
+}
+
+/** Banded x for bar categories — each index owns a slot of `bandwidth` width. */
+export function buildBandScale(length: number, plotWidth: number) {
+  return scaleBand<number>()
+    .domain(Array.from({ length }, (_, i) => i))
+    .range([0, plotWidth])
+    .paddingInner(0.28)
+    .paddingOuter(0.18)
+}
+
+/** Index of the category whose band a horizontal pixel offset falls in. */
+export function indexAtBand(px: number, length: number, plotWidth: number) {
+  if (length <= 0 || plotWidth <= 0) return 0
+  const t = Math.max(0, Math.min(0.999, px / plotWidth))
+  return Math.min(length - 1, Math.floor(t * length))
+}
+
+/** value → vertical pixel, with the floor at the bottom of the plot. */
+export function buildYScale(max: number, plotHeight: number) {
+  return scaleLinear().domain([0, max]).nice().range([plotHeight, 0])
+}
+
+/** Index of the row nearest a horizontal pixel offset within the plot. */
+export function nearestIndex(px: number, length: number, plotWidth: number) {
+  if (length <= 1 || plotWidth <= 0) return 0
+  const t = Math.max(0, Math.min(1, px / plotWidth))
+  return Math.round(t * (length - 1))
+}

--- a/apps/console/src/components/dither-kit/series-context.tsx
+++ b/apps/console/src/components/dither-kit/series-context.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import { createContext, use } from "react"
+
+import type { Seed } from "./palette"
+
+export type SeriesContextValue = {
+  dataKey: string
+  seed: Seed
+  dimmed: boolean
+}
+
+export const SeriesContext = createContext<SeriesContextValue | null>(null)
+
+/** Boundary guard for series-scoped markers (`<Dot>`, `<ActiveDot>`). */
+export function useSeries(part: string) {
+  const ctx = use(SeriesContext)
+  if (!ctx) {
+    throw new Error(
+      `<${part} /> must be rendered inside a series (e.g. <Area />).`,
+    )
+  }
+  return ctx
+}

--- a/apps/console/src/components/dither-kit/sparkline.tsx
+++ b/apps/console/src/components/dither-kit/sparkline.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import { Area } from "./area"
+import { AreaChart } from "./area-chart"
+import type { AreaVariant } from "./chart-context"
+import type { BloomInput } from "./dither-paint"
+import type { DitherColor } from "./palette"
+
+export type SparklineProps = {
+  /** Plain numeric series — the common sparkline case. */
+  data: number[]
+  color: DitherColor
+  variant?: AreaVariant
+  /** Controlled crosshair position (e.g. a committed point). */
+  markerIndex?: number | null
+  /** Parent-driven hover (e.g. the whole card/row) — lifts the fill. */
+  hovered?: boolean
+  /** Glow on the dither fill. */
+  bloom?: BloomInput
+  /** Only bloom while hovered. */
+  bloomOnHover?: boolean
+  /** Play the entrance sweep — off by default for a calm spark. */
+  animate?: boolean
+  className?: string
+}
+
+/**
+ * Thin wrapper over {@link AreaChart} for the decorative-sparkline case: a
+ * single `number[]` series, no axes/grid/tooltip, no scrub crosshair (unless a
+ * `markerIndex` is supplied). Keeps the hover brightness lift.
+ */
+export function Sparkline({
+  data,
+  color,
+  variant = "gradient",
+  markerIndex = null,
+  hovered = false,
+  bloom = "off",
+  bloomOnHover = false,
+  animate = false,
+  className,
+}: SparklineProps) {
+  // React Compiler memoizes these against `data` / `color`.
+  const rows = data.map((v) => ({ v }))
+  const config = { v: { color } }
+
+  return (
+    <AreaChart
+      data={rows}
+      config={config}
+      interactive={false}
+      animate={animate}
+      markerIndex={markerIndex}
+      hovered={hovered}
+      bloom={bloom}
+      bloomOnHover={bloomOnHover}
+      margins={{ top: 0, right: 0, bottom: 0, left: 0 }}
+      className={className}
+    >
+      <Area dataKey="v" variant={variant} />
+    </AreaChart>
+  )
+}

--- a/apps/console/src/components/dither-kit/tooltip.tsx
+++ b/apps/console/src/components/dither-kit/tooltip.tsx
@@ -1,0 +1,107 @@
+"use client"
+
+import { AnimatePresence, motion } from "motion/react"
+import { useState } from "react"
+
+import { useCommonChart } from "./common-context"
+import { cn } from "./lib"
+import { rgb } from "./palette"
+
+export type TooltipVariant = "default" | "frosted-glass"
+
+const VARIANT: Record<TooltipVariant, string> = {
+  default: "bg-popover",
+  "frosted-glass": "bg-popover/70 backdrop-blur-sm",
+}
+
+/**
+ * Floating hover tooltip. Reads the shared common context so it works in every
+ * chart family. It glides between points and fades in/out (instead of snapping),
+ * and dims unselected series/slices.
+ */
+export function Tooltip({
+  labelKey,
+  valueFormatter,
+  variant = "default",
+}: {
+  labelKey?: string
+  valueFormatter?: (value: number, name: string) => string
+  variant?: TooltipVariant
+}) {
+  const chart = useCommonChart()
+  const show = chart.ready && chart.hoverIndex != null
+
+  // Retain the last hovered index so the card keeps its content while fading
+  // out — adjust-state-during-render (no refs in render).
+  const [lastIndex, setLastIndex] = useState(0)
+  if (chart.hoverIndex != null && chart.hoverIndex !== lastIndex) {
+    setLastIndex(chart.hoverIndex)
+  }
+  const index = chart.hoverIndex ?? lastIndex
+
+  const heading = chart.heading(index, labelKey)
+  const items = chart.itemsAt(index)
+
+  return (
+    <AnimatePresence>
+      {show && items.length > 0 && (
+        <motion.div
+          key="dither-tooltip"
+          initial={{
+            opacity: 0,
+            x: "-50%",
+            y: "-115%",
+            top: chart.tooltipTop,
+            left: chart.tooltipLeft,
+          }}
+          animate={{
+            opacity: 1,
+            x: "-50%",
+            y: "-115%",
+            top: chart.tooltipTop,
+            left: chart.tooltipLeft,
+          }}
+          exit={{ opacity: 0 }}
+          transition={{
+            type: "spring",
+            stiffness: 520,
+            damping: 38,
+            mass: 0.6,
+          }}
+          className={cn(
+            "pointer-events-none absolute z-10 rounded-md border px-2 py-1 shadow-sm",
+            VARIANT[variant],
+          )}
+        >
+          {heading && (
+            <div className="text-muted-foreground mb-0.5 font-mono text-[10px]">
+              {heading}
+            </div>
+          )}
+          <div className="flex flex-col gap-0.5">
+            {items.map((item) => (
+              <div
+                key={item.name}
+                className="text-popover-foreground flex items-center gap-1.5 font-mono text-[11px] tabular-nums"
+                style={{ opacity: item.dimmed ? 0.4 : 1 }}
+              >
+                <span
+                  className="size-2 rounded-[1px]"
+                  style={{ backgroundColor: rgb(item.seed.fill) }}
+                />
+                <span className="text-muted-foreground">{item.label}</span>
+                <span className="ml-auto pl-2 text-foreground">
+                  {valueFormatter
+                    ? valueFormatter(item.value, item.name)
+                    : item.value.toLocaleString()}
+                </span>
+              </div>
+            ))}
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}
+
+Tooltip.chartLayer = "dom" as const

--- a/apps/console/src/components/dither-kit/tooltip.tsx
+++ b/apps/console/src/components/dither-kit/tooltip.tsx
@@ -10,8 +10,8 @@ import { rgb } from "./palette"
 export type TooltipVariant = "default" | "frosted-glass"
 
 const VARIANT: Record<TooltipVariant, string> = {
-  default: "bg-popover",
-  "frosted-glass": "bg-popover/70 backdrop-blur-sm",
+  default: "bg-surface/80 backdrop-blur-xl",
+  "frosted-glass": "bg-surface/70 backdrop-blur-sm",
 }
 
 /**
@@ -69,12 +69,12 @@ export function Tooltip({
             mass: 0.6,
           }}
           className={cn(
-            "pointer-events-none absolute z-10 rounded-md border px-2 py-1 shadow-sm",
+            "pointer-events-none absolute z-10 border border-dashed border-border px-2 py-1 shadow-sm",
             VARIANT[variant],
           )}
         >
           {heading && (
-            <div className="text-muted-foreground mb-0.5 font-mono text-[10px]">
+            <div className="mb-0.5 font-mono text-[10px] text-muted-foreground">
               {heading}
             </div>
           )}
@@ -82,7 +82,7 @@ export function Tooltip({
             {items.map((item) => (
               <div
                 key={item.name}
-                className="text-popover-foreground flex items-center gap-1.5 font-mono text-[11px] tabular-nums"
+                className="flex items-center gap-1.5 font-mono text-[11px] text-popover-foreground tabular-nums"
                 style={{ opacity: item.dimmed ? 0.4 : 1 }}
               >
                 <span

--- a/apps/console/src/components/dither-kit/use-chart-dimensions.ts
+++ b/apps/console/src/components/dither-kit/use-chart-dimensions.ts
@@ -1,0 +1,37 @@
+import { useLayoutEffect, useRef, useState } from "react"
+
+export type Dimensions = { width: number; height: number }
+
+/**
+ * Tracks an element's CSS pixel size via {@link ResizeObserver}. Uses
+ * `clientWidth`/`clientHeight` (the layout size) rather than
+ * `getBoundingClientRect()` so a parent `layoutId` morph — which scales the
+ * element via a transform — can't trick the chart into measuring a scaled size
+ * and locking its canvas to it.
+ */
+export function useChartDimensions<T extends HTMLElement>() {
+  const ref = useRef<T>(null)
+  const [size, setSize] = useState<Dimensions>({ width: 0, height: 0 })
+
+  useLayoutEffect(() => {
+    const el = ref.current
+    if (!el) return
+
+    const measure = () => {
+      const width = Math.max(0, el.clientWidth)
+      const height = Math.max(0, el.clientHeight)
+      setSize((prev) =>
+        prev.width === width && prev.height === height
+          ? prev // guard against repeat fires
+          : { width, height },
+      )
+    }
+
+    const ro = new ResizeObserver(measure)
+    ro.observe(el)
+    measure()
+    return () => ro.disconnect()
+  }, [])
+
+  return { ref, size }
+}

--- a/apps/console/src/components/dither-kit/x-axis.tsx
+++ b/apps/console/src/components/dither-kit/x-axis.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import { useChartPart } from "./chart-context"
+
+export function XAxis({
+  dataKey,
+  tickFormatter,
+  tickMargin = 8,
+  maxTicks = 8,
+}: {
+  dataKey?: string
+  tickFormatter?: (value: unknown, index: number) => string
+  tickMargin?: number
+  maxTicks?: number
+}) {
+  const ctx = useChartPart("XAxis")
+  if (!ctx.ready) return null
+
+  const step = Math.max(1, Math.ceil(ctx.dataLength / maxTicks))
+  const y = ctx.plot.height + tickMargin
+
+  return (
+    <g className="text-muted-foreground fill-current font-mono text-[10px]">
+      {ctx.data.map((row, i) => {
+        if (i % step !== 0) return null
+        const raw = dataKey ? row[dataKey] : i
+        const label = tickFormatter ? tickFormatter(raw, i) : String(raw ?? "")
+        return (
+          <text
+            // biome-ignore lint/suspicious/noArrayIndexKey: index is the stable x position
+            key={i}
+            x={ctx.xCenter(i) ?? 0}
+            y={y}
+            textAnchor="middle"
+            dominantBaseline="hanging"
+            fill="currentColor"
+          >
+            {label}
+          </text>
+        )
+      })}
+    </g>
+  )
+}

--- a/apps/console/src/components/dither-kit/x-axis.tsx
+++ b/apps/console/src/components/dither-kit/x-axis.tsx
@@ -20,7 +20,7 @@ export function XAxis({
   const y = ctx.plot.height + tickMargin
 
   return (
-    <g className="text-muted-foreground fill-current font-mono text-[10px]">
+    <g className="fill-current font-mono text-[10px] text-muted-foreground">
       {ctx.data.map((row, i) => {
         if (i % step !== 0) return null
         const raw = dataKey ? row[dataKey] : i

--- a/apps/console/src/components/dither-kit/y-axis.tsx
+++ b/apps/console/src/components/dither-kit/y-axis.tsx
@@ -15,7 +15,7 @@ export function YAxis({
   if (!ctx.ready) return null
 
   return (
-    <g className="text-muted-foreground fill-current font-mono text-[10px]">
+    <g className="fill-current font-mono text-[10px] text-muted-foreground">
       {ctx.y.ticks(tickCount).map((t) => (
         <text
           key={t}

--- a/apps/console/src/components/dither-kit/y-axis.tsx
+++ b/apps/console/src/components/dither-kit/y-axis.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import { useChartPart } from "./chart-context"
+
+export function YAxis({
+  tickFormatter,
+  tickCount = 4,
+  tickMargin = 8,
+}: {
+  tickFormatter?: (value: number) => string
+  tickCount?: number
+  tickMargin?: number
+}) {
+  const ctx = useChartPart("YAxis")
+  if (!ctx.ready) return null
+
+  return (
+    <g className="text-muted-foreground fill-current font-mono text-[10px]">
+      {ctx.y.ticks(tickCount).map((t) => (
+        <text
+          key={t}
+          x={-tickMargin}
+          y={ctx.y(t)}
+          textAnchor="end"
+          dominantBaseline="central"
+          fill="currentColor"
+        >
+          {tickFormatter ? tickFormatter(t) : t}
+        </text>
+      ))}
+    </g>
+  )
+}

--- a/apps/console/src/lib/utils.ts
+++ b/apps/console/src/lib/utils.ts
@@ -1,0 +1,1 @@
+export { cn } from "@superserve/ui"

--- a/bun.lock
+++ b/bun.lock
@@ -50,7 +50,10 @@
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
+        "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.2.0",
         "motion": "^12.0.0",
         "next": "^16.1.6",
         "posthog-js": "^1.353.0",
@@ -58,6 +61,7 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "resend": "^6.9.2",
+        "tailwind-merge": "^3.6.0",
         "zod": "^3.25.67",
       },
       "devDependencies": {
@@ -67,6 +71,8 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
+        "@types/d3-scale": "^4.0.9",
+        "@types/d3-shape": "^3.1.7",
         "@types/node": "^25.2.3",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -169,7 +175,7 @@
     },
     "packages/sdk": {
       "name": "@superserve/sdk",
-      "version": "0.7.8",
+      "version": "0.8.0",
       "devDependencies": {
         "@superserve/typescript-config": "workspace:*",
         "@types/node": "^25.5.2",
@@ -1021,6 +1027,14 @@
 
     "@types/cors": ["@types/cors@2.8.19", "", { "dependencies": { "@types/node": "*" } }, "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg=="],
 
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
@@ -1370,6 +1384,24 @@
     "cssfilter": ["cssfilter@0.0.10", "", {}, "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
 
     "data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
 
@@ -1772,6 +1804,8 @@
     "inquirer": ["inquirer@12.3.0", "", { "dependencies": { "@inquirer/core": "^10.1.2", "@inquirer/prompts": "^7.2.1", "@inquirer/type": "^3.0.2", "ansi-escapes": "^4.3.2", "mute-stream": "^2.0.0", "run-async": "^3.0.0", "rxjs": "^7.8.1" }, "peerDependencies": { "@types/node": ">=18" } }, "sha512-3NixUXq+hM8ezj2wc7wC37b32/rHq1MwNZDYdvx+d6jokOD+r+i8Q4Pkylh9tISYP114A128LCX8RKhopC5RfQ=="],
 
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
 
@@ -2617,7 +2651,7 @@
 
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
 
-    "tailwind-merge": ["tailwind-merge@3.5.0", "", {}, "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A=="],
+    "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
 
     "tailwindcss": ["tailwindcss@4.2.2", "", {}, "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q=="],
 

--- a/packages/tailwind-config/theme.css
+++ b/packages/tailwind-config/theme.css
@@ -18,6 +18,12 @@
   --color-ring: var(--color-brand);
   --color-muted: rgba(255, 255, 255, 0.6);
 
+  /* shadcn-token aliases so registry-vendored components
+     (e.g. dither-kit) pick up the console palette */
+  --color-muted-foreground: var(--color-muted);
+  --color-popover: var(--color-surface);
+  --color-popover-foreground: var(--color-foreground);
+
   /* primary is the accent; aliased to brand so existing
      bg-primary / text-primary usages become mint in one move */
   --color-primary: var(--color-brand);


### PR DESCRIPTION
## Summary
- Vendor [dither-kit](https://github.com/Boring-Software-Inc/dither-kit) chart components into `apps/console/src/components/dither-kit/` via the shadcn CLI (adds `d3-scale`, `d3-shape`, `motion` + their type packages)
- Add `components.json` and a `cn` re-export shim (`src/lib/utils.ts`) so the shadcn CLI can install into the console
- Replace the hand-rolled SVG line charts on Plan & Usage with dither-kit `AreaChart` — dithered gradient fills, scrub tooltip, entrance animation; existing bucketing logic (`usage-chart.ts`) unchanged
- Tooltip/axis labels now include the hour for sub-day buckets

## Notes
- Upstream dither-kit has no license file yet — worth confirming with the author before merge since this vendors its source into a public repo
- Chart color uses the `green` palette seed (closest to the mint brand accent)

## Test plan
- [x] `tsc --noEmit` clean
- [x] `oxlint` 0 errors
- [x] 438 console unit tests pass
- [ ] Visual check of /plan-usage with real billing data

🤖 Generated with [Claude Code](https://claude.com/claude-code)