### PR TITLE
docs: document Python/pip availability per sandbox template

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -201,7 +201,11 @@
           },
           {
             "group": "Billing",
-            "pages": ["GET /billing/pricing", "GET /billing/pricing/public"]
+            "pages": [
+              "GET /billing/pricing",
+              "GET /billing/pricing/public",
+              "GET /billing/summary"
+            ]
           },
           {
             "group": "Team Management",

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -30,6 +30,10 @@ See [Get an API key](/api-key) for more options.
 
 ## 3. Create a sandbox and run a command
 
+<Note>
+`Sandbox.create()` defaults to the `superserve/base` template — a bare Ubuntu 24.04 image with no Python or pip installed. For Python work, pass `fromTemplate: "superserve/python-3.11"` (or another Python template). See [what each template includes](/templates/overview#python-pip-availability).
+</Note>
+
 <CodeGroup>
 ```typescript TypeScript
 import { Sandbox } from "@superserve/sdk"

--- a/docs/templates/overview.mdx
+++ b/docs/templates/overview.mdx
@@ -24,6 +24,25 @@ Curated by Superserve and available to every team. Identified by the `superserve
 
 A sandbox inherits its VM shape (vCPU, memory, disk) from the template it boots from — see [BuildSpec reference](/templates/build-spec) for the limits.
 
+## Python & pip availability
+
+Only some system templates include Python, and `pip install` behavior depends on how it got installed. Debian/Ubuntu's `apt`-installed Python is a PEP 668 "externally managed" environment — a bare `pip install` fails with `externally-managed-environment`. The official Python Docker images (`python:3.11-slim`, `python:3.11`) don't have this restriction.
+
+| Template | Python | pip | PEP 668 (externally managed) |
+|---|---|---|---|
+| `superserve/base` | Not installed | — | — |
+| `superserve/python-3.11` | 3.11 | Yes | No — `pip install` works directly |
+| `superserve/node-22` | Not installed | — | — |
+| `superserve/python-ml` | 3.11 | Yes | No — `pip install` works directly |
+| `superserve/code-interpreter` | 3.11 | Yes | No — `pip install` works directly |
+| `superserve/claude-code` | 3.12 (Ubuntu 24.04 system Python) | `pip3` | Yes — use a venv, `pipx`, or `pip install --break-system-packages` |
+| `superserve/openclaw` | Not installed | — | — |
+| `superserve/hermes` | Not installed | — | — |
+
+<Note>
+Need Python without the PEP 668 restriction? Boot from `superserve/python-3.11`, `superserve/python-ml`, or `superserve/code-interpreter` instead of installing Python via `apt` in a custom template — the official Python base images aren't externally managed.
+</Note>
+
 ## Team templates
 
 Team-owned templates let you bake in team-specific dependencies (e.g. `my-python-env` with scientific libs pre-installed). They're created via `Template.create()` and referenced by name.


### PR DESCRIPTION
## Summary
An AX eval flagged that the docs never state what the default sandbox image includes, which led to repeated pip-related errors (missing Python, PEP 668 `externally-managed-environment` failures). Adds a reference table so users can tell upfront whether a template has Python/pip and whether it's subject to PEP 668.

- `docs/templates/overview.mdx`: new "Python & pip availability" table across all system templates (Python presence/version, pip, PEP 668 status), plus a note pointing to the non-restricted Python templates.
- `docs/quickstart.mdx`: callout on the sandbox-creation step noting the default `superserve/base` template has no Python/pip, with a `fromTemplate` example.

## Testing
- `bun run docs:build` (mintlify validate) passes.
- Previewed both pages locally with `mintlify dev`.