### PR TITLE
Add pr-loop GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
       - "package.json"
       - "bun.lock"
       - "turbo.json"
-      - ".github/workflows/ci.yml"
+      - ".github/workflows/**"
   pull_request:
     branches: [main]
     paths:
@@ -22,7 +22,7 @@ on:
       - "package.json"
       - "bun.lock"
       - "turbo.json"
-      - ".github/workflows/ci.yml"
+      - ".github/workflows/**"
 
 jobs:
   ci:

--- a/.github/workflows/loop-pr-loop.yml
+++ b/.github/workflows/loop-pr-loop.yml
@@ -1,0 +1,35 @@
+# Installed by `superserve-loops add pr-loop`. Runs on every PR code change
+# (a commit pushed to a PR) — no idle cron. One warm-sandbox tick per event, then it sleeps.
+# Note: `pull_request` from a forked repo gets a read-only token, so reviews on fork PRs need
+# the cross-repo PAT path (see below) or `pull_request_target` (the loop runs PR code only in
+# the sandbox, never on the runner). Add `schedule:` back if you also want a safety-net sweep.
+name: loop-pr-loop
+on:
+  pull_request:
+    types: [opened, synchronize, reopened] # synchronize = new commits pushed to the PR
+  workflow_dispatch: {}
+concurrency:
+  # Serialize per repo: all PR reviews share one warm sandbox, so don't run two at once.
+  group: loop-pr-loop
+  cancel-in-progress: false
+# Least privilege: clone the repo + post the review and ready-to-merge / needs-human labels.
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  tick:
+    # Fork PRs can't read repo secrets or write with the built-in token — skip them.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: oven-sh/setup-bun@v2
+      # Runs the PUBLISHED loop — no loop source is vendored into this repo, and no repo
+      # checkout is needed (the sandbox clones the target repo itself). `@stable` is a
+      # Superserve-gated channel, so blessed updates roll out here without editing this file.
+      # --pr focuses the tick on the changed PR; empty on manual dispatch → sweep all.
+      - run: bunx @superserve/loops@stable run pr-loop --repo "${{ github.repository }}" --pr "${{ github.event.pull_request.number }}" --once
+        env:
+          SUPERSERVE_API_KEY: ${{ secrets.SUPERSERVE_API_KEY }}
+          SUPERSERVE_CLAUDE_SECRET: claude-oauth
+          # Reviews post as github-actions[bot] via the workflow's built-in token.
+          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Related Issues
<!-- Link any related issues: Fixes #123, Relates to #456 -->
None.

## Description
Adds a `loop-pr-loop` GitHub Actions workflow that runs the published `@superserve/loops` PR review loop on every PR code change (opened, synchronize, reopened) plus manual dispatch, driving one warm-sandbox tick per event with no idle cron. It uses least-privilege permissions (`contents: read`, `pull-requests: write`), serializes runs per repo via a concurrency group, and skips fork PRs that can't read secrets or write with the built-in token.

## Additional Context
The loop runs from the `@stable` Superserve-gated channel via `bunx`, so no loop source is vendored and no repo checkout is needed — the sandbox clones the target repo itself. Reviews post as `github-actions[bot]` using the workflow's built-in token.

## Testing
<!-- Describe how you tested these changes -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] All tests passing

## Screenshots/Demo
N/A