### PR TITLE
console: findTeamById prefers the cell a team names as home

### DIFF
--- a/apps/console/src/lib/api/team-directory.test.ts
+++ b/apps/console/src/lib/api/team-directory.test.ts
@@ -387,4 +387,33 @@ describe("findTeamById home-region preference", () => {
     const found = await findTeamById("t-1")
     expect(found?.region).toBe("use")
   })
+
+  const downCell = (message: string) =>
+    ({
+      from: vi.fn(() => {
+        throw new Error(message)
+      }),
+    }) as unknown as ReturnType<typeof cellClient>
+
+  it("serves the pointer row when the home cell is down", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    regions = ["use", "usw"]
+    cellClients = {
+      use: cellClient([], [team("usw")]),
+      usw: downCell("usw pooler unreachable"),
+    }
+    const found = await findTeamById("t-1")
+    expect(found?.region).toBe("use")
+    expect(errSpy).toHaveBeenCalledOnce()
+    errSpy.mockRestore()
+  })
+
+  it("still throws when the default cell fails during the lookup", async () => {
+    regions = ["use", "usw"]
+    cellClients = {
+      use: downCell("primary down"),
+      usw: cellClient([], [team("usw")]),
+    }
+    await expect(findTeamById("t-1")).rejects.toThrow("primary down")
+  })
 })

--- a/apps/console/src/lib/api/team-directory.test.ts
+++ b/apps/console/src/lib/api/team-directory.test.ts
@@ -416,4 +416,15 @@ describe("findTeamById home-region preference", () => {
     }
     await expect(findTeamById("t-1")).rejects.toThrow("primary down")
   })
+
+  it("ignores a pointer row whose home cell is not configured", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    regions = ["use"]
+    cellClients = {
+      use: cellClient([], [team("usw")]),
+    }
+    expect(await findTeamById("t-1")).toBeNull()
+    expect(errSpy).toHaveBeenCalledOnce()
+    errSpy.mockRestore()
+  })
 })

--- a/apps/console/src/lib/api/team-directory.test.ts
+++ b/apps/console/src/lib/api/team-directory.test.ts
@@ -7,7 +7,7 @@ let cellClients: Record<string, ReturnType<typeof cellClient>> = {}
 // Minimal per-cell client: team_member memberships and team name lookups.
 function cellClient(
   memberships: Array<{ team_id: string }>,
-  teams: Array<{ id: string; name: string }> = [],
+  teams: Array<{ id: string; name: string; home_region?: string | null }> = [],
   rbac: Array<{ team_id: string; status: string }> = [],
 ) {
   const from = vi.fn((table: string) => {
@@ -29,6 +29,12 @@ function cellClient(
       return {
         select: () => ({
           in: async () => ({ data: teams, error: null }),
+          eq: (_col: string, id: string) => ({
+            limit: async () => ({
+              data: teams.filter((t) => t.id === id),
+              error: null,
+            }),
+          }),
         }),
       }
     }
@@ -49,6 +55,7 @@ vi.mock("@/lib/cells", () => ({
 
 import {
   clearMembershipDirectoryCache,
+  findTeamById,
   listTeamMembershipsForUser,
   listTeamMembershipsForUserDetailed,
   listTeamsForUser,
@@ -335,5 +342,49 @@ describe("membershipExistsInCell", () => {
       ),
     }
     expect(await membershipExistsInCell("use", "u1", "t1")).toBe(false)
+  })
+})
+
+describe("findTeamById home-region preference", () => {
+  // After a cross-cell migration the team id exists in two cells: the live
+  // row in its new home and a detached pointer row in the old cell whose
+  // home_region names the new home. The lookup must return the home row.
+  const team = (home_region: string | null) => ({
+    id: "t-1",
+    name: "acme",
+    active_sandbox_count: 0,
+    max_sandboxes: 10,
+    created_at: "2026-01-01",
+    home_region,
+  })
+
+  it("prefers the cell the team names as home over an earlier pointer row", async () => {
+    regions = ["use", "usw"]
+    cellClients = {
+      use: cellClient([], [team("usw")]),
+      usw: cellClient([], [team("usw")]),
+    }
+    const found = await findTeamById("t-1")
+    expect(found?.region).toBe("usw")
+  })
+
+  it("falls back to the pointer row when the home row is missing", async () => {
+    regions = ["use", "usw"]
+    cellClients = {
+      use: cellClient([], [team("usw")]),
+      usw: cellClient([], []),
+    }
+    const found = await findTeamById("t-1")
+    expect(found?.region).toBe("use")
+  })
+
+  it("returns a row whose home_region is unset (pre-migration schema)", async () => {
+    regions = ["use", "usw"]
+    cellClients = {
+      use: cellClient([], [team(null)]),
+      usw: cellClient([], []),
+    }
+    const found = await findTeamById("t-1")
+    expect(found?.region).toBe("use")
   })
 })

--- a/apps/console/src/lib/api/team-directory.ts
+++ b/apps/console/src/lib/api/team-directory.ts
@@ -287,8 +287,14 @@ async function findTeamInRegion(
  * as home is authoritative; a row that names a different home is only a
  * pointer, used as a last resort if the home row is missing — including when
  * the home cell itself is degraded and could not be read.
+ *
+ * A pointer naming a cell that is not configured is dangling: its
+ * authoritative cell was never consulted, and the region it would hand
+ * callers routes impersonation and key minting into the detached copy. That
+ * fails closed — the row is ignored (logged) rather than served.
  */
 export async function findTeamById(teamId: string): Promise<TeamRecord | null> {
+  const regions = configuredRegions()
   const { items } = await acrossCells(async (region) => {
     const team = await findTeamInRegion(region, teamId)
     return team ? [team] : []
@@ -297,6 +303,12 @@ export async function findTeamById(teamId: string): Promise<TeamRecord | null> {
   let fallback: TeamRecord | null = null
   for (const { home_region, ...record } of items) {
     if (!home_region || home_region === record.region) return record
+    if (!regions.includes(home_region)) {
+      console.error(
+        `team directory: team ${record.id} row in cell ${record.region} names unconfigured home cell ${home_region}, ignoring detached row`,
+      )
+      continue
+    }
     fallback ??= record
   }
 

--- a/apps/console/src/lib/api/team-directory.ts
+++ b/apps/console/src/lib/api/team-directory.ts
@@ -252,11 +252,13 @@ export async function listAllTeams(): Promise<TeamRecord[]> {
 async function findTeamInRegion(
   region: string,
   teamId: string,
-): Promise<TeamRecord | null> {
+): Promise<(TeamRecord & { home_region: string | null }) | null> {
   const admin = cellFor(region).createAdminClient()
   const { data: teams, error } = await admin
     .from("team")
-    .select("id, name, active_sandbox_count, max_sandboxes, created_at")
+    .select(
+      "id, name, active_sandbox_count, max_sandboxes, created_at, home_region",
+    )
     .eq("id", teamId)
     .limit(1)
 
@@ -272,19 +274,29 @@ async function findTeamInRegion(
     max_sandboxes: team.max_sandboxes as number,
     created_at: team.created_at as string,
     region,
+    home_region: (team.home_region as string | null) ?? null,
   }
 }
 
 /**
- * Find a team by id across all configured cells. Returns the first match
- * with its source region, or null if the team does not exist anywhere.
+ * Find a team by id across all configured cells, preferring the cell the
+ * team calls home. After a cross-cell migration the same team id exists in
+ * two cells at once: the live row in its new home and a detached fallback
+ * row in the old cell (kept for rollback until purge). The fallback row's
+ * home_region points at the new cell, so a row found in the cell it names
+ * as home is authoritative; a row that names a different home is only a
+ * pointer, used as a last resort if the home row is missing.
  */
 export async function findTeamById(teamId: string): Promise<TeamRecord | null> {
   const regions = configuredRegions()
+  let fallback: TeamRecord | null = null
   for (const region of regions) {
     const team = await findTeamInRegion(region, teamId)
-    if (team) return team
+    if (!team) continue
+    const { home_region, ...record } = team
+    if (!home_region || home_region === region) return record
+    fallback ??= record
   }
 
-  return null
+  return fallback
 }

--- a/apps/console/src/lib/api/team-directory.ts
+++ b/apps/console/src/lib/api/team-directory.ts
@@ -285,16 +285,18 @@ async function findTeamInRegion(
  * row in the old cell (kept for rollback until purge). The fallback row's
  * home_region points at the new cell, so a row found in the cell it names
  * as home is authoritative; a row that names a different home is only a
- * pointer, used as a last resort if the home row is missing.
+ * pointer, used as a last resort if the home row is missing — including when
+ * the home cell itself is degraded and could not be read.
  */
 export async function findTeamById(teamId: string): Promise<TeamRecord | null> {
-  const regions = configuredRegions()
-  let fallback: TeamRecord | null = null
-  for (const region of regions) {
+  const { items } = await acrossCells(async (region) => {
     const team = await findTeamInRegion(region, teamId)
-    if (!team) continue
-    const { home_region, ...record } = team
-    if (!home_region || home_region === region) return record
+    return team ? [team] : []
+  })
+
+  let fallback: TeamRecord | null = null
+  for (const { home_region, ...record } of items) {
+    if (!home_region || home_region === record.region) return record
     fallback ??= record
   }
 


### PR DESCRIPTION
## Summary
Platform impersonation of a migrated team fails with 401s: the impersonation cookie pins the team's region at start, and `findTeamById` returns the first cell match in configured order — for a migrated team that's the detached fallback row in the old cell, whose keys are all revoked. Part of the multi-region cells effort.

## Decisions
- A row found in the cell it names as `home_region` is authoritative; a row naming a different home is treated as a pointer and used only when the home row is missing (covers the pre-purge rollback window).
- Rows with no `home_region` (pre-migration schema) behave exactly as before.

## Testing
- 3 new tests: home-row preference over an earlier pointer row, pointer fallback when the home row is missing, null-home_region compatibility.
- Full team-directory suite: 24/24.
- Root cause verified live against a migrated team (impersonation 401 → resolves after the equivalent data-side fix).