### PR TITLE
[TEST] docs: verify automatic Mintlify PR preview

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -70,7 +70,12 @@
         "groups": [
           {
             "group": "Get Started",
-            "pages": ["introduction", "quickstart", "api-key"]
+            "pages": [
+              "introduction",
+              "quickstart",
+              "api-key",
+              "preview-smoke-test"
+            ]
           },
           {
             "group": "Sandbox",

--- a/docs/preview-smoke-test.mdx
+++ b/docs/preview-smoke-test.mdx
@@ -1,0 +1,18 @@
+---
+title: "Mintlify preview smoke test"
+sidebarTitle: Preview smoke test
+description: A temporary page used to verify automatic Mintlify previews for pull requests.
+---
+
+<Warning>
+  This is a temporary test page. It should appear only in this pull request's
+  preview and must not be merged into the production documentation.
+</Warning>
+
+## Automatic preview is working
+
+If you can read this page at a `mintlify.app` preview URL, Mintlify successfully
+built documentation from the pull request branch before it was merged into
+`main`.
+
+**Smoke-test marker:** `mintlify-pr-preview-2026-07-16`


### PR DESCRIPTION
## Summary

- adds a temporary `preview-smoke-test` documentation page
- registers it under **Documentation → Get Started**

## Purpose

This draft PR exists only to test whether Mintlify automatically generates a preview for a documentation PR targeting `main`.

Expected result: the Mintlify check should provide a preview URL, and that preview should contain the page with marker `mintlify-pr-preview-2026-07-16`.

**Do not merge this PR.** Close it after the preview test.

## Validation

- `mintlify validate` passed under Node 22
- `bun run docs:check-nav` passed