### PR TITLE
Fix admin access to impersonated audit logs

### DIFF
--- a/apps/console/src/app/(dashboard)/audit-logs/page.tsx
+++ b/apps/console/src/app/(dashboard)/audit-logs/page.tsx
@@ -26,10 +26,13 @@ import { EmptyState } from "@/components/empty-state"
 import { ErrorState } from "@/components/error-state"
 import { PageHeader } from "@/components/page-header"
 import { Pagination } from "@/components/pagination"
+import { useQueryScope } from "@/components/query-provider"
 import { StickyHoverTableBody } from "@/components/sticky-hover-table"
 import { TableToolbar } from "@/components/table-toolbar"
 import { useActivityPage } from "@/hooks/use-activity"
 import { useListParams } from "@/hooks/use-list-params"
+import { useUser } from "@/hooks/use-user"
+import { canReadPlatformActivity } from "@/lib/admin/permissions"
 import { ACTIVITY_SORT_COLUMNS, type ActivityListParams } from "@/lib/api/types"
 
 const CATEGORY_TABS = [
@@ -60,6 +63,10 @@ function parseDateRange(
 
 function AuditLogsPageContent() {
   const searchParams = useSearchParams()
+  const queryScope = useQueryScope()
+  const { user, loading: userLoading } = useUser()
+  const canReadCurrentScope =
+    queryScope === "self" || canReadPlatformActivity(user)
 
   const {
     page,
@@ -108,7 +115,9 @@ function AuditLogsPageContent() {
   }
 
   const { data, isPending, error, refetch, isPlaceholderData } =
-    useActivityPage(params)
+    useActivityPage(params, {
+      enabled: queryScope === "self" || (!userLoading && canReadCurrentScope),
+    })
   const logs = data?.items ?? []
   const total = data?.total ?? 0
 
@@ -137,6 +146,15 @@ function AuditLogsPageContent() {
   // stale page during a params change — never treat its total as empty.
   const isEmpty =
     !isPending && !error && !isPlaceholderData && total === 0 && !hasFilters
+
+  if (queryScope !== "self" && !userLoading && !canReadCurrentScope) {
+    return (
+      <div className="flex h-full flex-col">
+        <PageHeader title="Audit Logs" />
+        <ErrorState message="Your account does not have platform activity read access for this team." />
+      </div>
+    )
+  }
 
   if (isPending) {
     return (

--- a/apps/console/src/app/(dashboard)/sandboxes/[sandbox_id]/page.tsx
+++ b/apps/console/src/app/(dashboard)/sandboxes/[sandbox_id]/page.tsx
@@ -8,6 +8,7 @@ import { usePostHog } from "posthog-js/react"
 import { useState } from "react"
 
 import { ErrorState } from "@/components/error-state"
+import { useQueryScope } from "@/components/query-provider"
 import { ActivitySection } from "@/components/sandboxes/activity-section"
 import { DeleteSandboxDialog } from "@/components/sandboxes/delete-sandbox-dialog"
 import { FilesSection } from "@/components/sandboxes/files-section"
@@ -135,6 +136,7 @@ export default function SandboxDetailPage() {
   const router = useRouter()
   const posthog = usePostHog()
   const sandboxId = params.sandbox_id
+  const queryScope = useQueryScope()
 
   const { data: sandbox, isPending, error, refetch } = useSandbox(sandboxId)
   const pauseMutation = usePauseSandbox()
@@ -145,7 +147,7 @@ export default function SandboxDetailPage() {
   const network = useSandboxNetwork(sandboxId)
 
   const { data: activity, isPending: activityPending } = useQuery({
-    queryKey: auditLogKeys.bySandbox(sandboxId),
+    queryKey: [...auditLogKeys.bySandbox(sandboxId), queryScope],
     queryFn: () => listActivityBySandboxAction(sandboxId),
     enabled: !!sandboxId,
     staleTime: 30_000,

--- a/apps/console/src/app/(dashboard)/sandboxes/[sandbox_id]/page.tsx
+++ b/apps/console/src/app/(dashboard)/sandboxes/[sandbox_id]/page.tsx
@@ -146,7 +146,12 @@ export default function SandboxDetailPage() {
 
   const network = useSandboxNetwork(sandboxId)
 
-  const { data: activity, isPending: activityPending } = useQuery({
+  const {
+    data: activity,
+    isPending: activityPending,
+    error: activityError,
+    refetch: refetchActivity,
+  } = useQuery({
     queryKey: [...auditLogKeys.bySandbox(sandboxId), queryScope],
     queryFn: () => listActivityBySandboxAction(sandboxId),
     enabled: !!sandboxId,
@@ -269,7 +274,12 @@ export default function SandboxDetailPage() {
         <PreviewSection sandbox={sandbox} onStart={handleStart} />
 
         {/* Layer 7: activity (history, lower priority) */}
-        <ActivitySection activity={activity} isPending={activityPending} />
+        <ActivitySection
+          activity={activity}
+          isPending={activityPending}
+          error={activityError}
+          onRetry={() => void refetchActivity()}
+        />
 
         {/* Layer 8: unified egress log (connections + secret requests) */}
         <NetworkLogTable

--- a/apps/console/src/components/sandboxes/activity-section.test.tsx
+++ b/apps/console/src/components/sandboxes/activity-section.test.tsx
@@ -1,0 +1,41 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { ActivitySection } from "./activity-section"
+
+describe("ActivitySection", () => {
+  it("shows activity query failures instead of an empty state", () => {
+    const onRetry = vi.fn()
+
+    render(
+      <ActivitySection
+        activity={undefined}
+        isPending={false}
+        error={
+          new Error(
+            "Forbidden: platform activity read access required while viewing another team",
+          )
+        }
+        onRetry={onRetry}
+      />,
+    )
+
+    expect(screen.getByText("Unable to load activity")).toBeInTheDocument()
+    expect(
+      screen.getByText(/platform activity read access required/i),
+    ).toBeInTheDocument()
+    expect(screen.queryByText("No Activity")).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Try Again" }))
+    expect(onRetry).toHaveBeenCalledOnce()
+  })
+
+  it("keeps the empty state for successful empty results", () => {
+    render(<ActivitySection activity={[]} isPending={false} error={null} />)
+
+    expect(screen.getByText("No Activity")).toBeInTheDocument()
+    expect(
+      screen.queryByText("Unable to load activity"),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/apps/console/src/components/sandboxes/activity-section.tsx
+++ b/apps/console/src/components/sandboxes/activity-section.tsx
@@ -12,6 +12,7 @@ import {
 } from "@superserve/ui"
 
 import { EmptyState } from "@/components/empty-state"
+import { ErrorState } from "@/components/error-state"
 import { StickyHoverTableBody } from "@/components/sticky-hover-table"
 import type { ActivityResponse } from "@/lib/api/types"
 import { formatTime } from "@/lib/format"
@@ -20,9 +21,16 @@ import { ACTIVITY_STATUS_VARIANT, formatDuration } from "@/lib/sandbox-utils"
 interface ActivitySectionProps {
   activity: ActivityResponse[] | undefined
   isPending: boolean
+  error: Error | null
+  onRetry?: () => void
 }
 
-export function ActivitySection({ activity, isPending }: ActivitySectionProps) {
+export function ActivitySection({
+  activity,
+  isPending,
+  error,
+  onRetry,
+}: ActivitySectionProps) {
   return (
     <>
       <div className="flex h-10 items-center border-b border-border px-4">
@@ -41,6 +49,14 @@ export function ActivitySection({ activity, isPending }: ActivitySectionProps) {
               <div className="h-3 w-12 animate-pulse bg-muted/20" />
             </div>
           ))}
+        </div>
+      ) : error ? (
+        <div className="border-b border-border">
+          <ErrorState
+            title="Unable to load activity"
+            message={error.message}
+            onRetry={onRetry}
+          />
         </div>
       ) : !activity || activity.length === 0 ? (
         <div className="border-b border-border py-10">

--- a/apps/console/src/hooks/use-activity.test.tsx
+++ b/apps/console/src/hooks/use-activity.test.tsx
@@ -1,0 +1,56 @@
+import { renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { auditLogKeys } from "@/lib/api/query-keys"
+import type { ActivityListParams } from "@/lib/api/types"
+import { createQueryWrapper } from "@/test/react-query"
+
+const queryScope = vi.hoisted(() => ({ value: "self" }))
+const listActivityPaged = vi.hoisted(() => vi.fn())
+
+vi.mock("@/components/query-provider", () => ({
+  useQueryScope: () => queryScope.value,
+}))
+
+vi.mock("@/lib/api/activity", () => ({
+  listActivityPaged: (...args: unknown[]) => listActivityPaged(...args),
+}))
+
+import { useActivityPage } from "./use-activity"
+
+const params: ActivityListParams = {
+  page: 1,
+  pageSize: 50,
+  sort: "created_at",
+  order: "desc",
+}
+
+describe("useActivityPage", () => {
+  beforeEach(() => {
+    queryScope.value = "self"
+    listActivityPaged.mockReset()
+  })
+
+  it("isolates cached activity by the current team scope", async () => {
+    listActivityPaged
+      .mockResolvedValueOnce({ items: [{ id: "self-log" }], total: 1 })
+      .mockResolvedValueOnce({ items: [{ id: "team-log" }], total: 1 })
+    const { queryClient, wrapper } = createQueryWrapper()
+    const { result, rerender } = renderHook(() => useActivityPage(params), {
+      wrapper,
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    queryScope.value = "team-1"
+    rerender()
+    await waitFor(() => expect(listActivityPaged).toHaveBeenCalledTimes(2))
+
+    expect(
+      queryClient.getQueryData([...auditLogKeys.list(params), "self"]),
+    ).toEqual({ items: [{ id: "self-log" }], total: 1 })
+    expect(
+      queryClient.getQueryData([...auditLogKeys.list(params), "team-1"]),
+    ).toEqual({ items: [{ id: "team-log" }], total: 1 })
+  })
+})

--- a/apps/console/src/hooks/use-activity.ts
+++ b/apps/console/src/hooks/use-activity.ts
@@ -1,13 +1,19 @@
 import { keepPreviousData, useQuery } from "@tanstack/react-query"
 
+import { useQueryScope } from "@/components/query-provider"
 import { listActivityPaged } from "@/lib/api/activity"
 import { auditLogKeys } from "@/lib/api/query-keys"
 import type { ActivityListParams } from "@/lib/api/types"
 
-export function useActivityPage(params: ActivityListParams) {
+export function useActivityPage(
+  params: ActivityListParams,
+  options: { enabled?: boolean } = {},
+) {
+  const queryScope = useQueryScope()
   return useQuery({
-    queryKey: auditLogKeys.list(params),
+    queryKey: [...auditLogKeys.list(params), queryScope],
     queryFn: () => listActivityPaged(params),
+    enabled: options.enabled,
     // Keep the current page on screen while the next page/filter loads so
     // navigation doesn't flash an empty table.
     placeholderData: keepPreviousData,

--- a/apps/console/src/lib/admin/impersonation-key.test.ts
+++ b/apps/console/src/lib/admin/impersonation-key.test.ts
@@ -47,7 +47,11 @@ describe("impersonation key rows", () => {
       "admin-1",
       "team-1",
       "use",
-      ["platform:sandbox:read", "platform:template:read"],
+      [
+        "platform:sandbox:read",
+        "platform:template:read",
+        "platform:activity:read",
+      ],
       7,
     )
 
@@ -56,7 +60,11 @@ describe("impersonation key rows", () => {
     expect(upserts[0]).toMatchObject({
       team_id: "team-1",
       name: IMPERSONATION_KEY_NAME,
-      scopes: ["platform:sandbox:read", "platform:template:read"],
+      scopes: [
+        "platform:sandbox:read",
+        "platform:template:read",
+        "platform:activity:read",
+      ],
       created_by: "admin-1",
       revoked_at: null,
     })

--- a/apps/console/src/lib/admin/impersonation.ts
+++ b/apps/console/src/lib/admin/impersonation.ts
@@ -134,8 +134,8 @@ export async function readImpersonationContext(): Promise<ImpersonationContext |
 
 /**
  * The team the current request should act as: the target team only when the
- * user has platform sandbox read access AND a valid impersonation cookie is
- * present; otherwise null (callers fall back to the user's own team).
+ * user has a supported platform read permission and a valid impersonation
+ * cookie is present; otherwise null (callers fall back to the user's own team).
  */
 export async function getImpersonationTeamId(
   user: User | null | undefined,

--- a/apps/console/src/lib/admin/permissions.ts
+++ b/apps/console/src/lib/admin/permissions.ts
@@ -2,10 +2,12 @@ import type { User } from "@supabase/supabase-js"
 
 export const PLATFORM_SANDBOX_READ_PERMISSION = "platform:sandbox:read"
 export const PLATFORM_TEMPLATE_READ_PERMISSION = "platform:template:read"
+export const PLATFORM_ACTIVITY_READ_PERMISSION = "platform:activity:read"
 export const PLATFORM_TEAMS_READ_PERMISSION = "platform:teams:read"
 export type PlatformImpersonationReadScope =
   | typeof PLATFORM_SANDBOX_READ_PERMISSION
   | typeof PLATFORM_TEMPLATE_READ_PERMISSION
+  | typeof PLATFORM_ACTIVITY_READ_PERMISSION
 
 const DEFAULT_STAFF_DOMAIN = "superserve.ai"
 
@@ -65,6 +67,12 @@ export function canReadPlatformTemplates(
   return hasPermission(user, PLATFORM_TEMPLATE_READ_PERMISSION)
 }
 
+export function canReadPlatformActivity(
+  user: User | null | undefined,
+): boolean {
+  return hasPermission(user, PLATFORM_ACTIVITY_READ_PERMISSION)
+}
+
 export function canReadPlatformTeams(user: User | null | undefined): boolean {
   return (
     isGoogleStaffUser(user) &&
@@ -82,6 +90,9 @@ export function platformImpersonationReadScopes(
   }
   if (canReadPlatformTemplates(user)) {
     scopes.push(PLATFORM_TEMPLATE_READ_PERMISSION)
+  }
+  if (canReadPlatformActivity(user)) {
+    scopes.push(PLATFORM_ACTIVITY_READ_PERMISSION)
   }
 
   return scopes

--- a/apps/console/src/lib/admin/staff.test.ts
+++ b/apps/console/src/lib/admin/staff.test.ts
@@ -2,6 +2,7 @@ import type { User } from "@supabase/supabase-js"
 import { describe, expect, it } from "vitest"
 
 import {
+  canReadPlatformActivity,
   canReadPlatformSandboxes,
   canReadPlatformTemplates,
   canReadPlatformTeams,
@@ -135,6 +136,19 @@ describe("platform resource read permissions", () => {
     ).toBe(true)
   })
 
+  it("requires the canonical activity permission only", () => {
+    expect(
+      canReadPlatformActivity(
+        user(
+          "person@example.com",
+          "email",
+          ["email"],
+          ["platform:activity:read"],
+        ),
+      ),
+    ).toBe(true)
+  })
+
   it("does not treat plural aliases as valid", () => {
     expect(
       canReadPlatformSandboxes(
@@ -156,9 +170,19 @@ describe("platform resource read permissions", () => {
         ),
       ),
     ).toBe(false)
+    expect(
+      canReadPlatformActivity(
+        user(
+          "person@example.com",
+          "email",
+          ["email"],
+          ["platform:activities:read"],
+        ),
+      ),
+    ).toBe(false)
   })
 
-  it("does not let team read imply sandbox or template access", () => {
+  it("does not let team read imply resource access", () => {
     expect(
       canReadPlatformSandboxes(
         user("person@example.com", "email", ["email"], ["platform:teams:read"]),
@@ -166,6 +190,11 @@ describe("platform resource read permissions", () => {
     ).toBe(false)
     expect(
       canReadPlatformTemplates(
+        user("person@example.com", "email", ["email"], ["platform:teams:read"]),
+      ),
+    ).toBe(false)
+    expect(
+      canReadPlatformActivity(
         user("person@example.com", "email", ["email"], ["platform:teams:read"]),
       ),
     ).toBe(false)
@@ -186,6 +215,13 @@ describe("platform resource read permissions", () => {
         }),
       ),
     ).toBe(false)
+    expect(
+      canReadPlatformActivity(
+        userWithMetadata({
+          userPermissions: ["platform:activity:read"],
+        }),
+      ),
+    ).toBe(false)
   })
 
   it("reads permissions from server-owned nested authorization claims", () => {
@@ -203,21 +239,36 @@ describe("platform resource read permissions", () => {
         }),
       ),
     ).toBe(true)
+    expect(
+      canReadPlatformActivity(
+        userWithMetadata({
+          appAuthorizationPermissions: ["platform:activity:read"],
+        }),
+      ),
+    ).toBe(true)
   })
 })
 
 describe("platform impersonation access", () => {
-  it("returns only canonical sandbox and template scopes", () => {
+  it("returns only canonical resource scopes", () => {
     expect(
       platformImpersonationReadScopes(
         user(
           "person@example.com",
           "google",
           ["google"],
-          ["platform:sandbox:read", "platform:template:read"],
+          [
+            "platform:sandbox:read",
+            "platform:template:read",
+            "platform:activity:read",
+          ],
         ),
       ),
-    ).toEqual(["platform:sandbox:read", "platform:template:read"])
+    ).toEqual([
+      "platform:sandbox:read",
+      "platform:template:read",
+      "platform:activity:read",
+    ])
   })
 
   it("returns only the matching scope when a single permission is present", () => {
@@ -241,6 +292,16 @@ describe("platform impersonation access", () => {
         ),
       ),
     ).toEqual(["platform:template:read"])
+    expect(
+      platformImpersonationReadScopes(
+        user(
+          "person@example.com",
+          "google",
+          ["google"],
+          ["platform:activity:read"],
+        ),
+      ),
+    ).toEqual(["platform:activity:read"])
   })
 
   it("does not include teams read", () => {
@@ -264,6 +325,16 @@ describe("platform impersonation access", () => {
           "google",
           ["google"],
           ["platform:sandbox:read"],
+        ),
+      ),
+    ).toBe(true)
+    expect(
+      canStartPlatformImpersonation(
+        user(
+          "a@superserve.ai",
+          "google",
+          ["google"],
+          ["platform:activity:read"],
         ),
       ),
     ).toBe(true)

--- a/apps/console/src/lib/api/activity-actions.test.ts
+++ b/apps/console/src/lib/api/activity-actions.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const getImpersonationContext = vi.hoisted(() => vi.fn())
+const canReadPlatformActivity = vi.hoisted(() => vi.fn())
+const resolveActiveTeam = vi.hoisted(() => vi.fn())
+const createServerClient = vi.hoisted(() => vi.fn())
+const cellFor = vi.hoisted(() => vi.fn())
+
+const query = vi.hoisted(() => {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {}
+  chain.select = vi.fn(() => chain)
+  chain.eq = vi.fn(() => chain)
+  chain.order = vi.fn(() => chain)
+  chain.limit = vi.fn(async () => ({ data: [], error: null }))
+  return chain
+})
+
+vi.mock("@/lib/admin/impersonation", () => ({
+  getImpersonationContext,
+}))
+
+vi.mock("@/lib/admin/permissions", () => ({
+  canReadPlatformActivity,
+}))
+
+vi.mock("@/lib/api/active-team", () => ({
+  resolveActiveTeam,
+}))
+
+vi.mock("@/lib/cells", () => ({
+  cellFor,
+}))
+
+vi.mock("@/lib/supabase/server", () => ({
+  createServerClient,
+}))
+
+import { listActivityBySandboxAction } from "./activity-actions"
+
+const user = {
+  id: "admin-1",
+  email: "admin@superserve.ai",
+  app_metadata: { permissions: ["platform:activity:read"] },
+}
+
+describe("listActivityBySandboxAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    createServerClient.mockResolvedValue({
+      auth: { getUser: vi.fn(async () => ({ data: { user } })) },
+    })
+    cellFor.mockReturnValue({
+      createAdminClient: () => ({ from: vi.fn(() => query) }),
+    })
+  })
+
+  it("reads the impersonated team in its home region", async () => {
+    getImpersonationContext.mockResolvedValue({
+      teamId: "team-target",
+      region: "usw",
+      teamName: "Target",
+    })
+    canReadPlatformActivity.mockReturnValue(true)
+
+    await listActivityBySandboxAction("sandbox-1")
+
+    expect(cellFor).toHaveBeenCalledWith("usw")
+    expect(query.eq).toHaveBeenCalledWith("sandbox_id", "sandbox-1")
+    expect(query.eq).toHaveBeenCalledWith("team_id", "team-target")
+    expect(resolveActiveTeam).not.toHaveBeenCalled()
+  })
+
+  it("fails closed when impersonation lacks activity access", async () => {
+    getImpersonationContext.mockResolvedValue({
+      teamId: "team-target",
+      region: "use",
+      teamName: "Target",
+    })
+    canReadPlatformActivity.mockReturnValue(false)
+
+    await expect(listActivityBySandboxAction("sandbox-1")).rejects.toThrow(
+      /platform activity read access required/,
+    )
+    expect(cellFor).not.toHaveBeenCalled()
+    expect(resolveActiveTeam).not.toHaveBeenCalled()
+  })
+
+  it("keeps normal users on their active team", async () => {
+    getImpersonationContext.mockResolvedValue(null)
+    resolveActiveTeam.mockResolvedValue({ teamId: "team-self", region: "use" })
+
+    await listActivityBySandboxAction("sandbox-1")
+
+    expect(cellFor).toHaveBeenCalledWith("use")
+    expect(query.eq).toHaveBeenCalledWith("team_id", "team-self")
+  })
+})

--- a/apps/console/src/lib/api/activity-actions.ts
+++ b/apps/console/src/lib/api/activity-actions.ts
@@ -1,12 +1,26 @@
 "use server"
 
+import type { User } from "@supabase/supabase-js"
+
+import { getImpersonationContext } from "@/lib/admin/impersonation"
+import { canReadPlatformActivity } from "@/lib/admin/permissions"
 import { resolveActiveTeam } from "@/lib/api/active-team"
 import type { TeamMembership } from "@/lib/api/team-directory"
 import { cellFor } from "@/lib/cells"
 import { createServerClient } from "@/lib/supabase/server"
 
-async function getTeam(userId: string): Promise<TeamMembership | null> {
-  return resolveActiveTeam(userId).catch(() => null)
+async function getTeam(user: User): Promise<TeamMembership | null> {
+  const impersonation = await getImpersonationContext(user)
+  if (impersonation) {
+    if (!canReadPlatformActivity(user)) {
+      throw new Error(
+        "Forbidden: platform activity read access required while viewing another team",
+      )
+    }
+    return { teamId: impersonation.teamId, region: impersonation.region }
+  }
+
+  return resolveActiveTeam(user.id).catch(() => null)
 }
 
 export async function listActivityBySandboxAction(
@@ -19,7 +33,7 @@ export async function listActivityBySandboxAction(
   } = await supabase.auth.getUser()
   if (!user) throw new Error("Not authenticated")
 
-  const team = await getTeam(user.id)
+  const team = await getTeam(user)
   if (!team) return []
 
   const admin = cellFor(team.region).createAdminClient()

--- a/apps/console/src/lib/api/proxy-auth.test.ts
+++ b/apps/console/src/lib/api/proxy-auth.test.ts
@@ -266,6 +266,7 @@ describe("proxy-auth impersonation", () => {
     vi.mocked(platformImpersonationReadScopes).mockReturnValue([
       "platform:sandbox:read",
       "platform:template:read",
+      "platform:activity:read",
     ])
     vi.mocked(ensureImpersonationKeyRow).mockResolvedValue(
       "ss_live_impersonation",
@@ -281,7 +282,11 @@ describe("proxy-auth impersonation", () => {
       "admin",
       "team-1",
       "use",
-      ["platform:sandbox:read", "platform:template:read"],
+      [
+        "platform:sandbox:read",
+        "platform:template:read",
+        "platform:activity:read",
+      ],
       expect.any(Number),
     )
   })
@@ -317,7 +322,7 @@ describe("proxy-auth impersonation", () => {
         "team-1",
       ),
     ).rejects.toThrow(
-      /impersonation requires platform sandbox or template read access/,
+      /impersonation requires a supported platform read permission/,
     )
   })
 })

--- a/apps/console/src/lib/api/proxy-auth.ts
+++ b/apps/console/src/lib/api/proxy-auth.ts
@@ -210,7 +210,7 @@ export async function getAuthApiKeyForUser(
     const scopes = platformImpersonationReadScopes(user)
     if (scopes.length === 0) {
       throw new Error(
-        "Forbidden: impersonation requires platform sandbox or template read access",
+        "Forbidden: impersonation requires a supported platform read permission",
       )
     }
 


### PR DESCRIPTION
## Summary

- add the dedicated `platform:activity:read` permission to console impersonation keys
- scope audit-log caches by the active or impersonated team
- resolve per-sandbox activity from the impersonated team's region
- fail closed with a clear authorization state when activity access is missing
- add permission, proxy-key, cache-isolation, and server-action tests

## Why

The audit-log page moved to the control-plane `GET /activity` endpoint, but temporary admin impersonation keys only carried sandbox and template scopes. The backend therefore rejected activity requests because impersonation keys intentionally have no customer RBAC actor. The per-sandbox activity action also fell back to the admin's own active team, and audit query keys were not isolated between team contexts.

## Impact

Authorized support admins can view another team's audit logs without receiving a 403 or mixing cached results between teams. Access remains read-only and requires the server-owned `platform:activity:read` authorization permission.

## Validation

- `bun run --cwd apps/console lint`
- `bun run --cwd apps/console typecheck`
- 58 focused Vitest tests passed across permissions, impersonation, proxy authentication, activity cache isolation, and activity server actions

