### PR TITLE
feat(pi): add @superserve/pi sandbox extension for the Pi coding agent

### DIFF
--- a/.github/workflows/pi-publish.yml
+++ b/.github/workflows/pi-publish.yml
@@ -1,0 +1,67 @@
+name: Publish Pi Extension
+
+# Tag-triggered (pi-v0.1.0 -> 0.1.0). A version satisfying the package's
+# @superserve/sdk range must already exist on npm. Configure Trusted Publishing for
+# @superserve/pi before creating the first tag.
+
+on:
+  push:
+    tags: ["pi-v*"]
+
+jobs:
+  publish:
+    name: Publish @superserve/pi
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Set version from tag
+        working-directory: packages/pi
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF#refs/tags/pi-v}"
+          jq --arg v "$VERSION" '.version = $v' package.json > package.json.tmp
+          mv package.json.tmp package.json
+          PIN="npm:@superserve/pi@$VERSION"
+          test "$(grep -Fc "$PIN" README.md)" -ge 2 || {
+            echo "::error::Update the exact install and secure-launcher pins in packages/pi/README.md to $VERSION" >&2
+            exit 1
+          }
+
+      - name: Verify runtime dependencies are published
+        working-directory: packages/pi
+        run: |
+          set -euo pipefail
+          SDK_RANGE="$(jq -r '.dependencies["@superserve/sdk"]' package.json)"
+          npm view "@superserve/sdk@$SDK_RANGE" version >/dev/null
+
+      - name: Build workspace SDK dependency
+        run: bunx turbo run build --filter=@superserve/sdk
+
+      - name: Validate
+        run: bunx turbo run lint format:check typecheck test build --filter=@superserve/pi
+
+      - name: Upgrade npm
+        run: npm install -g npm@latest
+
+      - name: Publish to npm
+        working-directory: packages/pi
+        run: npm publish --access public --provenance

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ apps/
   ui-docs/                 # UI component docs (Vite)
 packages/
   cli/                     # TypeScript CLI (@superserve/cli)
+  pi/                      # Pi sandbox extension (@superserve/pi)
   python-sdk/              # Python SDK (superserve on PyPI)
   sdk/                     # TypeScript SDK (@superserve/sdk)
   ui/                      # Shared UI components (@superserve/ui)
@@ -62,6 +63,11 @@ For more (per-package targets, dependency management, etc.), see [CONTRIBUTING.m
 
 - TypeScript: [`@superserve/sdk`](https://www.npmjs.com/package/@superserve/sdk) — `bun add @superserve/sdk`
 - Python: [`superserve`](https://pypi.org/project/superserve/) — `uv add superserve`
+
+## Agent integrations
+
+- Pi: [`@superserve/pi`](./packages/pi) — routes Pi's shell and filesystem
+  tools into a Superserve microVM with fail-closed execution
 
 Full reference at [docs.superserve.ai](https://docs.superserve.ai/?utm_source=github&utm_medium=readme).
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing
 
-How to publish new versions of the Superserve SDKs.
+How to publish new versions of Superserve packages.
 
 ## TypeScript SDK to npm
 
@@ -42,6 +42,23 @@ uv build --package superserve
 uv publish dist/superserve-*
 ```
 
+## Pi extension to npm
+
+The tag-triggered workflow publishes `@superserve/pi` with npm Trusted
+Publishing. Publish a compatible `@superserve/sdk` first, update the exact
+install and secure-launcher version pins in `packages/pi/README.md`, then create
+the matching tag:
+
+```bash
+git tag pi-v0.1.0
+git push origin pi-v0.1.0
+```
+
+The workflow derives the package version from the tag, verifies that the
+declared SDK range is available on npm, runs the package validation suite, and
+publishes with provenance. Configure
+`@superserve/pi` as an npm Trusted Publisher before creating the first tag.
+
 ## Release environment setup
 
 Copy `.env.release.example` to `.env.release`, fill in tokens, and `source` it before running publish commands. `.env.release` is gitignored.
@@ -53,9 +70,10 @@ Copy `.env.release.example` to `.env.release`, fill in tokens, and `source` it b
 
 ## CI workflow (GitHub Actions)
 
-| Workflow         | Trigger                      | Action                                                                                                                        |
-| ---------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| **Release SDKs** | Manual (`workflow_dispatch`) | Bumps version, builds, publishes to npm and/or PyPI, commits + tags. Inputs: `package` (`ts` / `python` / `both`), `version`. |
+| Workflow                 | Trigger                      | Action                                                                                                                        |
+| ------------------------ | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| **Release SDKs**         | Manual (`workflow_dispatch`) | Bumps version, builds, publishes to npm and/or PyPI, commits + tags. Inputs: `package` (`ts` / `python` / `both`), `version`. |
+| **Publish Pi Extension** | Tag (`pi-v*`)                | Validates and publishes `@superserve/pi` to npm with provenance.                                                              |
 
 Required repo secrets:
 

--- a/bun.lock
+++ b/bun.lock
@@ -181,6 +181,24 @@
         "vitest": "^4.0.0",
       },
     },
+    "packages/pi": {
+      "name": "@superserve/pi",
+      "version": "0.1.0",
+      "dependencies": {
+        "@superserve/sdk": "^0.8.0",
+      },
+      "devDependencies": {
+        "@earendil-works/pi-coding-agent": "0.80.9",
+        "@superserve/typescript-config": "workspace:*",
+        "@types/node": "^25.5.2",
+        "tsup": "^8.0.0",
+        "typescript": "^5.7.0",
+        "vitest": "^4.0.0",
+      },
+      "peerDependencies": {
+        "@earendil-works/pi-coding-agent": ">=0.80.9 <0.81.0",
+      },
+    },
     "packages/python-sdk": {
       "name": "@superserve/python-sdk",
       "version": "0.6.0",
@@ -277,6 +295,8 @@
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.91.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw=="],
+
     "@ark/schema": ["@ark/schema@0.55.0", "", { "dependencies": { "@ark/util": "0.55.0" } }, "sha512-IlSIc0FmLKTDGr4I/FzNHauMn0MADA6bCjT1wauu4k6MyxhC1R9gz0olNpIRvK7lGGDwtc/VO0RUDNvVQW5WFg=="],
 
     "@ark/util": ["@ark/util@0.55.0", "", {}, "sha512-aWFNK7aqSvqFtVsl1xmbTjGbg91uqtJV7Za76YGNEwIO4qLjMfyY8flmmbhooYMuqPCO2jyxu8hve943D+w3bA=="],
@@ -287,9 +307,53 @@
 
     "@aws-crypto/crc32": ["@aws-crypto/crc32@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg=="],
 
+    "@aws-crypto/sha256-browser": ["@aws-crypto/sha256-browser@5.2.0", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw=="],
+
+    "@aws-crypto/sha256-js": ["@aws-crypto/sha256-js@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA=="],
+
+    "@aws-crypto/supports-web-crypto": ["@aws-crypto/supports-web-crypto@5.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg=="],
+
     "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
 
+    "@aws-sdk/client-bedrock-runtime": ["@aws-sdk/client-bedrock-runtime@3.1048.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.11", "@aws-sdk/credential-provider-node": "^3.972.42", "@aws-sdk/eventstream-handler-node": "^3.972.16", "@aws-sdk/middleware-eventstream": "^3.972.12", "@aws-sdk/middleware-websocket": "^3.972.19", "@aws-sdk/token-providers": "3.1048.0", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/fetch-http-handler": "^5.4.2", "@smithy/node-http-handler": "^4.7.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ=="],
+
+    "@aws-sdk/core": ["@aws-sdk/core@3.975.3", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@aws-sdk/xml-builder": "^3.972.36", "@aws/lambda-invoke-store": "^0.3.0", "@smithy/core": "^3.29.4", "@smithy/signature-v4": "^5.6.5", "@smithy/types": "^4.16.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA=="],
+
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.59", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-Ny5e4Mfh3QPmiAc0AiUe+cbTXDlxkU3Rc+EpWOfyWeWEy6yp7Fa1KmfNeCc+1a8by9zQ9gtohmiQUkMPScF3ng=="],
+
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.61", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/fetch-http-handler": "^5.6.6", "@smithy/node-http-handler": "^4.9.6", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-8jAjgStl5Ytq4+HF3X/9f+EmRinaRbGRRtQGktlPfBRVx73H+R1y48vIeXerQtYGFaUqkEp3fT6jP854rVO2yQ=="],
+
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.973.4", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/credential-provider-env": "^3.972.59", "@aws-sdk/credential-provider-http": "^3.972.61", "@aws-sdk/credential-provider-login": "^3.972.66", "@aws-sdk/credential-provider-process": "^3.972.59", "@aws-sdk/credential-provider-sso": "^3.973.3", "@aws-sdk/credential-provider-web-identity": "^3.972.65", "@aws-sdk/nested-clients": "^3.997.33", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/credential-provider-imds": "^4.4.9", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-e6ZvVsj90aRALf1kHP+J4iqC1496ZpVgqI/+u0LJ5HL7q7ATauGy4gdDvRCP13L1pN/fMiZLah162PGIYkbUVQ=="],
+
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.66", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/nested-clients": "^3.997.33", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-g2fsqm87r/nKthLZ0VkkDBElkGg0PvSa8d97HQ6EilMbJTZ6hxa8FxkSZyJfgPfFdZn0TTmkOffQmTSUcAHIng=="],
+
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.70", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.59", "@aws-sdk/credential-provider-http": "^3.972.61", "@aws-sdk/credential-provider-ini": "^3.973.4", "@aws-sdk/credential-provider-process": "^3.972.59", "@aws-sdk/credential-provider-sso": "^3.973.3", "@aws-sdk/credential-provider-web-identity": "^3.972.65", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/credential-provider-imds": "^4.4.9", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3xzvkGdykBunxqh8WudmUpSyLWvIhfI6aBQo1b5rb3mDO5mNLadK+0hiI0qBQBMVynJbfLO+Ajy9dztMwy9O8w=="],
+
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.59", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-DlZF2/MhLlatDdlrIy3CUCpfdbLrKx+3SMjVo+WyHnPpwzkc/M3vwAHw4OVJf7DMvO+4vfRqSCMc/E9I1auN0g=="],
+
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.973.3", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/nested-clients": "^3.997.33", "@aws-sdk/token-providers": "3.1088.0", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-hmdDHoy2G5Es2e8IgelNMYUuSQI6uCIAKZMJ2u2PdKDhxvbk1uWD/g4+R7R5c/tJfKEB1+KjjWiaoCr/S+ZTiQ=="],
+
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.65", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/nested-clients": "^3.997.33", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-gHQb/Kt0chjk/JQDa/GJDqmAvEuVn8n7z10wK2h0LFM9TUDRkohgOO4aEF+s2sBLM0br7Cl5W6P7phgjrrJvLQ=="],
+
+    "@aws-sdk/eventstream-handler-node": ["@aws-sdk/eventstream-handler-node@3.972.29", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-t3tKQRTVXsI2QNPE3CaNjHl0wRO9Xi3acZkAyti2RQsiFmZ9Gi0kArX2ighlRJ1BtDVuul413gThAgzyTfgmWA=="],
+
+    "@aws-sdk/middleware-eventstream": ["@aws-sdk/middleware-eventstream@3.972.24", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-oykin4mDWxNOuYQ7SF1cHzgYeuFEkF4cdRwgvjFFbIklkx09qIFBiOgsORafG9sXZFO3TayMmQuAQYgADXhI8w=="],
+
+    "@aws-sdk/middleware-websocket": ["@aws-sdk/middleware-websocket@3.972.41", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/fetch-http-handler": "^5.6.6", "@smithy/signature-v4": "^5.6.5", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-LSbGvvYmjc4Br9BPYI2dTLnIclmrSiQbahkP4D6nRGVEv4qsCZ8csVuKBPVEEFCVD+EEngGh8ROls6XpumtwMg=="],
+
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.33", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/signature-v4-multi-region": "^3.996.41", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/fetch-http-handler": "^5.6.6", "@smithy/node-http-handler": "^4.9.6", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-dVZOroI/r3/ENvqNGgjMPul+jjlz9GddfVusgTXlVjfZj5isibOxecLkGQbRPp8XOuX+RAfjXLFgPkD1JS5xrw=="],
+
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.41", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@smithy/signature-v4": "^5.6.5", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng=="],
+
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1048.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.11", "@aws-sdk/nested-clients": "^3.997.9", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA=="],
+
     "@aws-sdk/types": ["@aws-sdk/types@3.973.13", "", { "dependencies": { "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg=="],
+
+    "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.8", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g=="],
+
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.36", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA=="],
+
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.3.0", "", {}, "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
@@ -344,6 +408,14 @@
     "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
 
     "@date-fns/tz": ["@date-fns/tz@1.4.1", "", {}, "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA=="],
+
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.80.9", "", { "dependencies": { "@earendil-works/pi-ai": "^0.80.9", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-tObjeOLiw1kYUciBi9R+rRyc4QGK+1akbLLQHvzsn2JrrV2btUdDncJ7jMIR5TKvOYKzKxAwQSl/5k7h3Tjrrg=="],
+
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.80.9", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-kHsH5nO4FU7mbKnskK0BVPVuWzNb2DrZtiN1fb6LamP+6BMI8xEZiAOw2fqs4VudvlMQgOLjtbgErv+kNJRPIg=="],
+
+    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.80.9", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.80.9", "@earendil-works/pi-ai": "^0.80.9", "@earendil-works/pi-tui": "^0.80.9", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-Clgx2Bg5NbMcCpGxusSDQwE+GC0g/d6sCBluE9aypPgSgtJ6n8VmZIIT6auXObMskpRgkr+XZ77wG5hf+cSDtg=="],
+
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.80.9", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-unPTW8hRgIHEGjV8mJJ2jqm+fzgnRubes6V2FPk9ay1W9ZLofcpYQ3NDfrODXSci+oKbBpX9JyYUMfQV6jCA/A=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
 
@@ -406,6 +478,8 @@
     "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.8", "", { "dependencies": { "@floating-ui/dom": "^1.7.6" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
+
+    "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
@@ -509,6 +583,28 @@
 
     "@leichtgewicht/ip-codec": ["@leichtgewicht/ip-codec@2.0.5", "", {}, "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="],
 
+    "@mariozechner/clipboard": ["@mariozechner/clipboard@0.3.9", "", { "optionalDependencies": { "@mariozechner/clipboard-darwin-arm64": "0.3.9", "@mariozechner/clipboard-darwin-universal": "0.3.9", "@mariozechner/clipboard-darwin-x64": "0.3.9", "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9", "@mariozechner/clipboard-linux-arm64-musl": "0.3.9", "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9", "@mariozechner/clipboard-linux-x64-gnu": "0.3.9", "@mariozechner/clipboard-linux-x64-musl": "0.3.9", "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9", "@mariozechner/clipboard-win32-x64-msvc": "0.3.9" } }, "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA=="],
+
+    "@mariozechner/clipboard-darwin-arm64": ["@mariozechner/clipboard-darwin-arm64@0.3.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ=="],
+
+    "@mariozechner/clipboard-darwin-universal": ["@mariozechner/clipboard-darwin-universal@0.3.9", "", { "os": "darwin" }, "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ=="],
+
+    "@mariozechner/clipboard-darwin-x64": ["@mariozechner/clipboard-darwin-x64@0.3.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg=="],
+
+    "@mariozechner/clipboard-linux-arm64-gnu": ["@mariozechner/clipboard-linux-arm64-gnu@0.3.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw=="],
+
+    "@mariozechner/clipboard-linux-arm64-musl": ["@mariozechner/clipboard-linux-arm64-musl@0.3.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ=="],
+
+    "@mariozechner/clipboard-linux-riscv64-gnu": ["@mariozechner/clipboard-linux-riscv64-gnu@0.3.9", "", { "os": "linux", "cpu": "none" }, "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw=="],
+
+    "@mariozechner/clipboard-linux-x64-gnu": ["@mariozechner/clipboard-linux-x64-gnu@0.3.9", "", { "os": "linux", "cpu": "x64" }, "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw=="],
+
+    "@mariozechner/clipboard-linux-x64-musl": ["@mariozechner/clipboard-linux-x64-musl@0.3.9", "", { "os": "linux", "cpu": "x64" }, "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ=="],
+
+    "@mariozechner/clipboard-win32-arm64-msvc": ["@mariozechner/clipboard-win32-arm64-msvc@0.3.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ=="],
+
+    "@mariozechner/clipboard-win32-x64-msvc": ["@mariozechner/clipboard-win32-x64-msvc@0.3.9", "", { "os": "win32", "cpu": "x64" }, "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA=="],
+
     "@mcpjam/cli": ["@mcpjam/cli@3.10.0", "", { "dependencies": { "@mcpjam/sdk": "^1.22.0", "@modelcontextprotocol/server": "^2.0.0-alpha.2", "commander": "^12.1.0", "posthog-node": "^5.24.10", "ws": "^8.18.0", "zod": "^4.1.12" }, "bin": { "mcpjam": "dist/index.js" } }, "sha512-L/xtJ2zRPWJqkcROZKNahrt4t7NVkbRtFmaLi8l3/ZND8OxGO/ftWukZ36Zg1jFcbGdiuYlrJqEGlIkLVMhnkg=="],
 
     "@mcpjam/sdk": ["@mcpjam/sdk@1.23.0", "", { "dependencies": { "@ai-sdk/amazon-bedrock": "^3.0.101", "@ai-sdk/anthropic": "^2.0.17", "@ai-sdk/azure": "^2.0.79", "@ai-sdk/deepseek": "^1.0.5", "@ai-sdk/google": "^2.0.11", "@ai-sdk/mistral": "^2.0.19", "@ai-sdk/openai": "^2.0.32", "@ai-sdk/xai": "^2.0.29", "@cfworker/json-schema": "^4.1.1", "@modelcontextprotocol/client": "^2.0.0-alpha.2", "@modelcontextprotocol/ext-apps": "^1.7.2", "@openrouter/ai-sdk-provider": "^2.2.0", "ai": "^6.0.141", "ollama-ai-provider-v2": "^1.5.2", "posthog-node": "^5.24.10", "zod": "^4.1.12" }, "peerDependencies": { "@sentry/node": "^8.55.0" }, "optionalPeers": ["@sentry/node"] }, "sha512-e8qrpxkxMhf5e+og6ATM9Y22q71RHM65qCPA1tcUQE2cl9tf+l7r6Fvee0kSyvYJHChYXTVqZwGFLoifCUQFGg=="],
@@ -536,6 +632,8 @@
     "@mintlify/scraping": ["@mintlify/scraping@4.0.522", "", { "dependencies": { "@mintlify/common": "1.0.661", "@mintlify/openapi-parser": "^0.0.8", "fs-extra": "11.1.1", "hast-util-to-mdast": "10.1.0", "js-yaml": "4.1.0", "mdast-util-mdx-jsx": "3.1.3", "neotraverse": "0.6.18", "puppeteer": "22.14.0", "rehype-parse": "9.0.1", "remark-gfm": "4.0.0", "remark-mdx": "3.0.1", "remark-parse": "11.0.0", "remark-stringify": "11.0.0", "unified": "11.0.5", "unist-util-visit": "5.0.0", "yargs": "17.7.1", "zod": "3.21.4" }, "bin": { "mintlify-scrape": "bin/cli.js" } }, "sha512-PL2k52WT5S5OAgnT2K13bP7J2El6XwiVvQlrLvxDYw5KMMV+y34YVJI8ZscKb4trjitWDgyK0UTq2KN6NQgn6g=="],
 
     "@mintlify/validation": ["@mintlify/validation@0.1.668", "", { "dependencies": { "@mintlify/mdx": "^3.0.4", "@mintlify/models": "0.0.291", "arktype": "2.1.27", "js-yaml": "4.1.0", "lcm": "0.0.3", "lodash": "4.18.1", "neotraverse": "0.6.18", "object-hash": "3.0.0", "openapi-types": "12.1.3", "uuid": "11.1.0", "zod": "3.24.0", "zod-to-json-schema": "3.20.4" } }, "sha512-nVK4qCsUORuYqiw5JagCr4kr8BHoM0JYA4xFuIDq2iRyKE5fgUTyCG65l7zCWiSCYqV5iciwqsBo3F0baio8NQ=="],
+
+    "@mistralai/mistralai": ["@mistralai/mistralai@2.2.6", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.40.0", "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ=="],
 
     "@modelcontextprotocol/client": ["@modelcontextprotocol/client@2.0.0-alpha.2", "", { "dependencies": { "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "jose": "^6.1.3", "pkce-challenge": "^5.0.0", "zod": "^4.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-FxlR5QyBPeCDEDPH2Kx20uygmuy9k2jh6ahUeEYtmVfUxboZZlUEUhn6w0XxnbxpkELcT1qyzTXC8Bqh3c8QUA=="],
 
@@ -863,6 +961,8 @@
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
+    "@silvia-odwyer/photon-node": ["@silvia-odwyer/photon-node@0.3.4", "", {}, "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA=="],
+
     "@sindresorhus/is": ["@sindresorhus/is@5.6.0", "", {}, "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g=="],
 
     "@sindresorhus/slugify": ["@sindresorhus/slugify@2.2.0", "", { "dependencies": { "@sindresorhus/transliterate": "^1.0.0", "escape-string-regexp": "^5.0.0" } }, "sha512-9Vybc/qX8Kj6pxJaapjkFbiUJPk7MAkCh/GFCxIBnnsuYCFPIXKvnLidG8xlepht3i24L5XemUmGtrJ3UWrl6w=="],
@@ -871,9 +971,17 @@
 
     "@smithy/core": ["@smithy/core@3.26.0", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g=="],
 
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.4.10", "", { "dependencies": { "@smithy/core": "^3.29.5", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-MJenAe4OKRZUo1LdYYFDCsSHxaHvInIU/z52GsheO9vl1/VSySVCr0zkyKD6TFiGkSUaWGxvKZ/70OvgUZR5HQ=="],
+
     "@smithy/eventstream-codec": ["@smithy/eventstream-codec@4.4.2", "", { "dependencies": { "@smithy/core": "^3.26.0", "tslib": "^2.6.2" } }, "sha512-iv6jeGoL5dIGXglIe0aJb8vvTuJkGB4z0LeB2mKV0PH9iAlr4jNhRhEWU7ZGmIeNC+8Zj6jhmSumDez6DidTOA=="],
 
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.6.7", "", { "dependencies": { "@smithy/core": "^3.29.5", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3zpg8yqqyXzoK2TsRDdkqVOj2RDBFfLXwCczOZ5c7TWB4eiaebfSCsbMjDPYB3PJ9ihV62QaeadZ+wLadZtNGA=="],
+
     "@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.7.3", "", { "dependencies": { "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA=="],
+
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.6.6", "", { "dependencies": { "@smithy/core": "^3.29.5", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-efP6DN3UTFrzIsGO42/xcabv8jU7+9nwEdphFUH7yL0k010ERyAWaO41KFQIDLcFZLZ8xzIQr4wplFxNzslSGQ=="],
 
     "@smithy/types": ["@smithy/types@4.15.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg=="],
 
@@ -942,6 +1050,8 @@
     "@superserve/mcp": ["@superserve/mcp@workspace:packages/mcp"],
 
     "@superserve/mcp-host": ["@superserve/mcp-host@workspace:apps/mcp"],
+
+    "@superserve/pi": ["@superserve/pi@workspace:packages/pi"],
 
     "@superserve/python-sdk": ["@superserve/python-sdk@workspace:packages/python-sdk"],
 
@@ -1074,6 +1184,8 @@
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
@@ -1243,11 +1355,15 @@
 
     "better-opn": ["better-opn@3.0.2", "", { "dependencies": { "open": "^8.0.4" } }, "sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ=="],
 
+    "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
+
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
     "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
 
     "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
+
+    "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
     "boxen": ["boxen@8.0.1", "", { "dependencies": { "ansi-align": "^3.0.1", "camelcase": "^8.0.0", "chalk": "^5.3.0", "cli-boxes": "^3.0.0", "string-width": "^7.2.0", "type-fest": "^4.21.0", "widest-line": "^5.0.0", "wrap-ansi": "^9.0.0" } }, "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw=="],
 
@@ -1260,6 +1376,8 @@
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
     "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
+
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
@@ -1391,7 +1509,7 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
-    "data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
+    "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
     "data-view-buffer": ["data-view-buffer@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-data-view": "^1.0.2" } }, "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ=="],
 
@@ -1451,6 +1569,8 @@
 
     "didyoumean": ["didyoumean@1.2.2", "", {}, "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="],
 
+    "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
+
     "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
 
     "dns-packet": ["dns-packet@5.6.1", "", { "dependencies": { "@leichtgewicht/ip-codec": "^2.0.1" } }, "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw=="],
@@ -1472,6 +1592,8 @@
     "dot-prop": ["dot-prop@10.1.0", "", { "dependencies": { "type-fest": "^5.0.0" } }, "sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
@@ -1599,6 +1721,8 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
+
     "fflate": ["fflate@0.4.8", "", {}, "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
@@ -1620,6 +1744,8 @@
     "form-data-encoder": ["form-data-encoder@2.1.4", "", {}, "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw=="],
 
     "format": ["format@0.2.2", "", {}, "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww=="],
+
+    "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
@@ -1643,7 +1769,11 @@
 
     "functions-have-names": ["functions-have-names@1.2.3", "", {}, "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="],
 
+    "gaxios": ["gaxios@7.2.0", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg=="],
+
     "gcd": ["gcd@0.0.1", "", {}, "sha512-VNx3UEGr+ILJTiMs1+xc5SX1cMgJCrXezKPa003APUWNqQqaF6n25W8VcR7nHN6yRWbvvUTwCpZCFJeWC2kXlw=="],
+
+    "gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
 
     "generator-function": ["generator-function@2.0.1", "", {}, "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g=="],
 
@@ -1678,6 +1808,10 @@
     "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
 
     "globrex": ["globrex@0.1.2", "", {}, "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="],
+
+    "google-auth-library": ["google-auth-library@10.9.0", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg=="],
+
+    "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
@@ -1741,7 +1875,11 @@
 
     "hex-rgb": ["hex-rgb@5.0.0", "", {}, "sha512-NQO+lgVUCtHxZ792FodgW0zflK+ozS9X9dwGp9XvvmPlH7pyxd588cn24TD3rmPm/N0AIRXF10Otah8yKqGw4w=="],
 
+    "highlight.js": ["highlight.js@10.7.3", "", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
+
     "hono": ["hono@4.12.26", "", {}, "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw=="],
+
+    "hosted-git-info": ["hosted-git-info@9.0.3", "", { "dependencies": { "lru-cache": "^11.1.0" } }, "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg=="],
 
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
@@ -1907,11 +2045,15 @@
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
+    "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
+
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
     "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
 
     "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
@@ -1926,6 +2068,10 @@
     "jsonpath-plus": ["jsonpath-plus@10.4.0", "", { "dependencies": { "@jsep-plugin/assignment": "^1.3.0", "@jsep-plugin/regex": "^1.0.4", "jsep": "^1.4.0" }, "bin": { "jsonpath": "bin/jsonpath-cli.js", "jsonpath-plus": "bin/jsonpath-cli.js" } }, "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA=="],
 
     "jsonpointer": ["jsonpointer@5.0.1", "", {}, "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ=="],
+
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
 
     "katex": ["katex@0.16.45", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA=="],
 
@@ -2193,6 +2339,8 @@
 
     "node-addon-api": ["node-addon-api@4.3.0", "", {}, "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="],
 
+    "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
+
     "node-fetch": ["node-fetch@2.6.7", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ=="],
 
     "node-releases": ["node-releases@2.0.37", "", {}, "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg=="],
@@ -2233,6 +2381,8 @@
 
     "open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
+    "openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
+
     "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
 
     "openid-client": ["openid-client@6.8.3", "", { "dependencies": { "jose": "^6.2.2", "oauth4webapi": "^3.8.5" } }, "sha512-AoY/NaN9esS3+xvHInFSK0g3skSfeE0uqQAKRj4rB6/GsBIvzwTUaYo9+HcqpKIaP0dP85p5W07hayKgS4GAeA=="],
@@ -2250,6 +2400,8 @@
     "p-any": ["p-any@4.0.0", "", { "dependencies": { "p-cancelable": "^3.0.0", "p-some": "^6.0.0" } }, "sha512-S/B50s+pAVe0wmEZHmBs/9yJXeZ5KhHzOsgKzt0hRdgkoR3DxW9ts46fcsWi/r3VnzsnkKS7q4uimze+zjdryw=="],
 
     "p-cancelable": ["p-cancelable@3.0.0", "", {}, "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw=="],
+
+    "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
 
     "p-some": ["p-some@6.0.0", "", { "dependencies": { "aggregate-error": "^4.0.0", "p-cancelable": "^3.0.0" } }, "sha512-CJbQCKdfSX3fIh8/QKgS+9rjm7OBNUTmwWswAFQAhc8j1NR1dsEDETUEuVUtQHZpV+J03LqWBEwvu0g1Yn+TYg=="],
 
@@ -2272,6 +2424,8 @@
     "parseley": ["parseley@0.12.1", "", { "dependencies": { "leac": "^0.6.0", "peberminta": "^0.9.0" } }, "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw=="],
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "partial-json": ["partial-json@0.1.7", "", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
 
     "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
 
@@ -2340,6 +2494,8 @@
     "promise-stream-reader": ["promise-stream-reader@1.0.1", "", {}, "sha512-Tnxit5trUjBAqqZCGWwjyxhmgMN4hGrtpW3Oc/tRI4bpm/O2+ej72BB08l6JBnGQgVDGCLvHFGjGgQS6vzhwXg=="],
 
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
+
+    "proper-lockfile": ["proper-lockfile@4.1.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
@@ -2475,6 +2631,8 @@
 
     "retext-stringify": ["retext-stringify@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "nlcst-to-string": "^4.0.0", "unified": "^11.0.0" } }, "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA=="],
 
+    "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
+
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
@@ -2507,7 +2665,7 @@
 
     "selderee": ["selderee@0.11.0", "", { "dependencies": { "parseley": "^0.12.0" } }, "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA=="],
 
-    "semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
+    "semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
 
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
@@ -2689,6 +2847,8 @@
 
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
 
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
     "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
 
     "tsconfck": ["tsconfck@3.1.6", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "tsconfck": "bin/tsconfck.js" } }, "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w=="],
@@ -2711,6 +2871,8 @@
 
     "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
+    "typebox": ["typebox@1.1.38", "", {}, "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA=="],
+
     "typed-array-buffer": ["typed-array-buffer@1.0.3", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-typed-array": "^1.1.14" } }, "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw=="],
 
     "typed-array-byte-length": ["typed-array-byte-length@1.0.3", "", { "dependencies": { "call-bind": "^1.0.8", "for-each": "^0.3.3", "gopd": "^1.2.0", "has-proto": "^1.2.0", "is-typed-array": "^1.1.14" } }, "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg=="],
@@ -2728,6 +2890,8 @@
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
 
     "unbzip2-stream": ["unbzip2-stream@1.4.3", "", { "dependencies": { "buffer": "^5.2.1", "through": "^2.3.8" } }, "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg=="],
+
+    "undici": ["undici@8.5.0", "", {}, "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg=="],
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
@@ -2801,6 +2965,8 @@
 
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
+    "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
+
     "web-vitals": ["web-vitals@5.2.0", "", {}, "sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA=="],
 
     "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
@@ -2869,7 +3035,109 @@
 
     "@asyncapi/parser/ajv-formats": ["ajv-formats@2.1.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA=="],
 
+    "@aws-crypto/sha256-browser/@aws-sdk/types": ["@aws-sdk/types@3.974.2", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA=="],
+
+    "@aws-crypto/sha256-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@aws-crypto/sha256-js/@aws-sdk/types": ["@aws-sdk/types@3.974.2", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA=="],
+
     "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@aws-sdk/core/@aws-sdk/types": ["@aws-sdk/types@3.974.2", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA=="],
+
+    "@aws-sdk/core/@smithy/core": ["@smithy/core@3.29.5", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ=="],
+
+    "@aws-sdk/core/@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
+
+    "@aws-sdk/credential-provider-env/@aws-sdk/types": ["@aws-sdk/types@3.974.2", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA=="],
+
+    "@aws-sdk/credential-provider-env/@smithy/core": ["@smithy/core@3.29.5", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ=="],
+
+    "@aws-sdk/credential-provider-env/@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
+
+    "@aws-sdk/credential-provider-http/@aws-sdk/types": ["@aws-sdk/types@3.974.2", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA=="],
+
+    "@aws-sdk/credential-provider-http/@smithy/core": ["@smithy/core@3.29.5", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ=="],
+
+    "@aws-sdk/credential-provider-http/@smithy/node-http-handler": ["@smithy/node-http-handler@4.9.7", "", { "dependencies": { "@smithy/core": "^3.29.5", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-wCU8HCLjAtAVqxxe0j2xff9LcEPw3yjBbg5IdQDIYFnxnPxbxcSLc7rgex7kqm9L/WYOnJEgaWQlfDkZleozMA=="],
+
+    "@aws-sdk/credential-provider-http/@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
+
+    "@aws-sdk/credential-provider-ini/@aws-sdk/types": ["@aws-sdk/types@3.974.2", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA=="],
+
+    "@aws-sdk/credential-provider-ini/@smithy/core": ["@smithy/core@3.29.5", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ=="],
+
+    "@aws-sdk/credential-provider-ini/@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
+
+    "@aws-sdk/credential-provider-login/@aws-sdk/types": ["@aws-sdk/types@3.974.2", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA=="],
+
+    "@aws-sdk/credential-provider-login/@smithy/core": ["@smithy/core@3.29.5", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ=="],
+
+    "@aws-sdk/credential-provider-login/@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
+
+    "@aws-sdk/credential-provider-node/@aws-sdk/types": ["@aws-sdk/types@3.974.2", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA=="],
+
+    "@aws-sdk/credential-provider-node/@smithy/core": ["@smithy/core@3.29.5", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ=="],
+
+    "@aws-sdk/credential-provider-node/@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
+
+    "@aws-sdk/credential-provider-process/@aws-sdk/types": ["@aws-sdk/types@3.974.2", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA=="],
+
+    "@aws-sdk/credential-provider-process/@smithy/core": ["@smithy/core@3.29.5", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ=="],
+
+    "@aws-sdk/credential-provider-process/@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
+
+    "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1088.0", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/nested-clients": "^3.997.33", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-4ObatWt2qpJg5FBk4LOOKrTQYzaqeewAtdO3r9ZO8lH9YqLtpTzLyIdy0mJ+nVdfYOnqISkKNfmzP22bNDhwyw=="],
+
+    "@aws-sdk/credential-provider-sso/@aws-sdk/types": ["@aws-sdk/types@3.974.2", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA=="],
+
+    "@aws-sdk/credential-provider-sso/@smithy/core": ["@smithy/core@3.29.5", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ=="],
+
+    "@aws-sdk/credential-provider-sso/@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
+
+    "@aws-sdk/credential-provider-web-identity/@aws-sdk/types": ["@aws-sdk/types@3.974.2", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA=="],
+
+    "@aws-sdk/credential-provider-web-identity/@smithy/core": ["@smithy/core@3.29.5", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ=="],
+
+    "@aws-sdk/credential-provider-web-identity/@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
+
+    "@aws-sdk/eventstream-handler-node/@aws-sdk/types": ["@aws-sdk/types@3.974.2", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA=="],
+
+    "@aws-sdk/eventstream-handler-node/@smithy/core": ["@smithy/core@3.29.5", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ=="],
+
+    "@aws-sdk/eventstream-handler-node/@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
+
+    "@aws-sdk/middleware-eventstream/@aws-sdk/types": ["@aws-sdk/types@3.974.2", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA=="],
+
+    "@aws-sdk/middleware-eventstream/@smithy/core": ["@smithy/core@3.29.5", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ=="],
+
+    "@aws-sdk/middleware-eventstream/@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
+
+    "@aws-sdk/middleware-websocket/@aws-sdk/types": ["@aws-sdk/types@3.974.2", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA=="],
+
+    "@aws-sdk/middleware-websocket/@smithy/core": ["@smithy/core@3.29.5", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ=="],
+
+    "@aws-sdk/middleware-websocket/@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
+
+    "@aws-sdk/nested-clients/@aws-sdk/types": ["@aws-sdk/types@3.974.2", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA=="],
+
+    "@aws-sdk/nested-clients/@smithy/core": ["@smithy/core@3.29.5", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ=="],
+
+    "@aws-sdk/nested-clients/@smithy/node-http-handler": ["@smithy/node-http-handler@4.9.7", "", { "dependencies": { "@smithy/core": "^3.29.5", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-wCU8HCLjAtAVqxxe0j2xff9LcEPw3yjBbg5IdQDIYFnxnPxbxcSLc7rgex7kqm9L/WYOnJEgaWQlfDkZleozMA=="],
+
+    "@aws-sdk/nested-clients/@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
+
+    "@aws-sdk/signature-v4-multi-region/@aws-sdk/types": ["@aws-sdk/types@3.974.2", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA=="],
+
+    "@aws-sdk/signature-v4-multi-region/@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
+
+    "@aws-sdk/token-providers/@aws-sdk/types": ["@aws-sdk/types@3.974.2", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA=="],
+
+    "@aws-sdk/token-providers/@smithy/core": ["@smithy/core@3.29.5", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ=="],
+
+    "@aws-sdk/token-providers/@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
+
+    "@aws-sdk/xml-builder/@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
 
     "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -2890,6 +3158,14 @@
     "@babel/helper-module-transforms/@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
 
     "@babel/template/@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
+
+    "@earendil-works/pi-ai/@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+
+    "@earendil-works/pi-coding-agent/jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
+
+    "@earendil-works/pi-tui/get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
+
+    "@earendil-works/pi-tui/marked": ["marked@18.0.5", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w=="],
 
     "@inquirer/core/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
@@ -2912,6 +3188,8 @@
     "@mintlify/cli/posthog-node": ["posthog-node@5.17.2", "", { "dependencies": { "@posthog/core": "1.7.1" } }, "sha512-lz3YJOr0Nmiz0yHASaINEDHqoV+0bC3eD8aZAG+Ky292dAnVYul+ga/dMX8KCBXg8hHfKdxw0SztYD5j6dgUqQ=="],
 
     "@mintlify/cli/react": ["react@19.2.3", "", {}, "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA=="],
+
+    "@mintlify/cli/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "@mintlify/cli/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
@@ -2989,6 +3267,8 @@
 
     "@mintlify/validation/zod-to-json-schema": ["zod-to-json-schema@3.20.4", "", { "peerDependencies": { "zod": "^3.20.0" } }, "sha512-Un9+kInJ2Zt63n6Z7mLqBifzzPcOyX+b+Exuzf7L1+xqck9Q2EPByyTRduV3kmSPaXaRer1JCsucubpgL1fipg=="],
 
+    "@mistralai/mistralai/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
     "@modelcontextprotocol/client/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
@@ -3036,6 +3316,18 @@
     "@shikijs/twoslash/@shikijs/core": ["@shikijs/core@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA=="],
 
     "@shikijs/twoslash/@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
+
+    "@smithy/credential-provider-imds/@smithy/core": ["@smithy/core@3.29.5", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ=="],
+
+    "@smithy/credential-provider-imds/@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
+
+    "@smithy/fetch-http-handler/@smithy/core": ["@smithy/core@3.29.5", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ=="],
+
+    "@smithy/fetch-http-handler/@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
+
+    "@smithy/signature-v4/@smithy/core": ["@smithy/core@3.29.5", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ=="],
+
+    "@smithy/signature-v4/@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
 
     "@stoplight/better-ajv-errors/leven": ["leven@3.1.0", "", {}, "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="],
 
@@ -3143,7 +3435,13 @@
 
     "fs-minipass/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
+    "gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+
+    "get-uri/data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
+
     "hast-util-to-mdast/unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "hosted-git-info/lru-cache": ["lru-cache@11.3.5", "", {}, "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="],
 
     "htmlparser2/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
@@ -3219,6 +3517,8 @@
 
     "ora/log-symbols": ["log-symbols@6.0.0", "", { "dependencies": { "chalk": "^5.3.0", "is-unicode-supported": "^1.3.0" } }, "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw=="],
 
+    "p-retry/retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
+
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
@@ -3292,6 +3592,10 @@
     "xss/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
     "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "@aws-crypto/sha256-browser/@aws-sdk/types/@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
+
+    "@aws-crypto/sha256-js/@aws-sdk/types/@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
 
     "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 

--- a/packages/pi/LICENSE
+++ b/packages/pi/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/pi/README.md
+++ b/packages/pi/README.md
@@ -1,0 +1,144 @@
+# @superserve/pi
+
+Run Pi's shell and filesystem tools in a remote Superserve microVM while Pi,
+model credentials, and session state stay on the host.
+
+The package routes all seven built-in tools (`bash`, `read`, `write`, `edit`,
+`grep`, `find`, and `ls`) plus interactive `!` commands. Once Superserve mode is
+requested, sandbox failures are fail-closed: commands are rejected rather than
+retried on the host.
+
+## Install
+
+```sh
+pi install npm:@superserve/pi@0.1.0
+```
+
+Set the API key on the host:
+
+```sh
+export SUPERSERVE_API_KEY=ss_live_...
+```
+
+`SUPERSERVE_BASE_URL` can override the API endpoint for a self-hosted or staging
+deployment. Neither value is forwarded to sandbox commands.
+
+The extension supports Pi 0.80.x starting at 0.80.9 and Node.js 22.19 or newer
+when Pi is running under Node. New Pi minor releases must be reviewed before
+the peer range and runtime gate are widened because isolation depends on
+extension ordering and tool-event semantics.
+
+## Isolation-safe usage
+
+Pi extensions and project resources are JavaScript that run in Pi's host
+process. For untrusted repositories, load only this package and disable host
+project resources:
+
+```sh
+pi \
+  --no-builtin-tools \
+  --no-extensions \
+  --no-skills \
+  --no-prompt-templates \
+  --no-themes \
+  --no-context-files \
+  --no-approve \
+  -e npm:@superserve/pi@0.1.0 \
+  --superserve
+```
+
+Do not use `--no-tools`; it also removes the Superserve tool definitions. Avoid
+combining this launcher with `--tools read,...`, which can reactivate built-in
+tools if the extension fails to load.
+
+Pass `--superserve` on every fresh invocation, including when resuming a bound
+session. A bound session opened without explicit Superserve intent is blocked
+and must be restarted with the secure launcher; it never silently falls back to
+host tools.
+
+For trusted projects, `pi --superserve` is a shorter convenience command. It is
+not the isolation boundary when other global or CLI extensions are loaded:
+extensions share Pi's host process, and an earlier extension can intercept the
+interactive `!` shell handler. The package verifies ownership of model-facing
+tool names and fails closed on collisions, but only the exclusive launcher
+removes the host-extension ordering risk completely.
+
+A new session creates one sandbox from `superserve/node-22`, uploads the current
+contents of Git-tracked files to `/workspace`, and creates a synthetic initial
+Git commit there. Dirty tracked files are included. Untracked and ignored files
+are excluded, which avoids uploading common local secret files. Tracked secret
+files are included, so audit the Git index or use `--superserve-sync none` when
+necessary.
+
+Changes remain in the sandbox. Save a bounded ZIP archive to the local checkout
+before deleting or allowing the sandbox to expire:
+
+```text
+/superserve download
+/superserve download output/review.zip
+```
+
+The command creates missing parent directories, but never extracts the archive
+or overwrites an existing file.
+
+## Flags
+
+| Flag                                       | Default              | Purpose                                         |
+| ------------------------------------------ | -------------------- | ----------------------------------------------- |
+| `--superserve`                             | off                  | Enable fail-closed sandbox routing              |
+| `--superserve-template <name-or-id>`       | `superserve/node-22` | Template used for new sandboxes                 |
+| `--superserve-sandbox <id>`                | none                 | Attach an existing sandbox; implies secure mode |
+| `--superserve-timeout <seconds>`           | `3600`               | Provider auto-pause timeout                     |
+| `--superserve-auto-delete <seconds\|none>` | `86400`              | Delete after continuous paused time             |
+| `--superserve-sync <tracked\|none>`        | `tracked`            | Upload tracked files when creating a sandbox    |
+
+Custom templates must provide Node.js 22 and a POSIX shell. Tracked workspace
+sync also expects `tar`; its synthetic Git baseline is skipped if `git` is not
+installed in the template.
+
+## Session lifecycle
+
+The package stores only versioned sandbox metadata in Pi's session JSONL. It
+never persists API keys, access tokens, or secret values.
+
+- Resuming a session with explicit `--superserve` intent reconnects and
+  activates its sandbox.
+- Forking allocates a different sandbox and uploads the current host checkout;
+  it never attaches the parent's sandbox.
+- Quitting or switching a persisted session pauses its sandbox.
+- An in-memory session destroys sandboxes created by the package on shutdown.
+- Provider 404 responses create a replacement only during session restoration;
+  authentication, network, and server errors remain fail-closed.
+- A provisioning key reconciles crashes between sandbox creation and session
+  persistence without blindly creating a duplicate.
+
+Use `/superserve` for status. Other actions are `pause`, `resume`, `list`,
+`connect <id>`, `kill`, `new`, and `download [output.zip]`. There is no command
+that switches a sandbox-intended session back to host tools.
+
+## Security boundaries and current limitations
+
+- Model and interactive tool calls execute in the Superserve sandbox. Pi itself
+  and this installed package execute on the host.
+- Unknown model tools are blocked while Superserve mode is active because their
+  implementations cannot be transparently moved into the sandbox.
+- Pi's host shell environment is never passed to sandbox commands.
+- Shell output is fetched through the SDK's bounded non-streaming path with a
+  1 MiB hard response cap, then reduced to Pi's bounded tail without saving
+  full output on the host. Commands default to 10 minutes and are capped at one
+  hour. Text files are streamed remotely in bounded line ranges; attached image
+  payloads are capped at 10 MiB.
+- Initial sync invokes `git` and `tar` binaries resolved outside
+  workspace-controlled `PATH` entries on the host. Model commands never reach
+  those processes.
+- Network egress currently uses the provider default and is unrestricted. This
+  release provides compute and filesystem isolation, not a strict outbound
+  network policy. Do not describe it as deny-all egress until provider-level
+  enforcement is complete.
+- Attached existing sandboxes are not overwritten with the local workspace and
+  are paused, not destroyed, during automatic shutdown.
+- Sandboxes do not mount the host checkout. Use the explicit ZIP download flow
+  to review and recover remote changes.
+- Do not open the same persisted Pi session concurrently. The provider does not
+  yet expose the atomic lease needed to prevent two Pi processes from sharing a
+  bound sandbox.

--- a/packages/pi/package.json
+++ b/packages/pi/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@superserve/pi",
+  "version": "0.1.0",
+  "description": "Run Pi coding-agent tools in isolated Superserve sandboxes",
+  "keywords": [
+    "agents",
+    "ai",
+    "firecracker",
+    "pi-package",
+    "sandbox",
+    "superserve"
+  ],
+  "homepage": "https://superserve.ai?utm_source=npm&utm_medium=package_meta",
+  "bugs": {
+    "url": "https://github.com/superserve-ai/superserve/issues"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/superserve-ai/superserve.git",
+    "directory": "packages/pi"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "lint": "bunx oxlint",
+    "format": "bunx oxfmt --write",
+    "format:check": "bunx oxfmt --check",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@superserve/sdk": "^0.8.0"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "0.80.9",
+    "@superserve/typescript-config": "workspace:*",
+    "@types/node": "^25.5.2",
+    "tsup": "^8.0.0",
+    "typescript": "^5.7.0",
+    "vitest": "^4.0.0"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": ">=0.80.9 <0.81.0"
+  },
+  "engines": {
+    "node": ">=22.19.0"
+  },
+  "pi": {
+    "extensions": [
+      "./dist/index.js"
+    ]
+  }
+}

--- a/packages/pi/src/bridge.ts
+++ b/packages/pi/src/bridge.ts
@@ -1,0 +1,540 @@
+import { Buffer } from "node:buffer"
+
+import {
+  BRIDGE_PATH,
+  MAX_BRIDGE_OUTPUT_BYTES,
+  MAX_GREP_CONTEXT,
+  MAX_GREP_RESULTS,
+  MAX_LS_RESULTS,
+} from "./constants.js"
+import type { SandboxHandle } from "./types.js"
+
+const MAX_BRIDGE_INPUT_BYTES = 64 * 1024
+
+export type BridgeAction =
+  | "access"
+  | "exists"
+  | "glob"
+  | "grep"
+  | "home"
+  | "list"
+  | "read"
+  | "stat"
+
+interface BridgeSuccess<T> {
+  ok: true
+  value: T
+}
+
+interface BridgeFailure {
+  ok: false
+  error: string
+  code?: string
+}
+
+export interface BridgeListResult {
+  exists: boolean
+  isDirectory: boolean
+  entries: Array<{ name: string; isDirectory: boolean }>
+}
+
+export interface BridgeGrepResult {
+  output: string
+  matchLimitReached: boolean
+  linesTruncated: boolean
+  responseLimitReached: boolean
+}
+
+export type BridgeReadResult =
+  | {
+      kind: "image"
+      mimeType: string
+      size: number
+    }
+  | {
+      kind: "text"
+      content: string
+      contentLimitReached: boolean
+      firstLineBytes: number
+      selectedLines: number
+      totalLines: number
+    }
+
+export class BridgeError extends Error {
+  readonly code?: string
+
+  constructor(message: string, code?: string) {
+    super(message)
+    this.name = "BridgeError"
+    this.code = code
+  }
+}
+
+export async function installBridge(
+  sandbox: SandboxHandle,
+  signal?: AbortSignal,
+): Promise<void> {
+  await sandbox.files.write(BRIDGE_PATH, BRIDGE_SOURCE, {
+    timeoutMs: 30_000,
+    signal,
+  })
+}
+
+export async function callBridge<T>(
+  sandbox: SandboxHandle,
+  action: BridgeAction,
+  input: Record<string, unknown> = {},
+  signal?: AbortSignal,
+): Promise<T> {
+  const encoded = Buffer.from(JSON.stringify(input)).toString("base64url")
+  if (Buffer.byteLength(encoded) > MAX_BRIDGE_INPUT_BYTES) {
+    throw new BridgeError("Remote filesystem request is too large")
+  }
+
+  const result = await sandbox.commands.run(`node ${BRIDGE_PATH} ${action}`, {
+    env: { SUPERSERVE_PI_INPUT: encoded },
+    timeoutMs: 30_000,
+    signal,
+    maxOutputBytes: MAX_BRIDGE_OUTPUT_BYTES,
+  })
+  if (result.exitCode !== 0) {
+    const message =
+      result.stderr.trim() || `bridge exited with ${result.exitCode}`
+    throw new BridgeError(`Superserve filesystem bridge failed: ${message}`)
+  }
+
+  let response: unknown
+  try {
+    response = JSON.parse(result.stdout)
+  } catch {
+    throw new BridgeError("Superserve filesystem bridge returned invalid JSON")
+  }
+  if (!isBridgeResponse(response)) {
+    throw new BridgeError(
+      "Superserve filesystem bridge returned an invalid response",
+    )
+  }
+  if (!response.ok) {
+    throw new BridgeError(response.error, response.code)
+  }
+  return response.value as T
+}
+
+function isBridgeResponse(
+  value: unknown,
+): value is BridgeSuccess<unknown> | BridgeFailure {
+  if (typeof value !== "object" || value === null || !("ok" in value)) {
+    return false
+  }
+  const response = value as Record<string, unknown>
+  if (response.ok === true) return "value" in response
+  return response.ok === false && typeof response.error === "string"
+}
+
+const BRIDGE_SOURCE = String.raw`
+import { createReadStream } from "node:fs"
+import { access, lstat, open, opendir, readFile, readdir, stat } from "node:fs/promises"
+import { homedir } from "node:os"
+import path from "node:path"
+
+const action = process.argv[2]
+const encoded = process.env.SUPERSERVE_PI_INPUT || "e30"
+// The SDK cap includes the data plane's outer JSON envelope, which escapes this
+// process's JSON stdout again. Keep the inner response well below half the cap.
+const MAX_RESPONSE_BYTES = 768 * 1024
+const MAX_SEARCH_VALUE_BYTES = 512 * 1024
+const MAX_READ_CONTENT_BYTES = 64 * 1024
+const MAX_READ_LINES = 2_001
+
+function respond(value) {
+  const response = JSON.stringify({ ok: true, value })
+  if (Buffer.byteLength(response) > MAX_RESPONSE_BYTES) {
+    throw new Error("Bridge response exceeds the safe output limit")
+  }
+  process.stdout.write(response)
+}
+
+function fail(error) {
+  const message = error instanceof Error ? error.message : String(error)
+  const code = error && typeof error === "object" && "code" in error
+    ? String(error.code)
+    : undefined
+  process.stdout.write(JSON.stringify({ ok: false, error: message, code }))
+}
+
+function parseInput() {
+  return JSON.parse(Buffer.from(encoded, "base64url").toString("utf8"))
+}
+
+function requireString(input, key) {
+  const value = input[key]
+  if (typeof value !== "string") throw new Error("Invalid " + key)
+  return value
+}
+
+function boundedInteger(value, fallback, minimum, maximum) {
+  if (!Number.isFinite(value)) return fallback
+  return Math.min(maximum, Math.max(minimum, Math.floor(value)))
+}
+
+function matchesGlob(relativePath, pattern) {
+  if (!pattern) return true
+  if (pattern.includes("/")) {
+    return path.matchesGlob(relativePath, pattern) ||
+      path.matchesGlob(relativePath, "**/" + pattern)
+  }
+  return path.matchesGlob(path.posix.basename(relativePath), pattern)
+}
+
+function jsonValueBytes(value) {
+  return Buffer.byteLength(JSON.stringify(value))
+}
+
+function appendUtf8Prefix(current, value, maxBytes) {
+  if (maxBytes <= 0 || value.length === 0) return current
+  const valueBuffer = Buffer.from(value)
+  if (valueBuffer.length <= maxBytes) return current + value
+  let end = maxBytes
+  while (end > 0 && end < valueBuffer.length && (valueBuffer[end] & 0xc0) === 0x80) {
+    end -= 1
+  }
+  return current + valueBuffer.subarray(0, end).toString("utf8")
+}
+
+function detectImageMimeType(prefix) {
+  if (
+    prefix.length >= 8 &&
+    prefix[0] === 0x89 &&
+    prefix.subarray(1, 4).toString("ascii") === "PNG" &&
+    prefix[4] === 0x0d &&
+    prefix[5] === 0x0a &&
+    prefix[6] === 0x1a &&
+    prefix[7] === 0x0a
+  ) return "image/png"
+  if (prefix.length >= 3 && prefix[0] === 0xff && prefix[1] === 0xd8 && prefix[2] === 0xff) {
+    return "image/jpeg"
+  }
+  const signature = prefix.subarray(0, 6).toString("ascii")
+  if (signature === "GIF87a" || signature === "GIF89a") return "image/gif"
+  if (
+    prefix.length >= 12 &&
+    prefix.subarray(0, 4).toString("ascii") === "RIFF" &&
+    prefix.subarray(8, 12).toString("ascii") === "WEBP"
+  ) return "image/webp"
+  if (prefix.length >= 2 && prefix[0] === 0x42 && prefix[1] === 0x4d) {
+    return "image/bmp"
+  }
+  return undefined
+}
+
+async function inspectImage(targetPath) {
+  const handle = await open(targetPath, "r")
+  try {
+    const info = await handle.stat()
+    if (!info.isFile()) throw new Error("Path is not a regular file: " + targetPath)
+    const prefix = Buffer.alloc(16)
+    const { bytesRead } = await handle.read(prefix, 0, prefix.length, 0)
+    const mimeType = detectImageMimeType(prefix.subarray(0, bytesRead))
+    return mimeType ? { mimeType, size: info.size } : undefined
+  } finally {
+    await handle.close()
+  }
+}
+
+async function listEntries(targetPath, limit) {
+  const selected = []
+  const directory = await opendir(targetPath)
+  for await (const entry of directory) {
+    const item = { name: entry.name, isDirectory: entry.isDirectory() }
+    let low = 0
+    let high = selected.length
+    while (low < high) {
+      const middle = (low + high) >>> 1
+      const comparison = selected[middle].name
+        .toLowerCase()
+        .localeCompare(item.name.toLowerCase())
+      if (comparison <= 0) low = middle + 1
+      else high = middle
+    }
+    selected.splice(low, 0, item)
+    if (selected.length > limit) selected.pop()
+  }
+  return selected
+}
+
+async function runRead(input) {
+  const targetPath = requireString(input, "path")
+  const image = await inspectImage(targetPath)
+  if (image) return { kind: "image", ...image }
+
+  const offset = boundedInteger(input.offset, 1, 1, Number.MAX_SAFE_INTEGER)
+  const requestedLimit = input.limit === undefined
+    ? MAX_READ_LINES
+    : boundedInteger(input.limit, 1, 1, MAX_READ_LINES)
+  const selected = []
+  let selectedBytes = 0
+  let selectedLines = 0
+  let totalLines = 0
+  let currentLine = ""
+  let currentLineBytes = 0
+  let currentPreviewBytes = 0
+  let currentPreviewComplete = true
+  let contentLimitReached = false
+  let firstLineBytes = 0
+  let pendingCarriageReturn = false
+
+  function appendSegment(segment) {
+    const segmentBytes = Buffer.byteLength(segment)
+    currentLineBytes += segmentBytes
+    const lineNumber = totalLines + 1
+    if (lineNumber < offset || selectedLines >= requestedLimit) return
+    if (!currentPreviewComplete) return
+    const separatorBytes = selectedLines > 0 ? 1 : 0
+    const remaining = MAX_READ_CONTENT_BYTES - selectedBytes - separatorBytes - currentPreviewBytes
+    const next = appendUtf8Prefix(currentLine, segment, remaining)
+    const appendedBytes = Buffer.byteLength(next) - Buffer.byteLength(currentLine)
+    currentPreviewBytes += appendedBytes
+    currentLine = next
+    if (appendedBytes < segmentBytes) {
+      currentPreviewComplete = false
+      contentLimitReached = true
+    }
+  }
+
+  function finishLine() {
+    totalLines += 1
+    if (totalLines >= offset && selectedLines < requestedLimit) {
+      if (selectedLines === 0) firstLineBytes = currentLineBytes
+      const separatorBytes = selectedLines > 0 ? 1 : 0
+      if (selectedBytes + separatorBytes + currentPreviewBytes <= MAX_READ_CONTENT_BYTES) {
+        selected.push(currentLine)
+        selectedBytes += separatorBytes + currentPreviewBytes
+      } else {
+        contentLimitReached = true
+      }
+      selectedLines += 1
+    }
+    currentLine = ""
+    currentLineBytes = 0
+    currentPreviewBytes = 0
+    currentPreviewComplete = true
+  }
+
+  const stream = createReadStream(targetPath, { encoding: "utf8" })
+  for await (const rawChunk of stream) {
+    let chunk = (pendingCarriageReturn ? "\r" : "") + rawChunk
+    pendingCarriageReturn = chunk.endsWith("\r")
+    if (pendingCarriageReturn) chunk = chunk.slice(0, -1)
+    const normalized = chunk.replace(/\r\n/g, "\n").replace(/\r/g, "\n")
+    const parts = normalized.split("\n")
+    appendSegment(parts[0] || "")
+    for (let index = 1; index < parts.length; index += 1) {
+      finishLine()
+      appendSegment(parts[index] || "")
+    }
+  }
+  if (pendingCarriageReturn) finishLine()
+  finishLine()
+
+  return {
+    kind: "text",
+    content: selected.join("\n"),
+    contentLimitReached,
+    firstLineBytes,
+    selectedLines,
+    totalLines,
+  }
+}
+
+async function walk(root, limit, visit) {
+  const rootStat = await lstat(root)
+  if (!rootStat.isDirectory()) {
+    await visit(root, path.posix.basename(root))
+    return
+  }
+
+  let visited = 0
+  async function walkDirectory(directory, relativeDirectory) {
+    const entries = await readdir(directory, { withFileTypes: true })
+    for (const entry of entries) {
+      if (visited >= limit) return false
+      if (entry.name === ".git" || entry.name === "node_modules") continue
+      const absolutePath = path.posix.join(directory, entry.name)
+      const relativePath = relativeDirectory
+        ? path.posix.join(relativeDirectory, entry.name)
+        : entry.name
+      if (entry.isDirectory()) {
+        if (!(await walkDirectory(absolutePath, relativePath))) return false
+        continue
+      }
+      visited += 1
+      if (!(await visit(absolutePath, relativePath))) return false
+    }
+    return true
+  }
+
+  await walkDirectory(root, "")
+}
+
+function createMatcher(pattern, literal, ignoreCase) {
+  if (literal) {
+    const needle = ignoreCase ? pattern.toLowerCase() : pattern
+    return (line) => (ignoreCase ? line.toLowerCase() : line).includes(needle)
+  }
+  const expression = new RegExp(pattern, ignoreCase ? "i" : undefined)
+  return (line) => expression.test(line)
+}
+
+async function runGrep(input) {
+  const root = requireString(input, "path")
+  const pattern = requireString(input, "pattern")
+  const literal = input.literal === true
+  const ignoreCase = input.ignoreCase === true
+  const glob = typeof input.glob === "string" ? input.glob : undefined
+  const context = boundedInteger(input.context, 0, 0, ${MAX_GREP_CONTEXT})
+  const limit = boundedInteger(input.limit, 100, 1, ${MAX_GREP_RESULTS})
+  const maxLineLength = boundedInteger(input.maxLineLength, 2_000, 80, 10_000)
+  const matcher = createMatcher(pattern, literal, ignoreCase)
+  const rootStat = await stat(root)
+  const rootIsDirectory = rootStat.isDirectory()
+  const output = []
+  let outputValueBytes = 2
+  let matchCount = 0
+  let linesTruncated = false
+  let responseLimitReached = false
+
+  function appendOutput(line) {
+    const lineBytes = jsonValueBytes(line) + (output.length > 0 ? 1 : 0)
+    if (outputValueBytes + lineBytes > MAX_SEARCH_VALUE_BYTES) {
+      responseLimitReached = true
+      return false
+    }
+    output.push(line)
+    outputValueBytes += lineBytes
+    return true
+  }
+
+  await walk(root, 100_000, async (absolutePath, relativePath) => {
+    if (matchCount >= limit || responseLimitReached) return false
+    if (glob && !matchesGlob(relativePath, glob)) return true
+
+    let content
+    try {
+      content = await readFile(absolutePath, "utf8")
+    } catch {
+      return true
+    }
+    if (content.includes("\0")) return true
+
+    const lines = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n")
+    const displayPath = rootIsDirectory
+      ? relativePath
+      : path.posix.basename(absolutePath)
+    for (let index = 0; index < lines.length; index += 1) {
+      if (!matcher(lines[index] || "")) continue
+      matchCount += 1
+      const start = context > 0 ? Math.max(0, index - context) : index
+      const end = context > 0 ? Math.min(lines.length - 1, index + context) : index
+      for (let outputIndex = start; outputIndex <= end; outputIndex += 1) {
+        const rawLine = (lines[outputIndex] || "").replace(/\r/g, "")
+        const line = rawLine.length > maxLineLength
+          ? rawLine.slice(0, maxLineLength)
+          : rawLine
+        if (line.length !== rawLine.length) linesTruncated = true
+        const separator = outputIndex === index ? ":" : "-"
+        if (!appendOutput(
+          displayPath + separator + (outputIndex + 1) + separator + " " + line,
+        )) return false
+      }
+      if (matchCount >= limit || responseLimitReached) return false
+    }
+    return true
+  })
+
+  return {
+    output: output.join("\n"),
+    matchLimitReached: matchCount >= limit,
+    linesTruncated,
+    responseLimitReached,
+  }
+}
+
+async function main() {
+  const input = parseInput()
+  if (action === "home") {
+    respond(homedir())
+    return
+  }
+
+  const targetPath = requireString(input, "path")
+  if (action === "access") {
+    await access(targetPath)
+    respond(null)
+    return
+  }
+  if (action === "exists") {
+    try {
+      await access(targetPath)
+      respond(true)
+    } catch {
+      respond(false)
+    }
+    return
+  }
+  if (action === "stat") {
+    const info = await stat(targetPath)
+    respond({ isDirectory: info.isDirectory() })
+    return
+  }
+  if (action === "list") {
+    try {
+      const info = await stat(targetPath)
+      if (!info.isDirectory()) {
+        respond({ exists: true, isDirectory: false, entries: [] })
+        return
+      }
+      const limit = boundedInteger(input.limit, 501, 1, ${MAX_LS_RESULTS + 1})
+      respond({
+        exists: true,
+        isDirectory: true,
+        entries: await listEntries(targetPath, limit),
+      })
+    } catch (error) {
+      if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+        respond({ exists: false, isDirectory: false, entries: [] })
+        return
+      }
+      throw error
+    }
+    return
+  }
+  if (action === "glob") {
+    const pattern = requireString(input, "pattern")
+    const limit = boundedInteger(input.limit, 1_000, 1, 5_000)
+    const results = []
+    let resultValueBytes = 2
+    await walk(targetPath, 100_000, async (absolutePath, relativePath) => {
+      if (matchesGlob(relativePath, pattern)) {
+        const entryBytes = jsonValueBytes(absolutePath) + (results.length > 0 ? 1 : 0)
+        if (resultValueBytes + entryBytes > MAX_SEARCH_VALUE_BYTES) return false
+        results.push(absolutePath)
+        resultValueBytes += entryBytes
+      }
+      return results.length < limit
+    })
+    respond(results)
+    return
+  }
+  if (action === "grep") {
+    respond(await runGrep(input))
+    return
+  }
+  if (action === "read") {
+    respond(await runRead(input))
+    return
+  }
+  throw new Error("Unknown bridge action: " + action)
+}
+
+main().catch(fail)
+`

--- a/packages/pi/src/constants.ts
+++ b/packages/pi/src/constants.ts
@@ -1,0 +1,33 @@
+export const GUEST_WORKSPACE = "/workspace"
+export const SESSION_ENTRY_TYPE = "superserve-sandbox"
+export const SESSION_ENTRY_VERSION = 1 as const
+export const CREATED_BY = "@superserve/pi"
+export const DEFAULT_TEMPLATE = "superserve/node-22"
+export const DEFAULT_TIMEOUT_SECONDS = 3_600
+export const DEFAULT_AUTO_DELETE_SECONDS = 86_400
+export const DEFAULT_COMMAND_TIMEOUT_SECONDS = 600
+export const MAX_COMMAND_TIMEOUT_SECONDS = 3_600
+export const MAX_COMMAND_OUTPUT_BYTES = 1024 * 1024
+export const MAX_FILE_READ_BYTES = 10 * 1024 * 1024
+export const MAX_BRIDGE_OUTPUT_BYTES = 2 * 1024 * 1024
+export const MAX_SYNC_ARCHIVE_BYTES = 100 * 1024 * 1024
+export const MAX_WORKSPACE_DOWNLOAD_BYTES = 250 * 1024 * 1024
+export const MAX_SYNC_FILES = 10_000
+export const MAX_LS_RESULTS = 1_000
+export const MAX_FIND_RESULTS = 5_000
+export const MAX_GREP_RESULTS = 1_000
+export const MAX_GREP_CONTEXT = 10
+export const BRIDGE_PATH = "/tmp/superserve-pi-bridge-v1.mjs"
+export const WORKSPACE_ARCHIVE_PATH = "/tmp/superserve-pi-workspace.tar.gz"
+
+export const ROUTED_TOOL_NAMES = [
+  "read",
+  "write",
+  "edit",
+  "bash",
+  "grep",
+  "find",
+  "ls",
+] as const
+
+export const ROUTED_TOOLS = new Set<string>(ROUTED_TOOL_NAMES)

--- a/packages/pi/src/index.ts
+++ b/packages/pi/src/index.ts
@@ -1,0 +1,490 @@
+import {
+  VERSION,
+  type ExtensionAPI,
+  type ExtensionContext,
+  type SourceInfo,
+  type UserBashEventResult,
+} from "@earendil-works/pi-coding-agent"
+
+import {
+  DEFAULT_AUTO_DELETE_SECONDS,
+  DEFAULT_TEMPLATE,
+  DEFAULT_TIMEOUT_SECONDS,
+  GUEST_WORKSPACE,
+  ROUTED_TOOLS,
+  SESSION_ENTRY_TYPE,
+} from "./constants.js"
+import {
+  formatError,
+  SandboxLifecycle,
+  type LifecycleDependencies,
+} from "./lifecycle.js"
+import {
+  createSandboxBashOperations,
+  createSandboxToolRegistrar,
+} from "./tools.js"
+
+export interface SuperservePiOptions extends LifecycleDependencies {
+  argv?: readonly string[]
+  invocationState?: SuperservePiInvocationState
+  localCwd?: string
+  piVersion?: string
+}
+
+export interface SuperservePiInvocationState {
+  routingRequested: boolean
+}
+
+export function createSuperservePiExtension(
+  options: SuperservePiOptions = {},
+): (pi: ExtensionAPI) => void {
+  return (pi) => {
+    registerFlags(pi)
+
+    const localCwd = options.localCwd ?? process.cwd()
+    const rawFlagIntent = hasRawFlagIntent(options.argv ?? process.argv)
+    const compatibilityError = piCompatibilityError(
+      options.piVersion ?? VERSION,
+    )
+    const invocationState =
+      options.invocationState ?? getProcessInvocationState()
+    const lifecycle = new SandboxLifecycle(
+      createLifecycleApi(pi, invocationState),
+      localCwd,
+      options,
+    )
+    const registerSandboxTools = createSandboxToolRegistrar(pi, lifecycle)
+    let routingRequired = rawFlagIntent || invocationState.routingRequested
+    let routingVerificationError: string | undefined
+
+    const verifyRouting = (): string | undefined => {
+      if (compatibilityError) {
+        routingVerificationError = compatibilityError
+        return routingVerificationError
+      }
+      try {
+        routingVerificationError = verifyRoutedToolSources(pi)
+      } catch (error) {
+        routingVerificationError = routingVerificationFailure(
+          `provenance inspection failed: ${formatError(error)}`,
+        )
+      }
+      return routingVerificationError
+    }
+
+    const failClosed = (
+      error: string,
+      ctx?: Pick<ExtensionContext, "ui">,
+    ): void => {
+      routingRequired = true
+      routingVerificationError = error
+      try {
+        pi.setActiveTools([])
+      } catch {
+        // Event handlers must still return a fail-closed result if Pi state is stale.
+      }
+      try {
+        ctx?.ui.notify(error, "error")
+      } catch {
+        // Notifications are optional and must not break the isolation decision.
+      }
+    }
+
+    const registerRoutingTools = (): string | undefined => {
+      if (compatibilityError) return compatibilityError
+      try {
+        registerSandboxTools()
+        return undefined
+      } catch (error) {
+        return routingVerificationFailure(
+          `tool registration failed: ${formatError(error)}`,
+        )
+      }
+    }
+
+    const requireVerifiedRouting = (): void => {
+      routingRequired = true
+      const registrationError = registerRoutingTools()
+      if (registrationError) {
+        failClosed(registrationError)
+        throw new Error(registrationError)
+      }
+      const verificationError = verifyRouting()
+      if (verificationError) {
+        failClosed(verificationError)
+        throw new Error(verificationError)
+      }
+      invocationState.routingRequested = true
+    }
+
+    pi.on("project_trust", () => {
+      if (
+        !rawFlagIntent &&
+        !invocationState.routingRequested &&
+        !lifecycle.hasFlagIntent()
+      ) {
+        return { trusted: "undecided" }
+      }
+      return { trusted: "no", remember: false }
+    })
+
+    pi.on("session_start", async (event, ctx) => {
+      const invocationRequested =
+        rawFlagIntent ||
+        invocationState.routingRequested ||
+        lifecycle.hasFlagIntent()
+      routingRequired = invocationRequested || hasSessionBinding(ctx)
+      let verificationError: string | undefined
+      if (routingRequired) {
+        const registrationError = registerRoutingTools()
+        if (registrationError) {
+          failClosed(registrationError, ctx)
+          return
+        }
+        verificationError = verifyRouting()
+        if (verificationError) {
+          failClosed(verificationError, ctx)
+          return
+        }
+        if (invocationRequested) invocationState.routingRequested = true
+      }
+
+      await lifecycle.start(event.reason, ctx)
+      if (!routingRequired && lifecycle.isEnabled()) {
+        routingRequired = true
+        const registrationError = registerRoutingTools()
+        if (registrationError) {
+          failClosed(registrationError, ctx)
+          return
+        }
+        verificationError = verifyRouting()
+        if (!verificationError) {
+          invocationState.routingRequested = true
+          pi.setActiveTools([...ROUTED_TOOLS])
+        }
+      }
+
+      if (!lifecycle.isEnabled()) {
+        if (routingRequired) pi.setActiveTools([])
+        return
+      }
+
+      if (verificationError) failClosed(verificationError, ctx)
+    })
+
+    pi.on("session_shutdown", async (event, ctx) => {
+      await lifecycle.shutdown(event.reason, ctx)
+    })
+
+    pi.on("tool_call", (event) => {
+      const secureMode = routingRequired || lifecycle.isEnabled()
+      if (!secureMode) return
+      routingRequired = true
+
+      const verificationError = verifyRouting()
+      if (verificationError) {
+        failClosed(verificationError)
+        return { block: true, reason: verificationError }
+      }
+      if (!lifecycle.isEnabled()) {
+        return {
+          block: true,
+          reason:
+            "Superserve mode was requested but did not initialize. The tool was blocked rather than executed on the host.",
+        }
+      }
+      if (ROUTED_TOOLS.has(event.toolName)) return
+      return {
+        block: true,
+        reason: `Tool "${event.toolName}" is not routed through Superserve. It was blocked rather than executed on the host.`,
+      }
+    })
+
+    pi.on(
+      "user_bash",
+      async (_event, ctx): Promise<UserBashEventResult | undefined> => {
+        const secureMode = routingRequired || lifecycle.isEnabled()
+        if (!secureMode) return undefined
+        routingRequired = true
+
+        const verificationError = verifyRouting()
+        if (verificationError || !lifecycle.isEnabled()) {
+          const detail =
+            verificationError ??
+            "Superserve mode was requested but did not initialize"
+          return failedUserBashResult(detail)
+        }
+        try {
+          const active = await lifecycle.requireSandbox(ctx)
+          return {
+            operations: createSandboxBashOperations(active, ctx.cwd),
+          }
+        } catch (error) {
+          return failedUserBashResult(formatError(error))
+        }
+      },
+    )
+
+    pi.on("before_agent_start", (event, ctx) => {
+      if (!lifecycle.isEnabled()) return
+      const localLine = `Current working directory: ${ctx.cwd}`
+      const remoteLine = `Current working directory: ${GUEST_WORKSPACE} (Superserve sandbox)`
+      const systemPrompt = event.systemPrompt.includes(localLine)
+        ? event.systemPrompt.replace(localLine, remoteLine)
+        : `${event.systemPrompt}\n\n${remoteLine}`
+      return {
+        systemPrompt: `${systemPrompt}\n\nAll shell and filesystem tools are routed to the Superserve sandbox. The host workspace is not directly available to tools. Network egress uses the provider default and is currently unrestricted.`,
+      }
+    })
+
+    pi.registerCommand("superserve", {
+      description:
+        "Manage the Superserve sandbox: status, pause, resume, list, connect, kill, new, or download",
+      handler: async (argumentsText, ctx) => {
+        const parts = argumentsText.trim().split(/\s+/).filter(Boolean)
+        const action = parts.shift() ?? "status"
+        const value = parts.join(" ") || undefined
+        try {
+          switch (action) {
+            case "status":
+              ctx.ui.notify(lifecycle.statusLines().join("\n"), "info")
+              return
+            case "pause":
+              await lifecycle.pause(ctx)
+              ctx.ui.notify("Superserve sandbox paused", "info")
+              return
+            case "resume": {
+              requireVerifiedRouting()
+              const active = await lifecycle.requireSandbox(ctx)
+              ctx.ui.notify(
+                `Superserve sandbox active: ${active.sandbox.id}`,
+                "info",
+              )
+              return
+            }
+            case "list": {
+              const sandboxes = await lifecycle.list()
+              const output =
+                sandboxes.length === 0
+                  ? "No Pi-created Superserve sandboxes found"
+                  : sandboxes
+                      .map(
+                        (sandbox) =>
+                          `${sandbox.id}  ${sandbox.status}  ${sandbox.name}`,
+                      )
+                      .join("\n")
+              ctx.ui.notify(output, "info")
+              return
+            }
+            case "connect": {
+              requireVerifiedRouting()
+              const active = await lifecycle.connect(value ?? "", ctx)
+              ctx.ui.notify(
+                `Connected to Superserve sandbox ${active.sandbox.id}`,
+                "info",
+              )
+              return
+            }
+            case "kill":
+              await lifecycle.kill(ctx)
+              ctx.ui.notify("Superserve sandbox destroyed", "warning")
+              return
+            case "new": {
+              requireVerifiedRouting()
+              const active = await lifecycle.createNew(ctx)
+              ctx.ui.notify(
+                `Created Superserve sandbox ${active.sandbox.id}`,
+                "info",
+              )
+              return
+            }
+            case "download": {
+              const result = await lifecycle.downloadWorkspace(value, ctx)
+              ctx.ui.notify(
+                `Saved ${result.bytes} bytes to ${result.path}`,
+                "info",
+              )
+              return
+            }
+            default:
+              throw new Error(
+                "Usage: /superserve [status|pause|resume|list|connect <id>|kill|new|download [output.zip]]",
+              )
+          }
+        } catch (error) {
+          ctx.ui.notify(formatError(error), "error")
+        }
+      },
+    })
+  }
+}
+
+function verifyRoutedToolSources(pi: ExtensionAPI): string | undefined {
+  const sourceAnchors = pi
+    .getCommands()
+    .filter((command) => command.name === "superserve")
+  if (sourceAnchors.length !== 1) {
+    return routingVerificationFailure(
+      "the /superserve command source anchor is missing or ambiguous",
+    )
+  }
+
+  const tools = pi.getAllTools()
+  const sourceAnchor = sourceAnchors[0]
+
+  const missing: string[] = []
+  const conflicting: string[] = []
+  for (const name of ROUTED_TOOLS) {
+    const tool = tools.find((candidate) => candidate.name === name)
+    if (!tool) missing.push(name)
+    else if (!sameSourceInfo(tool.sourceInfo, sourceAnchor.sourceInfo)) {
+      conflicting.push(name)
+    }
+  }
+
+  const details: string[] = []
+  if (missing.length > 0) details.push(`missing: ${missing.join(", ")}`)
+  if (conflicting.length > 0) {
+    details.push(`registered by another source: ${conflicting.join(", ")}`)
+  }
+  return details.length > 0
+    ? routingVerificationFailure(details.join("; "))
+    : undefined
+}
+
+function sameSourceInfo(left: SourceInfo, right: SourceInfo): boolean {
+  return (
+    left.path === right.path &&
+    left.source === right.source &&
+    left.scope === right.scope &&
+    left.origin === right.origin &&
+    left.baseDir === right.baseDir
+  )
+}
+
+function routingVerificationFailure(detail: string): string {
+  return `Superserve routing source verification failed (${detail}). All tools were disabled; use the secure exclusive launcher.`
+}
+
+function piCompatibilityError(version: string): string | undefined {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:([+-]).*)?$/.exec(version)
+  const supported =
+    match !== null &&
+    match[4] !== "-" &&
+    Number(match[1]) === 0 &&
+    Number(match[2]) === 80 &&
+    Number(match[3]) >= 9
+  return supported
+    ? undefined
+    : `Unsupported Pi version ${version}; @superserve/pi requires >=0.80.9 <0.81.0. All tools were disabled rather than risking host execution.`
+}
+
+function hasRawFlagIntent(argv: readonly string[]): boolean {
+  return argv.some(
+    (argument) =>
+      argument === "--superserve" ||
+      argument.startsWith("--superserve=") ||
+      argument === "--superserve-sandbox" ||
+      argument.startsWith("--superserve-sandbox="),
+  )
+}
+
+function hasSessionBinding(ctx: ExtensionContext): boolean {
+  return ctx.sessionManager
+    .getBranch()
+    .some(
+      (entry) =>
+        entry?.type === "custom" && entry.customType === SESSION_ENTRY_TYPE,
+    )
+}
+
+const INVOCATION_STATE_KEY = Symbol.for("@superserve/pi/invocation-state/v1")
+
+function getProcessInvocationState(): SuperservePiInvocationState {
+  const processGlobals = globalThis as typeof globalThis & {
+    [key: symbol]: unknown
+  }
+  const existing = processGlobals[INVOCATION_STATE_KEY]
+  if (
+    typeof existing === "object" &&
+    existing !== null &&
+    "routingRequested" in existing &&
+    typeof existing.routingRequested === "boolean"
+  ) {
+    return existing as SuperservePiInvocationState
+  }
+  const created: SuperservePiInvocationState = { routingRequested: false }
+  processGlobals[INVOCATION_STATE_KEY] = created
+  return created
+}
+
+function createLifecycleApi(
+  pi: ExtensionAPI,
+  invocationState: SuperservePiInvocationState,
+): ExtensionAPI {
+  return new Proxy(pi, {
+    get(target, property, receiver) {
+      if (property !== "getFlag") return Reflect.get(target, property, receiver)
+      return (name: string): boolean | string | undefined => {
+        if (name === "superserve" && invocationState.routingRequested) {
+          return true
+        }
+        return target.getFlag(name)
+      }
+    },
+  })
+}
+
+function failedUserBashResult(detail: string): UserBashEventResult {
+  return {
+    result: {
+      output: `Superserve unavailable: ${detail}\nThe command was not run on the host.`,
+      exitCode: 1,
+      cancelled: false,
+      truncated: false,
+    },
+  }
+}
+
+function registerFlags(pi: ExtensionAPI): void {
+  pi.registerFlag("superserve", {
+    description: "Run Pi tools in a Superserve sandbox",
+    type: "boolean",
+    default: false,
+  })
+  pi.registerFlag("superserve-template", {
+    description: `Sandbox template (default: ${DEFAULT_TEMPLATE})`,
+    type: "string",
+    default: DEFAULT_TEMPLATE,
+  })
+  pi.registerFlag("superserve-sandbox", {
+    description: "Connect to an existing Superserve sandbox ID",
+    type: "string",
+  })
+  pi.registerFlag("superserve-timeout", {
+    description: "Auto-pause timeout in seconds",
+    type: "string",
+    default: String(DEFAULT_TIMEOUT_SECONDS),
+  })
+  pi.registerFlag("superserve-auto-delete", {
+    description: "Delete after this many paused seconds, or none",
+    type: "string",
+    default: String(DEFAULT_AUTO_DELETE_SECONDS),
+  })
+  pi.registerFlag("superserve-sync", {
+    description: "Initial workspace upload: tracked or none",
+    type: "string",
+    default: "tracked",
+  })
+}
+
+export default createSuperservePiExtension()
+
+export { SandboxLifecycle } from "./lifecycle.js"
+export type {
+  ActiveSandbox,
+  SandboxBinding,
+  SandboxBootstrap,
+  SandboxHandle,
+  SandboxProvider,
+} from "./types.js"

--- a/packages/pi/src/lifecycle.ts
+++ b/packages/pi/src/lifecycle.ts
@@ -1,0 +1,1018 @@
+import { randomUUID } from "node:crypto"
+import { lstat, mkdir, open, realpath } from "node:fs/promises"
+import path from "node:path"
+
+import type {
+  ExtensionAPI,
+  ExtensionContext,
+} from "@earendil-works/pi-coding-agent"
+import { ConflictError, NotFoundError } from "@superserve/sdk"
+
+import {
+  CREATED_BY,
+  DEFAULT_AUTO_DELETE_SECONDS,
+  DEFAULT_TEMPLATE,
+  DEFAULT_TIMEOUT_SECONDS,
+  GUEST_WORKSPACE,
+  MAX_WORKSPACE_DOWNLOAD_BYTES,
+  ROUTED_TOOL_NAMES,
+  SESSION_ENTRY_TYPE,
+  SESSION_ENTRY_VERSION,
+} from "./constants.js"
+import { defaultSandboxProvider } from "./provider.js"
+import type {
+  ActiveSandbox,
+  SandboxBinding,
+  SandboxBootstrap,
+  SandboxHandle,
+  SandboxProvider,
+  SandboxRuntimeOptions,
+} from "./types.js"
+import { bootstrapSandbox } from "./workspace.js"
+
+type SessionStartReason = "startup" | "reload" | "new" | "resume" | "fork"
+type SessionShutdownReason = "quit" | "reload" | "new" | "resume" | "fork"
+
+export interface LifecycleDependencies {
+  provider?: SandboxProvider
+  bootstrap?: SandboxBootstrap
+  now?: () => Date
+  randomId?: () => string
+  sleep?: (milliseconds: number) => Promise<void>
+}
+
+export class SandboxLifecycle {
+  private readonly provider: SandboxProvider
+  private readonly bootstrap: SandboxBootstrap
+  private readonly now: () => Date
+  private readonly randomId: () => string
+  private readonly sleep: (milliseconds: number) => Promise<void>
+  private active: ActiveSandbox | undefined
+  private binding: SandboxBinding | undefined
+  private transition: Promise<ActiveSandbox> | undefined
+  private enabled = false
+  private carryIntent = false
+  private initializationError: Error | undefined
+  private currentSessionPersistent = false
+  private currentCwd: string
+  private invocationOptIn = false
+
+  constructor(
+    private readonly pi: ExtensionAPI,
+    localCwd: string,
+    dependencies: LifecycleDependencies = {},
+  ) {
+    this.currentCwd = localCwd
+    this.provider = dependencies.provider ?? defaultSandboxProvider
+    this.bootstrap = dependencies.bootstrap ?? bootstrapSandbox
+    this.now = dependencies.now ?? (() => new Date())
+    this.randomId = dependencies.randomId ?? randomUUID
+    this.sleep =
+      dependencies.sleep ??
+      ((milliseconds) =>
+        new Promise((resolve) => setTimeout(resolve, milliseconds)))
+  }
+
+  isEnabled(): boolean {
+    return this.enabled
+  }
+
+  getActive(): ActiveSandbox | undefined {
+    return this.active
+  }
+
+  getBinding(): SandboxBinding | undefined {
+    return this.binding
+  }
+
+  hasFlagIntent(): boolean {
+    return (
+      this.pi.getFlag("superserve") === true ||
+      this.getStringFlag("superserve-sandbox") !== undefined
+    )
+  }
+
+  async start(
+    reason: SessionStartReason,
+    ctx: ExtensionContext,
+  ): Promise<void> {
+    this.currentCwd = ctx.cwd
+    this.active = undefined
+    this.transition = undefined
+    this.initializationError = undefined
+    this.currentSessionPersistent =
+      ctx.sessionManager.getSessionFile() !== undefined
+
+    const ownerSessionId = ctx.sessionManager.getSessionId()
+    const persisted = findPersistedBindings(ctx, ownerSessionId)
+    const restored = persisted.restored
+    const inherited = persisted.inherited
+    const flagIntent = this.hasFlagIntent()
+    this.invocationOptIn = this.carryIntent || flagIntent
+    this.enabled =
+      this.invocationOptIn ||
+      restored !== undefined ||
+      inherited !== undefined ||
+      persisted.error !== undefined
+    this.carryIntent = false
+    this.binding = restored
+
+    if (!this.enabled) {
+      clearStatus(ctx)
+      return
+    }
+
+    this.pi.setActiveTools([...ROUTED_TOOL_NAMES])
+    setStatus(ctx, "Superserve: connecting")
+
+    try {
+      if (!this.invocationOptIn) {
+        throw new Error(
+          "This session contains a Superserve sandbox binding, but this Pi invocation did not opt in. Restart Pi with --superserve to reconnect; sandbox tools remain fail-closed.",
+        )
+      }
+      if (persisted.error) throw persisted.error
+      const explicitSandboxFlag = this.getStringFlag("superserve-sandbox")
+      let explicitSandboxId: string | undefined
+      if (explicitSandboxFlag !== undefined) {
+        // An explicit target must never fall back to an older restored binding,
+        // including when the new value itself is malformed.
+        this.binding = undefined
+        explicitSandboxId = requireSandboxId(
+          explicitSandboxFlag,
+          "--superserve-sandbox",
+        )
+      }
+
+      if (reason === "fork" || (restored === undefined && inherited)) {
+        await this.provisionNew(this.readRuntimeOptions(), ctx)
+      } else if (explicitSandboxId !== undefined) {
+        if (
+          restored?.sandboxId !== undefined &&
+          sameSandboxIdentity(restored.sandboxId, explicitSandboxId) &&
+          restored.state !== "destroyed"
+        ) {
+          this.binding = restored
+          await this.connectBinding(restored, ctx, false)
+        } else {
+          await this.attach(explicitSandboxId, ctx)
+        }
+      } else if (restored?.state === "provisioning") {
+        await this.reconcileProvisioning(restored, ctx)
+      } else if (restored?.state === "attaching") {
+        await this.connectBinding(restored, ctx, false)
+      } else if (restored?.state === "active" || restored?.state === "paused") {
+        await this.connectBinding(restored, ctx, true)
+      } else if (restored?.state === "destroyed") {
+        throw new Error(
+          "This session's Superserve sandbox was destroyed. Run /superserve new to create another one.",
+        )
+      } else {
+        await this.provisionNew(this.readRuntimeOptions(), ctx)
+      }
+    } catch (error) {
+      this.initializationError = toError(error)
+      setStatus(ctx, "Superserve: unavailable", "warning")
+      notify(ctx, formatError(this.initializationError), "error")
+    }
+  }
+
+  async shutdown(
+    reason: SessionShutdownReason,
+    ctx: ExtensionContext,
+  ): Promise<void> {
+    this.carryIntent = this.invocationOptIn && reason !== "quit"
+    const active = this.active
+    const binding = this.binding
+    this.active = undefined
+    this.transition = undefined
+    this.initializationError = undefined
+    clearStatus(ctx)
+
+    if (!this.enabled || !active || !binding) return
+    if (reason === "reload") return
+
+    try {
+      if (this.currentSessionPersistent || !binding.managed) {
+        await active.sandbox.pause()
+        this.binding = this.appendBinding({ ...binding, state: "paused" })
+      } else {
+        await active.sandbox.kill()
+        this.binding = this.appendBinding({ ...binding, state: "destroyed" })
+      }
+    } catch (error) {
+      notify(
+        ctx,
+        `Could not release Superserve sandbox ${active.sandbox.id}: ${formatError(error)}`,
+        "warning",
+      )
+    }
+  }
+
+  async requireSandbox(ctx?: ExtensionContext): Promise<ActiveSandbox> {
+    if (ctx) this.currentCwd = ctx.cwd
+    if (!this.enabled) {
+      throw new Error("Superserve sandbox mode is not enabled")
+    }
+    if (!this.invocationOptIn) {
+      throw this.unavailableError()
+    }
+    if (this.active) return this.active
+    if (this.transition) return this.transition
+
+    const binding = this.binding
+    if (!binding) {
+      throw this.unavailableError()
+    }
+    if (binding.state === "destroyed") {
+      throw new Error(
+        "Superserve sandbox was destroyed. The command was not run on the host. Run /superserve new.",
+      )
+    }
+    if (binding.state === "missing") {
+      throw new Error(
+        "Superserve sandbox is missing. The command was not run on the host. Run /superserve new.",
+      )
+    }
+
+    this.transition = (
+      binding.state === "provisioning"
+        ? this.reconcileProvisioning(binding, ctx)
+        : this.connectBinding(binding, ctx, false)
+    ).finally(() => {
+      this.transition = undefined
+    })
+    return this.transition
+  }
+
+  async createNew(ctx: ExtensionContext): Promise<ActiveSandbox> {
+    this.currentCwd = ctx.cwd
+    this.enableSecureMode()
+    const options = this.readRuntimeOptions()
+    if (this.active && this.binding) {
+      await this.active.sandbox.pause()
+      this.binding = this.appendBinding({
+        ...this.binding,
+        state: "paused",
+      })
+      this.active = undefined
+    }
+    this.initializationError = undefined
+    return this.provisionNew(options, ctx)
+  }
+
+  async connect(
+    sandboxId: string,
+    ctx: ExtensionContext,
+  ): Promise<ActiveSandbox> {
+    this.currentCwd = ctx.cwd
+    const trimmed = sandboxId.trim()
+    if (!trimmed) throw new Error("Usage: /superserve connect <sandbox-id>")
+    this.enableSecureMode()
+    const validatedSandboxId = requireSandboxId(trimmed, "/superserve connect")
+    if (this.active && this.binding) {
+      await this.active.sandbox.pause()
+      this.binding = this.appendBinding({
+        ...this.binding,
+        state: "paused",
+      })
+      this.active = undefined
+    }
+    this.initializationError = undefined
+    return this.attach(validatedSandboxId, ctx)
+  }
+
+  async pause(ctx: ExtensionContext): Promise<void> {
+    const active = await this.requireSandbox(ctx)
+    await active.sandbox.pause()
+    this.binding = this.appendBinding({
+      ...active.binding,
+      state: "paused",
+    })
+    this.active = undefined
+    setStatus(ctx, `Superserve: paused ${shortId(active.sandbox.id)}`)
+  }
+
+  async kill(ctx: ExtensionContext): Promise<void> {
+    if (!this.enabled || !this.invocationOptIn) {
+      throw new Error(
+        "Superserve sandbox mode is not enabled for this invocation",
+      )
+    }
+    const binding = this.binding
+    if (!binding?.sandboxId) {
+      throw new Error("No Superserve sandbox is bound to this session")
+    }
+    const sandboxId = requireSandboxId(
+      binding.sandboxId,
+      "persisted Superserve binding",
+    )
+    if (this.active) await this.active.sandbox.kill()
+    else await this.provider.killById(sandboxId)
+    this.active = undefined
+    this.binding = this.appendBinding({ ...binding, state: "destroyed" })
+    setStatus(ctx, "Superserve: destroyed", "warning")
+  }
+
+  async list(): Promise<
+    Array<{ id: string; name: string; status: string; createdAt: Date }>
+  > {
+    const sandboxes = await this.provider.list({
+      metadata: { "created-by": CREATED_BY },
+    })
+    return sandboxes.map((sandbox) => ({
+      id: requireSandboxId(sandbox.id, "Superserve list response"),
+      name: sandbox.name,
+      status: sandbox.status,
+      createdAt: sandbox.createdAt,
+    }))
+  }
+
+  async downloadWorkspace(
+    output: string | undefined,
+    ctx: ExtensionContext,
+  ): Promise<{ path: string; bytes: number }> {
+    this.currentCwd = ctx.cwd
+    const active = await this.requireSandbox(ctx)
+    const outputPath = resolveDownloadPath(
+      this.currentCwd,
+      output?.trim() ||
+        `superserve-${shortId(active.sandbox.id)}-workspace.zip`,
+    )
+    const downloadTarget = await createDownloadParent(
+      this.currentCwd,
+      outputPath,
+    )
+    const archive = await active.sandbox.files.downloadDir(GUEST_WORKSPACE, {
+      timeoutMs: 300_000,
+      signal: ctx.signal,
+      maxBytes: MAX_WORKSPACE_DOWNLOAD_BYTES,
+    })
+    await revalidateDownloadParent(downloadTarget)
+    const file = await open(downloadTarget.filePath, "wx", 0o600)
+    try {
+      await file.writeFile(archive)
+    } finally {
+      await file.close()
+    }
+    return { path: outputPath, bytes: archive.byteLength }
+  }
+
+  statusLines(): string[] {
+    if (!this.enabled) return ["Superserve mode: disabled"]
+    const binding = this.binding
+    return [
+      "Superserve mode: enabled (fail-closed)",
+      `Sandbox: ${binding?.sandboxId ?? "unavailable"}`,
+      `State: ${binding?.state ?? "initialization failed"}`,
+      `Workspace: ${GUEST_WORKSPACE}`,
+      `Template: ${binding?.template ?? "external sandbox"}`,
+      "Network egress: provider default (currently unrestricted)",
+    ]
+  }
+
+  private enableSecureMode(): void {
+    this.enabled = true
+    this.invocationOptIn = true
+    this.pi.setActiveTools([...ROUTED_TOOL_NAMES])
+  }
+
+  private async provisionNew(
+    options: SandboxRuntimeOptions,
+    ctx?: ExtensionContext,
+  ): Promise<ActiveSandbox> {
+    const timestamp = this.now().toISOString()
+    const binding: SandboxBinding = {
+      version: SESSION_ENTRY_VERSION,
+      ownerSessionId:
+        ctx?.sessionManager.getSessionId() ??
+        this.binding?.ownerSessionId ??
+        this.randomId(),
+      clientId: this.randomId(),
+      bindingId: this.randomId(),
+      state: "provisioning",
+      managed: true,
+      workspacePath: GUEST_WORKSPACE,
+      template: options.template,
+      timeoutSeconds: options.timeoutSeconds,
+      autoDeleteSeconds: options.autoDeleteSeconds,
+      sync: options.sync,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    }
+    this.binding = this.appendBinding(binding)
+    return this.provision(binding, options, ctx)
+  }
+
+  private async provision(
+    binding: SandboxBinding,
+    options: SandboxRuntimeOptions,
+    ctx?: ExtensionContext,
+  ): Promise<ActiveSandbox> {
+    let sandbox: SandboxHandle | undefined
+    let sandboxId: string | undefined
+    const localCwd = ctx?.cwd ?? this.currentCwd
+    this.currentCwd = localCwd
+    try {
+      setStatus(ctx, `Superserve: creating ${options.template}`)
+      sandbox = await this.provider.create({
+        name: sandboxName(localCwd, binding.bindingId),
+        fromTemplate: options.template,
+        timeoutSeconds: options.timeoutSeconds,
+        autoDeleteSeconds: options.autoDeleteSeconds,
+        metadata: metadataFor(binding),
+        signal: ctx?.signal,
+      })
+      sandboxId = requireSandboxId(sandbox.id, "Superserve create response")
+      const initialized = await this.bootstrap(sandbox, {
+        localCwd,
+        sync: options.sync,
+        uploadWorkspace: true,
+        signal: ctx?.signal,
+      })
+      const activeBinding = this.appendBinding({
+        ...binding,
+        state: "active",
+        sandboxId,
+        guestHome: initialized.guestHome,
+      })
+      const active = {
+        sandbox,
+        binding: activeBinding,
+        guestHome: initialized.guestHome,
+      }
+      this.binding = activeBinding
+      this.active = active
+      this.initializationError = undefined
+      setStatus(ctx, `Superserve: ${shortId(sandbox.id)} (${GUEST_WORKSPACE})`)
+      if (initialized.syncedFiles > 0) {
+        notify(
+          ctx,
+          `Superserve sandbox ready. Uploaded ${initialized.syncedFiles} tracked files (${formatBytes(initialized.syncedBytes)}).`,
+          "info",
+        )
+      }
+      return active
+    } catch (error) {
+      if (sandbox) {
+        try {
+          await sandbox.kill()
+        } catch {
+          // The original setup failure is more useful than cleanup failure.
+        }
+        this.binding = this.appendBindingBestEffort({
+          ...binding,
+          state: "missing",
+          sandboxId,
+        })
+      }
+      throw error
+    }
+  }
+
+  private async attach(
+    sandboxId: string,
+    ctx?: ExtensionContext,
+  ): Promise<ActiveSandbox> {
+    const validatedSandboxId = requireSandboxId(
+      sandboxId,
+      "Superserve sandbox ID",
+    )
+    if (ctx) this.currentCwd = ctx.cwd
+    const timestamp = this.now().toISOString()
+    const binding = this.appendBinding({
+      version: SESSION_ENTRY_VERSION,
+      ownerSessionId:
+        ctx?.sessionManager.getSessionId() ??
+        this.binding?.ownerSessionId ??
+        this.randomId(),
+      clientId: this.randomId(),
+      bindingId: this.randomId(),
+      state: "attaching",
+      managed: false,
+      sandboxId: validatedSandboxId,
+      workspacePath: GUEST_WORKSPACE,
+      sync: "none",
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    })
+    this.binding = binding
+    return this.connectBinding(binding, ctx, false)
+  }
+
+  private async connectBinding(
+    binding: SandboxBinding,
+    ctx: ExtensionContext | undefined,
+    replaceMissing: boolean,
+  ): Promise<ActiveSandbox> {
+    if (!binding.sandboxId) {
+      throw new Error("Persisted Superserve binding has no sandbox ID")
+    }
+    const sandboxId = requireSandboxId(
+      binding.sandboxId,
+      "persisted Superserve binding",
+    )
+    const localCwd = ctx?.cwd ?? this.currentCwd
+    this.currentCwd = localCwd
+    setStatus(ctx, `Superserve: connecting ${shortId(sandboxId)}`)
+
+    let sandbox: SandboxHandle
+    try {
+      sandbox = await this.connectWithRetry(sandboxId, ctx?.signal)
+    } catch (error) {
+      if (!(error instanceof NotFoundError)) throw error
+      if (binding.state === "attaching") throw error
+      this.binding = this.appendBinding({ ...binding, state: "missing" })
+      if (replaceMissing) {
+        return this.provisionNew(optionsFromBinding(binding), ctx)
+      }
+      throw errorWithCause(
+        "Superserve sandbox no longer exists. The operation was not run on the host. Run /superserve new.",
+        error,
+      )
+    }
+
+    const initialized = await this.bootstrap(sandbox, {
+      localCwd,
+      sync: "none",
+      uploadWorkspace: false,
+      signal: ctx?.signal,
+    })
+    const activeBinding = this.appendBinding({
+      ...binding,
+      state: "active",
+      sandboxId: sandbox.id,
+      guestHome: initialized.guestHome,
+    })
+    const active = {
+      sandbox,
+      binding: activeBinding,
+      guestHome: initialized.guestHome,
+    }
+    this.binding = activeBinding
+    this.active = active
+    this.initializationError = undefined
+    setStatus(ctx, `Superserve: ${shortId(sandbox.id)} (${GUEST_WORKSPACE})`)
+    return active
+  }
+
+  private async reconcileProvisioning(
+    binding: SandboxBinding,
+    ctx?: ExtensionContext,
+  ): Promise<ActiveSandbox> {
+    if (ctx) this.currentCwd = ctx.cwd
+    const metadata = metadataFor(binding)
+    const listed = await this.provider.list({
+      metadata,
+      signal: ctx?.signal,
+    })
+    const candidates = listed.filter((candidate) =>
+      Object.entries(metadata).every(
+        ([key, value]) => candidate.metadata[key] === value,
+      ),
+    )
+    for (const candidate of candidates) {
+      requireSandboxId(candidate.id, "Superserve list response")
+    }
+    if (candidates.length === 0) {
+      return this.provision(binding, optionsFromBinding(binding), ctx)
+    }
+
+    const selected = candidates.reduce((earliest, candidate) =>
+      candidate.createdAt.getTime() < earliest.createdAt.getTime() ||
+      (candidate.createdAt.getTime() === earliest.createdAt.getTime() &&
+        candidate.id.localeCompare(earliest.id) < 0)
+        ? candidate
+        : earliest,
+    )
+    for (const duplicate of candidates.filter(
+      (candidate) => candidate.id !== selected.id,
+    )) {
+      await this.provider.killById(duplicate.id, { signal: ctx?.signal })
+    }
+
+    const recovered = this.appendBinding({
+      ...binding,
+      sandboxId: selected.id,
+      state: "active",
+    })
+    return this.connectBinding(recovered, ctx, true)
+  }
+
+  private async connectWithRetry(
+    sandboxId: string,
+    signal?: AbortSignal,
+  ): Promise<SandboxHandle> {
+    const validatedSandboxId = requireSandboxId(
+      sandboxId,
+      "Superserve sandbox ID",
+    )
+    const delays = [50, 150, 450]
+    for (let attempt = 0; ; attempt += 1) {
+      try {
+        const sandbox = await this.provider.connect(validatedSandboxId, {
+          signal,
+        })
+        const returnedSandboxId = requireSandboxId(
+          sandbox.id,
+          "Superserve connect response",
+        )
+        if (!sameSandboxIdentity(returnedSandboxId, validatedSandboxId)) {
+          throw new Error(
+            `Superserve connect response returned sandbox ${returnedSandboxId}, expected ${validatedSandboxId}`,
+          )
+        }
+        return sandbox
+      } catch (error) {
+        if (!(error instanceof ConflictError) || attempt >= delays.length) {
+          throw error
+        }
+        await this.sleep(delays[attempt] ?? 450)
+      }
+    }
+  }
+
+  private appendBinding(binding: SandboxBinding): SandboxBinding {
+    const next = { ...binding, updatedAt: this.now().toISOString() }
+    this.pi.appendEntry(SESSION_ENTRY_TYPE, next)
+    return next
+  }
+
+  private appendBindingBestEffort(binding: SandboxBinding): SandboxBinding {
+    try {
+      return this.appendBinding(binding)
+    } catch {
+      return binding
+    }
+  }
+
+  private readRuntimeOptions(): SandboxRuntimeOptions {
+    const template =
+      this.getStringFlag("superserve-template") ?? DEFAULT_TEMPLATE
+    const timeoutSeconds = parseIntegerFlag(
+      this.pi.getFlag("superserve-timeout"),
+      "--superserve-timeout",
+      DEFAULT_TIMEOUT_SECONDS,
+      1,
+    )
+    const autoDeleteFlag = this.pi.getFlag("superserve-auto-delete")
+    const autoDeleteSeconds =
+      typeof autoDeleteFlag === "string" && autoDeleteFlag.trim() === "none"
+        ? undefined
+        : parseIntegerFlag(
+            autoDeleteFlag,
+            "--superserve-auto-delete",
+            DEFAULT_AUTO_DELETE_SECONDS,
+            0,
+          )
+    const syncFlag = this.getStringFlag("superserve-sync") ?? "tracked"
+    if (syncFlag !== "tracked" && syncFlag !== "none") {
+      throw new Error("--superserve-sync must be tracked or none")
+    }
+    return { template, timeoutSeconds, autoDeleteSeconds, sync: syncFlag }
+  }
+
+  private getStringFlag(name: string): string | undefined {
+    const value = this.pi.getFlag(name)
+    if (typeof value !== "string") return undefined
+    const trimmed = value.trim()
+    return trimmed || undefined
+  }
+
+  private unavailableError(): Error {
+    const detail = this.initializationError
+      ? ` ${formatError(this.initializationError)}`
+      : ""
+    return new Error(
+      `Superserve sandbox is unavailable; the operation was not run on the host.${detail}`,
+    )
+  }
+}
+
+interface PersistedBindings {
+  restored?: SandboxBinding
+  inherited?: SandboxBinding
+  error?: Error
+}
+
+function findPersistedBindings(
+  ctx: ExtensionContext,
+  ownerSessionId: string,
+): PersistedBindings {
+  const branch = ctx.sessionManager.getBranch()
+  for (let index = branch.length - 1; index >= 0; index -= 1) {
+    const entry = branch[index]
+    if (entry?.type !== "custom" || entry.customType !== SESSION_ENTRY_TYPE) {
+      continue
+    }
+    const binding = parseBinding(entry.data)
+    if (!binding) {
+      return {
+        error: new Error(
+          "Persisted Superserve binding is invalid; sandbox tools remain fail-closed. Run /superserve new to replace it.",
+        ),
+      }
+    }
+    return binding.ownerSessionId === ownerSessionId
+      ? { restored: binding }
+      : { inherited: binding }
+  }
+  return {}
+}
+
+export function parseBinding(value: unknown): SandboxBinding | undefined {
+  if (typeof value !== "object" || value === null) return undefined
+  const binding = value as Record<string, unknown>
+  if (
+    binding.version !== SESSION_ENTRY_VERSION ||
+    typeof binding.ownerSessionId !== "string" ||
+    typeof binding.clientId !== "string" ||
+    typeof binding.bindingId !== "string" ||
+    !isBindingState(binding.state) ||
+    typeof binding.managed !== "boolean" ||
+    binding.workspacePath !== GUEST_WORKSPACE ||
+    (binding.sandboxId !== undefined &&
+      (typeof binding.sandboxId !== "string" ||
+        !isSandboxId(binding.sandboxId))) ||
+    (binding.guestHome !== undefined &&
+      typeof binding.guestHome !== "string") ||
+    (binding.template !== undefined && typeof binding.template !== "string") ||
+    (binding.timeoutSeconds !== undefined &&
+      typeof binding.timeoutSeconds !== "number") ||
+    (binding.autoDeleteSeconds !== undefined &&
+      typeof binding.autoDeleteSeconds !== "number") ||
+    (binding.sync !== "tracked" && binding.sync !== "none") ||
+    typeof binding.createdAt !== "string" ||
+    typeof binding.updatedAt !== "string"
+  ) {
+    return undefined
+  }
+  return binding as unknown as SandboxBinding
+}
+
+function isBindingState(value: unknown): value is SandboxBinding["state"] {
+  return (
+    value === "provisioning" ||
+    value === "attaching" ||
+    value === "active" ||
+    value === "paused" ||
+    value === "missing" ||
+    value === "destroyed"
+  )
+}
+
+const SANDBOX_ID_RE =
+  /^(?:sb-[a-z0-9]{1,17}-)?[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$/
+
+function isSandboxId(value: string): boolean {
+  return SANDBOX_ID_RE.test(value)
+}
+
+function requireSandboxId(value: unknown, source: string): string {
+  if (typeof value !== "string" || !isSandboxId(value)) {
+    throw new Error(
+      `${source} must be a valid Superserve sandbox ID (UUID or sb-<region>-<UUID>)`,
+    )
+  }
+  return value
+}
+
+function sameSandboxIdentity(left: string, right: string): boolean {
+  return sandboxUuid(left) === sandboxUuid(right)
+}
+
+function sandboxUuid(sandboxId: string): string {
+  return sandboxId.slice(-36).toLowerCase()
+}
+
+function metadataFor(binding: SandboxBinding): Record<string, string> {
+  return {
+    "created-by": CREATED_BY,
+    "pi-client-id": binding.clientId,
+    "pi-session-id": binding.ownerSessionId,
+    "pi-binding-id": binding.bindingId,
+    "entry-version": String(SESSION_ENTRY_VERSION),
+  }
+}
+
+function optionsFromBinding(binding: SandboxBinding): SandboxRuntimeOptions {
+  return {
+    template: binding.template ?? DEFAULT_TEMPLATE,
+    timeoutSeconds: binding.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS,
+    autoDeleteSeconds: binding.autoDeleteSeconds,
+    sync: binding.sync,
+  }
+}
+
+function sandboxName(localCwd: string, bindingId: string): string {
+  const project = path
+    .basename(localCwd)
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 28)
+  return `pi-${project || "workspace"}-${bindingId.slice(0, 8)}`
+}
+
+function resolveDownloadPath(localCwd: string, output: string): string {
+  const root = path.resolve(localCwd)
+  const resolved = path.resolve(root, output)
+  const relative = path.relative(root, resolved)
+  if (
+    relative === "" ||
+    relative === ".." ||
+    relative.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relative)
+  ) {
+    throw new Error("Workspace download path must stay inside the current cwd")
+  }
+  return resolved
+}
+
+interface DownloadTarget {
+  rootPath: string
+  parentPath: string
+  filePath: string
+}
+
+async function createDownloadParent(
+  localCwd: string,
+  outputPath: string,
+): Promise<DownloadTarget> {
+  const lexicalRoot = path.resolve(localCwd)
+  const relativeParent = path.relative(lexicalRoot, path.dirname(outputPath))
+  if (isOutsidePath(relativeParent)) {
+    throw new Error("Workspace download path must stay inside the current cwd")
+  }
+
+  const rootPath = await realpath(lexicalRoot)
+  let parentPath = rootPath
+  for (const segment of relativeParent.split(path.sep)) {
+    if (!segment || segment === ".") continue
+    if (segment === "..") {
+      throw new Error(
+        "Workspace download path must stay inside the current cwd",
+      )
+    }
+    const nextPath = path.join(parentPath, segment)
+    await ensureDownloadDirectory(nextPath)
+    const resolved = await realpath(nextPath)
+    if (!isPathWithin(rootPath, resolved)) {
+      throw new Error(
+        "Workspace download path must stay inside the current cwd",
+      )
+    }
+    parentPath = resolved
+  }
+
+  return {
+    rootPath,
+    parentPath,
+    filePath: path.join(parentPath, path.basename(outputPath)),
+  }
+}
+
+async function ensureDownloadDirectory(directoryPath: string): Promise<void> {
+  try {
+    const info = await lstat(directoryPath)
+    if (info.isSymbolicLink() || !info.isDirectory()) {
+      throw new Error(
+        "Workspace download parent must not contain symlinks or non-directories",
+      )
+    }
+    return
+  } catch (error) {
+    if (!hasFileSystemCode(error, "ENOENT")) throw error
+  }
+
+  try {
+    await mkdir(directoryPath, { mode: 0o700 })
+  } catch (error) {
+    if (!hasFileSystemCode(error, "EEXIST")) throw error
+  }
+
+  const info = await lstat(directoryPath)
+  if (info.isSymbolicLink() || !info.isDirectory()) {
+    throw new Error(
+      "Workspace download parent must not contain symlinks or non-directories",
+    )
+  }
+}
+
+async function revalidateDownloadParent(target: DownloadTarget): Promise<void> {
+  const info = await lstat(target.parentPath)
+  const resolved = await realpath(target.parentPath)
+  if (
+    info.isSymbolicLink() ||
+    !info.isDirectory() ||
+    resolved !== target.parentPath ||
+    !isPathWithin(target.rootPath, resolved) ||
+    path.dirname(target.filePath) !== target.parentPath
+  ) {
+    throw new Error(
+      "Workspace download parent changed or escaped the current cwd",
+    )
+  }
+}
+
+function hasFileSystemCode(error: unknown, code: string): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === code
+  )
+}
+
+function isOutsidePath(relativePath: string): boolean {
+  return (
+    relativePath === ".." ||
+    relativePath.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativePath)
+  )
+}
+
+function isPathWithin(rootPath: string, targetPath: string): boolean {
+  const relative = path.relative(rootPath, targetPath)
+  return !isOutsidePath(relative)
+}
+
+function parseIntegerFlag(
+  value: boolean | string | undefined,
+  name: string,
+  fallback: number,
+  minimum: number,
+): number {
+  if (value === undefined) return fallback
+  if (typeof value !== "string" || !/^\d+$/.test(value.trim())) {
+    throw new Error(
+      `${name} must be an integer greater than or equal to ${minimum}`,
+    )
+  }
+  const number = Number(value)
+  if (!Number.isSafeInteger(number) || number < minimum) {
+    throw new Error(
+      `${name} must be an integer greater than or equal to ${minimum}`,
+    )
+  }
+  return number
+}
+
+export function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
+}
+
+function errorWithCause(message: string, cause: unknown): Error {
+  const error = new Error(message)
+  ;(error as Error & { cause?: unknown }).cause = cause
+  return error
+}
+
+function setStatus(
+  ctx: ExtensionContext | undefined,
+  message: string,
+  color: "accent" | "warning" = "accent",
+): void {
+  if (!ctx?.hasUI) return
+  try {
+    ctx.ui.setStatus("superserve", ctx.ui.theme.fg(color, message))
+  } catch {
+    // Status is optional in non-TUI frontends.
+  }
+}
+
+function clearStatus(ctx: ExtensionContext | undefined): void {
+  if (!ctx?.hasUI) return
+  try {
+    ctx.ui.setStatus("superserve", undefined)
+  } catch {
+    // Status is optional in non-TUI frontends.
+  }
+}
+
+function notify(
+  ctx: ExtensionContext | undefined,
+  message: string,
+  level: "info" | "warning" | "error",
+): void {
+  if (!ctx?.hasUI) return
+  try {
+    ctx.ui.notify(message, level)
+  } catch {
+    // Notifications are optional in non-TUI frontends.
+  }
+}
+
+function shortId(id: string): string {
+  return id.slice(0, 8)
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${Math.ceil(bytes / 1024)} KiB`
+  return `${Math.ceil(bytes / (1024 * 1024))} MiB`
+}

--- a/packages/pi/src/provider.ts
+++ b/packages/pi/src/provider.ts
@@ -1,0 +1,10 @@
+import { Sandbox } from "@superserve/sdk"
+
+import type { SandboxProvider } from "./types.js"
+
+export const defaultSandboxProvider: SandboxProvider = {
+  create: (options) => Sandbox.create(options),
+  connect: (sandboxId, options) => Sandbox.connect(sandboxId, options),
+  list: (options) => Sandbox.list(options),
+  killById: (sandboxId, options) => Sandbox.killById(sandboxId, options),
+}

--- a/packages/pi/src/tools.ts
+++ b/packages/pi/src/tools.ts
@@ -1,0 +1,739 @@
+import { Buffer } from "node:buffer"
+import path from "node:path"
+
+import {
+  createBashToolDefinition,
+  createEditToolDefinition,
+  createFindToolDefinition,
+  createGrepToolDefinition,
+  createLsToolDefinition,
+  createReadToolDefinition,
+  createWriteToolDefinition,
+  DEFAULT_MAX_BYTES,
+  DEFAULT_MAX_LINES,
+  formatSize,
+  truncateHead,
+  truncateTail,
+  type AgentToolResult,
+  type BashOperations,
+  type EditOperations,
+  type ExtensionAPI,
+  type ExtensionContext,
+  type FindOperations,
+  type GrepToolDetails,
+  type GrepToolInput,
+  type LsOperations,
+  type ReadOperations,
+  type ReadToolDetails,
+  type ReadToolInput,
+  type WriteOperations,
+} from "@earendil-works/pi-coding-agent"
+import { TimeoutError } from "@superserve/sdk"
+
+import {
+  BridgeError,
+  callBridge,
+  type BridgeGrepResult,
+  type BridgeListResult,
+  type BridgeReadResult,
+} from "./bridge.js"
+import {
+  DEFAULT_COMMAND_TIMEOUT_SECONDS,
+  GUEST_WORKSPACE,
+  MAX_COMMAND_OUTPUT_BYTES,
+  MAX_COMMAND_TIMEOUT_SECONDS,
+  MAX_FILE_READ_BYTES,
+  MAX_FIND_RESULTS,
+  MAX_GREP_CONTEXT,
+  MAX_GREP_RESULTS,
+  MAX_LS_RESULTS,
+} from "./constants.js"
+import type { SandboxLifecycle } from "./lifecycle.js"
+import type { ActiveSandbox } from "./types.js"
+
+export function createSandboxToolRegistrar(
+  pi: ExtensionAPI,
+  lifecycle: SandboxLifecycle,
+): () => void {
+  let registered = false
+  return () => {
+    if (registered) return
+    registerRead(pi, lifecycle)
+    registerWrite(pi, lifecycle)
+    registerEdit(pi, lifecycle)
+    registerBash(pi, lifecycle)
+    registerLs(pi, lifecycle)
+    registerFind(pi, lifecycle)
+    registerGrep(pi, lifecycle)
+    registered = true
+  }
+}
+
+export function createSandboxBashOperations(
+  active: ActiveSandbox,
+  localCwd: string,
+): BashOperations {
+  return {
+    exec: async (command, cwd, { onData, signal, timeout }) => {
+      if (signal?.aborted) throw new Error("aborted")
+      const timeoutSeconds = clampInteger(
+        timeout,
+        DEFAULT_COMMAND_TIMEOUT_SECONDS,
+        1,
+        MAX_COMMAND_TIMEOUT_SECONDS,
+      )
+      try {
+        const result = await active.sandbox.commands.run(command, {
+          cwd: mapAbsolutePath(cwd, localCwd, active.guestHome),
+          timeoutMs: timeoutSeconds * 1000,
+          signal,
+          maxOutputBytes: MAX_COMMAND_OUTPUT_BYTES,
+        })
+        if (signal?.aborted) throw new Error("aborted")
+        const combined = result.stdout + result.stderr
+        const notice =
+          "\n\n[Superserve command output truncated to a bounded tail; full output was not written to the host.]"
+        const bounded = truncateTail(combined, {
+          maxBytes: DEFAULT_MAX_BYTES - Buffer.byteLength(notice),
+          maxLines: DEFAULT_MAX_LINES - 3,
+        })
+        const output = bounded.truncated
+          ? `${bounded.content}${notice}`
+          : combined
+        if (output) onData(Buffer.from(output))
+        return { exitCode: result.exitCode }
+      } catch (error) {
+        if (signal?.aborted) throw errorWithCause("aborted", error)
+        if (error instanceof TimeoutError) {
+          throw errorWithCause(`timeout:${timeoutSeconds}`, error)
+        }
+        throw error
+      }
+    },
+  }
+}
+
+function registerRead(pi: ExtensionAPI, lifecycle: SandboxLifecycle): void {
+  const local = createReadToolDefinition(GUEST_WORKSPACE)
+  pi.registerTool({
+    ...local,
+    async execute(id, params, signal, onUpdate, ctx) {
+      const active = await lifecycle.requireSandbox(ctx)
+      return executeRemoteRead(
+        active,
+        ctx.cwd,
+        rewritePathParameter(params, ctx.cwd, active.guestHome),
+        signal,
+        ctx,
+      )
+    },
+  })
+}
+
+function registerWrite(pi: ExtensionAPI, lifecycle: SandboxLifecycle): void {
+  const local = createWriteToolDefinition(GUEST_WORKSPACE)
+  pi.registerTool({
+    ...local,
+    async execute(id, params, signal, onUpdate, ctx) {
+      const active = await lifecycle.requireSandbox(ctx)
+      const remote = createWriteToolDefinition(GUEST_WORKSPACE, {
+        operations: createWriteOperations(active, ctx.cwd, signal),
+      })
+      return remote.execute(
+        id,
+        rewritePathParameter(params, ctx.cwd, active.guestHome),
+        signal,
+        onUpdate,
+        ctx,
+      )
+    },
+  })
+}
+
+function registerEdit(pi: ExtensionAPI, lifecycle: SandboxLifecycle): void {
+  const local = createEditToolDefinition(GUEST_WORKSPACE)
+  const { renderCall: _hostEditPreview, ...safeDefinition } = local
+  pi.registerTool({
+    ...safeDefinition,
+    async execute(id, params, signal, onUpdate, ctx) {
+      const active = await lifecycle.requireSandbox(ctx)
+      const remote = createEditToolDefinition(GUEST_WORKSPACE, {
+        operations: createEditOperations(active, ctx.cwd, signal),
+      })
+      return remote.execute(
+        id,
+        rewritePathParameter(params, ctx.cwd, active.guestHome),
+        signal,
+        onUpdate,
+        ctx,
+      )
+    },
+  })
+}
+
+function registerBash(pi: ExtensionAPI, lifecycle: SandboxLifecycle): void {
+  const local = createBashToolDefinition(GUEST_WORKSPACE)
+  pi.registerTool({
+    ...local,
+    description: `Execute a bash command in the Superserve sandbox working directory. The SDK response is capped at ${formatSize(MAX_COMMAND_OUTPUT_BYTES)}; responses over that cap fail safely. Successful output is limited to the last ${DEFAULT_MAX_LINES} lines or ${formatSize(DEFAULT_MAX_BYTES)}, and no full-output copy is written to the host. Optionally provide a timeout in seconds.`,
+    async execute(id, params, signal, onUpdate, ctx) {
+      const active = await lifecycle.requireSandbox(ctx)
+      const remote = createBashToolDefinition(GUEST_WORKSPACE, {
+        operations: createSandboxBashOperations(active, ctx.cwd),
+      })
+      return remote.execute(
+        id,
+        {
+          ...params,
+          timeout: clampInteger(
+            params.timeout,
+            DEFAULT_COMMAND_TIMEOUT_SECONDS,
+            1,
+            MAX_COMMAND_TIMEOUT_SECONDS,
+          ),
+        },
+        signal,
+        onUpdate,
+        ctx,
+      )
+    },
+  })
+}
+
+function registerLs(pi: ExtensionAPI, lifecycle: SandboxLifecycle): void {
+  const local = createLsToolDefinition(GUEST_WORKSPACE)
+  pi.registerTool({
+    ...local,
+    async execute(id, params, signal, onUpdate, ctx) {
+      const active = await lifecycle.requireSandbox(ctx)
+      const limit = clampInteger(params.limit, 500, 1, MAX_LS_RESULTS)
+      const remote = createLsToolDefinition(GUEST_WORKSPACE, {
+        operations: createLsOperations(active, ctx.cwd, signal, limit + 1),
+      })
+      return remote.execute(
+        id,
+        {
+          ...rewritePathParameter(params, ctx.cwd, active.guestHome),
+          limit,
+        },
+        signal,
+        onUpdate,
+        ctx,
+      )
+    },
+  })
+}
+
+function registerFind(pi: ExtensionAPI, lifecycle: SandboxLifecycle): void {
+  const local = createFindToolDefinition(GUEST_WORKSPACE)
+  pi.registerTool({
+    ...local,
+    description: `${local.description} In Superserve sandbox mode, .git and node_modules directories are excluded, but .gitignore rules are not evaluated.`,
+    promptSnippet:
+      "Find files by glob pattern (Superserve excludes .git/node_modules; it does not evaluate .gitignore)",
+    async execute(id, params, signal, onUpdate, ctx) {
+      const active = await lifecycle.requireSandbox(ctx)
+      const remote = createFindToolDefinition(GUEST_WORKSPACE, {
+        operations: createFindOperations(active, ctx.cwd, signal),
+      })
+      return remote.execute(
+        id,
+        {
+          ...rewritePathParameter(params, ctx.cwd, active.guestHome),
+          limit: clampInteger(params.limit, 1_000, 1, MAX_FIND_RESULTS),
+        },
+        signal,
+        onUpdate,
+        ctx,
+      )
+    },
+  })
+}
+
+function registerGrep(pi: ExtensionAPI, lifecycle: SandboxLifecycle): void {
+  const local = createGrepToolDefinition(GUEST_WORKSPACE)
+  pi.registerTool({
+    ...local,
+    description: `${local.description} In Superserve sandbox mode, .git and node_modules directories are excluded, but .gitignore rules are not evaluated.`,
+    promptSnippet:
+      "Search file contents (Superserve excludes .git/node_modules; it does not evaluate .gitignore)",
+    async execute(id, params, signal, onUpdate, ctx) {
+      const active = await lifecycle.requireSandbox(ctx)
+      return executeRemoteGrep(
+        active,
+        ctx.cwd,
+        rewritePathParameter(params, ctx.cwd, active.guestHome),
+        signal,
+      )
+    },
+  })
+}
+
+function createReadOperations(
+  active: ActiveSandbox,
+  localCwd: string,
+  signal?: AbortSignal,
+): ReadOperations {
+  return {
+    readFile: async (filePath) =>
+      Buffer.from(
+        await active.sandbox.files.read(
+          mapAbsolutePath(filePath, localCwd, active.guestHome),
+          { maxBytes: MAX_FILE_READ_BYTES, signal },
+        ),
+      ),
+    access: async (filePath) => {
+      await callBridge(
+        active.sandbox,
+        "access",
+        { path: mapAbsolutePath(filePath, localCwd, active.guestHome) },
+        signal,
+      )
+    },
+    detectImageMimeType: async (filePath) =>
+      imageMimeType(mapAbsolutePath(filePath, localCwd, active.guestHome)),
+  }
+}
+
+async function executeRemoteRead(
+  active: ActiveSandbox,
+  localCwd: string,
+  params: ReadToolInput,
+  signal: AbortSignal | undefined,
+  ctx: ExtensionContext,
+): Promise<AgentToolResult<ReadToolDetails | undefined>> {
+  const offset = optionalPositiveInteger(params.offset, "offset") ?? 1
+  const limit = optionalPositiveInteger(params.limit, "limit")
+  const filePath = resolveGuestPath(params.path, localCwd, active.guestHome)
+  const result = await callBridge<BridgeReadResult>(
+    active.sandbox,
+    "read",
+    { path: filePath, offset, limit },
+    signal,
+  )
+  validateBridgeReadResult(result)
+
+  if (result.kind === "image") {
+    if (result.size > MAX_FILE_READ_BYTES) {
+      throw new Error(
+        `Image is ${formatSize(result.size)}, exceeds ${formatSize(MAX_FILE_READ_BYTES)} remote read limit`,
+      )
+    }
+    const buffer = Buffer.from(
+      await active.sandbox.files.read(filePath, {
+        maxBytes: MAX_FILE_READ_BYTES,
+        signal,
+      }),
+    )
+    const mimeType = detectSupportedImageMimeType(buffer)
+    if (!mimeType || mimeType !== result.mimeType) {
+      throw new Error("Remote image changed while it was being read")
+    }
+    let note = `Read image file [${mimeType}]`
+    if (!ctx.model || !ctx.model.input.includes("image")) {
+      note +=
+        "\n[Current model does not support images. The image will be omitted from this request.]"
+    }
+    return {
+      content: [
+        { type: "text", text: note },
+        { type: "image", data: buffer.toString("base64"), mimeType },
+      ],
+      details: undefined,
+    }
+  }
+
+  if (offset > result.totalLines) {
+    throw new Error(
+      `Offset ${offset} is beyond end of file (${result.totalLines} lines total)`,
+    )
+  }
+
+  const truncation = truncateHead(result.content)
+  let outputText: string
+  let details: ReadToolDetails | undefined
+  if (result.firstLineBytes > DEFAULT_MAX_BYTES) {
+    outputText = `[Line ${offset} is ${formatSize(result.firstLineBytes)}, exceeds ${formatSize(DEFAULT_MAX_BYTES)} limit. Use bash: sed -n '${offset}p' ${params.path} | head -c ${DEFAULT_MAX_BYTES}]`
+    details = { truncation }
+  } else if (truncation.truncated || result.contentLimitReached) {
+    const endLine = offset + truncation.outputLines - 1
+    const nextOffset = endLine + 1
+    const reason =
+      truncation.truncatedBy === "lines"
+        ? ""
+        : ` (${formatSize(DEFAULT_MAX_BYTES)} limit)`
+    outputText = `${truncation.content}\n\n[Showing lines ${offset}-${endLine} of ${result.totalLines}${reason}. Use offset=${nextOffset} to continue.]`
+    details = { truncation }
+  } else if (limit !== undefined && offset - 1 + limit < result.totalLines) {
+    const remaining = result.totalLines - (offset - 1 + limit)
+    outputText = `${truncation.content}\n\n[${remaining} more lines in file. Use offset=${offset + limit} to continue.]`
+  } else {
+    outputText = truncation.content
+  }
+
+  return {
+    content: [{ type: "text", text: outputText }],
+    details,
+  }
+}
+
+function createWriteOperations(
+  active: ActiveSandbox,
+  localCwd: string,
+  signal?: AbortSignal,
+): WriteOperations {
+  return {
+    writeFile: async (filePath, content) => {
+      await active.sandbox.files.write(
+        mapAbsolutePath(filePath, localCwd, active.guestHome),
+        content,
+        { signal },
+      )
+    },
+    mkdir: async (directory) => {
+      mapAbsolutePath(directory, localCwd, active.guestHome)
+    },
+  }
+}
+
+function createEditOperations(
+  active: ActiveSandbox,
+  localCwd: string,
+  signal?: AbortSignal,
+): EditOperations {
+  const read = createReadOperations(active, localCwd, signal)
+  const write = createWriteOperations(active, localCwd, signal)
+  return {
+    readFile: read.readFile,
+    access: read.access,
+    writeFile: write.writeFile,
+  }
+}
+
+function createLsOperations(
+  active: ActiveSandbox,
+  localCwd: string,
+  signal?: AbortSignal,
+  entryLimit = 501,
+): LsOperations {
+  let cached: { root: string; result: BridgeListResult } | undefined
+
+  const load = async (filePath: string) => {
+    const guestPath = mapAbsolutePath(filePath, localCwd, active.guestHome)
+    if (!cached) {
+      cached = {
+        root: guestPath,
+        result: await callBridge<BridgeListResult>(
+          active.sandbox,
+          "list",
+          { path: guestPath, limit: entryLimit },
+          signal,
+        ),
+      }
+    }
+    return { guestPath, cached }
+  }
+
+  return {
+    exists: async (filePath) => (await load(filePath)).cached.result.exists,
+    stat: async (filePath) => {
+      const loaded = await load(filePath)
+      if (loaded.guestPath === loaded.cached.root) {
+        return {
+          isDirectory: () => loaded.cached.result.isDirectory,
+        }
+      }
+      if (path.posix.dirname(loaded.guestPath) === loaded.cached.root) {
+        const name = path.posix.basename(loaded.guestPath)
+        const entry = loaded.cached.result.entries.find(
+          (candidate) => candidate.name === name,
+        )
+        if (!entry) throw new BridgeError(`Path not found: ${loaded.guestPath}`)
+        return { isDirectory: () => entry.isDirectory }
+      }
+      const result = await callBridge<{ isDirectory: boolean }>(
+        active.sandbox,
+        "stat",
+        { path: loaded.guestPath },
+        signal,
+      )
+      return { isDirectory: () => result.isDirectory }
+    },
+    readdir: async (directory) => {
+      const loaded = await load(directory)
+      return loaded.cached.result.entries.map((entry) => entry.name)
+    },
+  }
+}
+
+function createFindOperations(
+  active: ActiveSandbox,
+  localCwd: string,
+  signal?: AbortSignal,
+): FindOperations {
+  return {
+    exists: (filePath) =>
+      callBridge<boolean>(
+        active.sandbox,
+        "exists",
+        { path: mapAbsolutePath(filePath, localCwd, active.guestHome) },
+        signal,
+      ),
+    glob: async (pattern, cwd, options) => {
+      const results = await callBridge<unknown>(
+        active.sandbox,
+        "glob",
+        {
+          path: mapAbsolutePath(cwd, localCwd, active.guestHome),
+          pattern,
+          limit: clampInteger(options.limit, 1_000, 1, MAX_FIND_RESULTS),
+        },
+        signal,
+      )
+      if (
+        !Array.isArray(results) ||
+        !results.every((item) => typeof item === "string")
+      ) {
+        throw new BridgeError("Superserve find bridge returned invalid paths")
+      }
+      return results
+    },
+  }
+}
+
+async function executeRemoteGrep(
+  active: ActiveSandbox,
+  localCwd: string,
+  params: GrepToolInput,
+  signal?: AbortSignal,
+) {
+  const limit = clampInteger(params.limit, 100, 1, MAX_GREP_RESULTS)
+  const context = clampInteger(params.context, 0, 0, MAX_GREP_CONTEXT)
+  const searchPath = resolveGuestPath(
+    params.path ?? ".",
+    localCwd,
+    active.guestHome,
+  )
+  const result = await callBridge<BridgeGrepResult>(
+    active.sandbox,
+    "grep",
+    {
+      path: searchPath,
+      pattern: params.pattern,
+      glob: params.glob,
+      ignoreCase: params.ignoreCase,
+      literal: params.literal,
+      context,
+      limit,
+      maxLineLength: 2_000,
+    },
+    signal,
+  )
+  if (!result.output) {
+    return {
+      content: [{ type: "text" as const, text: "No matches found" }],
+      details: undefined,
+    }
+  }
+
+  const truncation = truncateHead(result.output, {
+    maxLines: Number.MAX_SAFE_INTEGER,
+  })
+  const details: GrepToolDetails = {}
+  const notices: string[] = []
+  let output = truncation.content
+  if (result.matchLimitReached) {
+    details.matchLimitReached = limit
+    notices.push(`${limit} matches limit reached`)
+  }
+  if (result.linesTruncated) {
+    details.linesTruncated = true
+    notices.push("long lines truncated")
+  }
+  if (truncation.truncated) {
+    details.truncation = truncation
+    notices.push(`${formatSize(truncation.maxBytes)} limit reached`)
+  }
+  if (result.responseLimitReached) {
+    notices.push("remote response limit reached")
+  }
+  if (notices.length > 0) output += `\n\n[${notices.join(". ")}]`
+  return {
+    content: [{ type: "text" as const, text: output }],
+    details: Object.keys(details).length > 0 ? details : undefined,
+  }
+}
+
+function rewritePathParameter<T extends { path?: string }>(
+  params: T,
+  localCwd: string,
+  guestHome: string,
+): T {
+  if (typeof params.path !== "string") return params
+  return {
+    ...params,
+    path: rewriteInputPath(params.path, localCwd, guestHome),
+  }
+}
+
+function rewriteInputPath(
+  input: string,
+  localCwd: string,
+  guestHome: string,
+): string {
+  const value = input.startsWith("@") ? input.slice(1) : input
+  if (value === "~") return guestHome
+  if (value.startsWith("~/")) return path.posix.join(guestHome, value.slice(2))
+  if (!path.isAbsolute(value)) return toPosix(value)
+  return mapAbsolutePath(value, localCwd, guestHome)
+}
+
+function resolveGuestPath(
+  input: string,
+  localCwd: string,
+  guestHome: string,
+): string {
+  const rewritten = rewriteInputPath(input, localCwd, guestHome)
+  return path.posix.isAbsolute(rewritten)
+    ? path.posix.normalize(rewritten)
+    : path.posix.resolve(GUEST_WORKSPACE, rewritten)
+}
+
+function mapAbsolutePath(
+  filePath: string,
+  localCwd: string,
+  guestHome: string,
+): string {
+  const value = filePath.startsWith("@") ? filePath.slice(1) : filePath
+  if (value === "~") return guestHome
+  if (value.startsWith("~/")) return path.posix.join(guestHome, value.slice(2))
+  const relative = path.relative(localCwd, value)
+  if (
+    relative === "" ||
+    (relative !== ".." &&
+      !relative.startsWith(`..${path.sep}`) &&
+      !path.isAbsolute(relative))
+  ) {
+    return relative
+      ? path.posix.join(GUEST_WORKSPACE, toPosix(relative))
+      : GUEST_WORKSPACE
+  }
+  return path.posix.normalize(toPosix(value))
+}
+
+function toPosix(value: string): string {
+  return value.split(path.sep).join(path.posix.sep)
+}
+
+function imageMimeType(filePath: string): string | null {
+  switch (path.posix.extname(filePath).toLowerCase()) {
+    case ".png":
+      return "image/png"
+    case ".jpg":
+    case ".jpeg":
+      return "image/jpeg"
+    case ".gif":
+      return "image/gif"
+    case ".webp":
+      return "image/webp"
+    case ".bmp":
+      return "image/bmp"
+    default:
+      return null
+  }
+}
+
+function clampInteger(
+  value: number | undefined,
+  fallback: number,
+  minimum: number,
+  maximum: number,
+): number {
+  if (!Number.isFinite(value)) return fallback
+  return Math.min(maximum, Math.max(minimum, Math.floor(value ?? fallback)))
+}
+
+function optionalPositiveInteger(
+  value: number | undefined,
+  name: string,
+): number | undefined {
+  if (value === undefined) return undefined
+  if (!Number.isFinite(value) || value < 1) {
+    throw new Error(`${name} must be a positive finite number`)
+  }
+  return Math.floor(value)
+}
+
+function validateBridgeReadResult(
+  result: BridgeReadResult,
+): asserts result is BridgeReadResult {
+  if (!result || typeof result !== "object" || !("kind" in result)) {
+    throw new BridgeError("Superserve read bridge returned an invalid result")
+  }
+  if (result.kind === "image") {
+    if (
+      typeof result.mimeType !== "string" ||
+      !Number.isSafeInteger(result.size) ||
+      result.size < 0
+    ) {
+      throw new BridgeError(
+        "Superserve read bridge returned invalid image data",
+      )
+    }
+    return
+  }
+  if (
+    result.kind !== "text" ||
+    typeof result.content !== "string" ||
+    typeof result.contentLimitReached !== "boolean" ||
+    !Number.isSafeInteger(result.firstLineBytes) ||
+    result.firstLineBytes < 0 ||
+    !Number.isSafeInteger(result.selectedLines) ||
+    result.selectedLines < 0 ||
+    !Number.isSafeInteger(result.totalLines) ||
+    result.totalLines < 1
+  ) {
+    throw new BridgeError("Superserve read bridge returned invalid text data")
+  }
+}
+
+function detectSupportedImageMimeType(buffer: Buffer): string | undefined {
+  if (
+    buffer.length >= 8 &&
+    buffer[0] === 0x89 &&
+    buffer.subarray(1, 4).toString("ascii") === "PNG" &&
+    buffer[4] === 0x0d &&
+    buffer[5] === 0x0a &&
+    buffer[6] === 0x1a &&
+    buffer[7] === 0x0a
+  ) {
+    return "image/png"
+  }
+  if (
+    buffer.length >= 3 &&
+    buffer[0] === 0xff &&
+    buffer[1] === 0xd8 &&
+    buffer[2] === 0xff
+  ) {
+    return "image/jpeg"
+  }
+  const signature = buffer.subarray(0, 6).toString("ascii")
+  if (signature === "GIF87a" || signature === "GIF89a") return "image/gif"
+  if (
+    buffer.length >= 12 &&
+    buffer.subarray(0, 4).toString("ascii") === "RIFF" &&
+    buffer.subarray(8, 12).toString("ascii") === "WEBP"
+  ) {
+    return "image/webp"
+  }
+  if (buffer.length >= 2 && buffer[0] === 0x42 && buffer[1] === 0x4d) {
+    return "image/bmp"
+  }
+  return undefined
+}
+
+function errorWithCause(message: string, cause: unknown): Error {
+  const error = new Error(message)
+  ;(error as Error & { cause?: unknown }).cause = cause
+  return error
+}

--- a/packages/pi/src/types.ts
+++ b/packages/pi/src/types.ts
@@ -1,0 +1,90 @@
+import type {
+  ConnectionOptions,
+  Sandbox,
+  SandboxCreateOptions,
+  SandboxInfo,
+  SandboxListOptions,
+} from "@superserve/sdk"
+
+import type { GUEST_WORKSPACE, SESSION_ENTRY_VERSION } from "./constants.js"
+
+export type SandboxHandle = Pick<
+  Sandbox,
+  | "id"
+  | "name"
+  | "status"
+  | "metadata"
+  | "commands"
+  | "files"
+  | "getInfo"
+  | "pause"
+  | "resume"
+  | "kill"
+>
+
+export interface SandboxProvider {
+  create(options: SandboxCreateOptions): Promise<SandboxHandle>
+  connect(
+    sandboxId: string,
+    options?: ConnectionOptions,
+  ): Promise<SandboxHandle>
+  list(options?: SandboxListOptions): Promise<SandboxInfo[]>
+  killById(sandboxId: string, options?: ConnectionOptions): Promise<void>
+}
+
+export type SandboxBindingState =
+  | "provisioning"
+  | "attaching"
+  | "active"
+  | "paused"
+  | "missing"
+  | "destroyed"
+
+export interface SandboxBinding {
+  version: typeof SESSION_ENTRY_VERSION
+  ownerSessionId: string
+  clientId: string
+  bindingId: string
+  state: SandboxBindingState
+  managed: boolean
+  sandboxId?: string
+  workspacePath: typeof GUEST_WORKSPACE
+  guestHome?: string
+  template?: string
+  timeoutSeconds?: number
+  autoDeleteSeconds?: number
+  sync: "tracked" | "none"
+  createdAt: string
+  updatedAt: string
+}
+
+export interface ActiveSandbox {
+  sandbox: SandboxHandle
+  binding: SandboxBinding
+  guestHome: string
+}
+
+export interface SandboxRuntimeOptions {
+  template: string
+  timeoutSeconds: number
+  autoDeleteSeconds: number | undefined
+  sync: "tracked" | "none"
+}
+
+export interface SandboxBootstrapOptions {
+  localCwd: string
+  sync: "tracked" | "none"
+  uploadWorkspace: boolean
+  signal?: AbortSignal
+}
+
+export interface SandboxBootstrapResult {
+  guestHome: string
+  syncedFiles: number
+  syncedBytes: number
+}
+
+export type SandboxBootstrap = (
+  sandbox: SandboxHandle,
+  options: SandboxBootstrapOptions,
+) => Promise<SandboxBootstrapResult>

--- a/packages/pi/src/workspace.ts
+++ b/packages/pi/src/workspace.ts
@@ -1,0 +1,376 @@
+import { Buffer } from "node:buffer"
+import { spawn } from "node:child_process"
+import { constants as fsConstants } from "node:fs"
+import {
+  access,
+  lstat,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  stat,
+} from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+
+import { callBridge, installBridge } from "./bridge.js"
+import {
+  GUEST_WORKSPACE,
+  MAX_BRIDGE_OUTPUT_BYTES,
+  MAX_SYNC_ARCHIVE_BYTES,
+  MAX_SYNC_FILES,
+  WORKSPACE_ARCHIVE_PATH,
+} from "./constants.js"
+import type {
+  SandboxBootstrapOptions,
+  SandboxBootstrapResult,
+  SandboxHandle,
+} from "./types.js"
+
+const HOST_PROCESS_TIMEOUT_MS = 120_000
+const MAX_GIT_OUTPUT_BYTES = 8 * 1024 * 1024
+
+interface ProcessResult {
+  stdout: Buffer
+  stderr: Buffer
+  exitCode: number
+}
+
+export async function bootstrapSandbox(
+  sandbox: SandboxHandle,
+  options: SandboxBootstrapOptions,
+): Promise<SandboxBootstrapResult> {
+  await runRemoteSetup(
+    sandbox,
+    `mkdir -p -- ${GUEST_WORKSPACE}`,
+    options.signal,
+  )
+  await installBridge(sandbox, options.signal)
+
+  let syncedFiles = 0
+  let syncedBytes = 0
+  if (options.uploadWorkspace && options.sync === "tracked") {
+    const synced = await uploadTrackedWorkspace(
+      sandbox,
+      options.localCwd,
+      options.signal,
+    )
+    syncedFiles = synced.fileCount
+    syncedBytes = synced.totalBytes
+  }
+
+  const guestHome = await callBridge<string>(
+    sandbox,
+    "home",
+    {},
+    options.signal,
+  )
+  return { guestHome, syncedFiles, syncedBytes }
+}
+
+async function uploadTrackedWorkspace(
+  sandbox: SandboxHandle,
+  localCwd: string,
+  signal?: AbortSignal,
+): Promise<{ fileCount: number; totalBytes: number }> {
+  const files = await listTrackedFiles(localCwd, signal)
+  let totalBytes = 0
+  const archiveFiles: string[] = []
+
+  for (const file of files) {
+    let info
+    try {
+      info = await lstat(path.join(localCwd, file))
+    } catch {
+      continue
+    }
+    if (!info.isFile() && !info.isSymbolicLink()) continue
+    totalBytes += info.size
+    if (totalBytes > MAX_SYNC_ARCHIVE_BYTES) {
+      throw new Error(
+        `Tracked workspace exceeds the ${formatBytes(MAX_SYNC_ARCHIVE_BYTES)} upload limit. Use --superserve-sync none or reduce the checkout.`,
+      )
+    }
+    archiveFiles.push(file)
+  }
+
+  if (archiveFiles.length === 0) {
+    return { fileCount: 0, totalBytes: 0 }
+  }
+
+  const temporaryDirectory = await mkdtemp(
+    path.join(tmpdir(), "superserve-pi-"),
+  )
+  const archivePath = path.join(temporaryDirectory, "workspace.tar.gz")
+  try {
+    const tarInput = Buffer.from(`${archiveFiles.join("\0")}\0`)
+    const result = await runProcess(
+      "tar",
+      ["-czf", archivePath, "--null", "-T", "-"],
+      {
+        cwd: localCwd,
+        input: tarInput,
+        signal,
+        maxOutputBytes: MAX_GIT_OUTPUT_BYTES,
+      },
+    )
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `Could not archive the tracked workspace: ${result.stderr.toString("utf8").trim() || `tar exited with ${result.exitCode}`}`,
+      )
+    }
+
+    const archiveInfo = await stat(archivePath)
+    if (archiveInfo.size > MAX_SYNC_ARCHIVE_BYTES) {
+      throw new Error(
+        `Workspace archive exceeds the ${formatBytes(MAX_SYNC_ARCHIVE_BYTES)} upload limit.`,
+      )
+    }
+    const archive = await readFile(archivePath)
+    await sandbox.files.write(WORKSPACE_ARCHIVE_PATH, archive, {
+      timeoutMs: HOST_PROCESS_TIMEOUT_MS,
+      signal,
+    })
+    await runRemoteSetup(
+      sandbox,
+      [
+        `tar -xzf ${WORKSPACE_ARCHIVE_PATH} -C ${GUEST_WORKSPACE}`,
+        `rm -f -- ${WORKSPACE_ARCHIVE_PATH}`,
+      ].join(" && "),
+      signal,
+    )
+    await initializeRemoteGit(sandbox, signal)
+    return { fileCount: archiveFiles.length, totalBytes }
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true })
+  }
+}
+
+async function listTrackedFiles(
+  cwd: string,
+  signal?: AbortSignal,
+): Promise<string[]> {
+  const result = await runProcess(
+    "git",
+    [
+      "-c",
+      "core.fsmonitor=false",
+      "-c",
+      "core.hooksPath=/dev/null",
+      "ls-files",
+      "-z",
+      "--cached",
+    ],
+    { cwd, signal, maxOutputBytes: MAX_GIT_OUTPUT_BYTES },
+  )
+  if (result.exitCode !== 0) {
+    throw new Error(
+      "Tracked workspace sync requires a Git checkout. Use --superserve-sync none for an empty or pre-populated sandbox.",
+    )
+  }
+
+  const files = result.stdout
+    .toString("utf8")
+    .split("\0")
+    .filter((file) => file.length > 0)
+  if (files.length > MAX_SYNC_FILES) {
+    throw new Error(
+      `Tracked workspace has ${files.length} files, exceeding the ${MAX_SYNC_FILES} file upload limit. Use --superserve-sync none or reduce the checkout.`,
+    )
+  }
+  return files
+}
+
+async function initializeRemoteGit(
+  sandbox: SandboxHandle,
+  signal?: AbortSignal,
+): Promise<void> {
+  const command = [
+    "command -v git >/dev/null 2>&1 || exit 0",
+    `cd ${GUEST_WORKSPACE}`,
+    "git init -q",
+    'git config user.name "Superserve Pi"',
+    'git config user.email "pi@superserve.local"',
+    "git add -A",
+    'git commit -qm "Initial workspace snapshot"',
+  ].join(" && ")
+  await runRemoteSetup(sandbox, command, signal)
+}
+
+async function runRemoteSetup(
+  sandbox: SandboxHandle,
+  command: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  const result = await sandbox.commands.run(command, {
+    timeoutMs: HOST_PROCESS_TIMEOUT_MS,
+    signal,
+    maxOutputBytes: MAX_BRIDGE_OUTPUT_BYTES,
+  })
+  if (result.exitCode !== 0) {
+    const output = result.stderr.trim() || result.stdout.trim()
+    throw new Error(
+      `Superserve workspace setup failed: ${output || `command exited with ${result.exitCode}`}`,
+    )
+  }
+}
+
+async function runProcess(
+  command: string,
+  args: string[],
+  options: {
+    cwd: string
+    input?: Buffer
+    signal?: AbortSignal
+    maxOutputBytes: number
+  },
+): Promise<ProcessResult> {
+  if (options.signal?.aborted) throw new Error("Operation aborted")
+  const trusted = await resolveTrustedExecutable(command, options.cwd)
+
+  return new Promise((resolve, reject) => {
+    const environment = Object.fromEntries(
+      Object.entries(process.env).filter(
+        ([key]) =>
+          !key.startsWith("GIT_") &&
+          key !== "TAR_OPTIONS" &&
+          key.toUpperCase() !== "PATH",
+      ),
+    )
+    environment.GIT_CONFIG_GLOBAL = "/dev/null"
+    environment.GIT_CONFIG_NOSYSTEM = "1"
+    environment.GIT_OPTIONAL_LOCKS = "0"
+    environment.PATH = trusted.path
+
+    const child = spawn(trusted.executable, args, {
+      cwd: options.cwd,
+      env: environment,
+      stdio: ["pipe", "pipe", "pipe"],
+    })
+    const stdout: Buffer[] = []
+    const stderr: Buffer[] = []
+    let outputBytes = 0
+    let settled = false
+
+    const finish = (callback: () => void) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      options.signal?.removeEventListener("abort", onAbort)
+      callback()
+    }
+    const stop = (error: Error) => {
+      child.kill("SIGKILL")
+      finish(() => reject(error))
+    }
+    const collect = (target: Buffer[]) => (chunk: Buffer) => {
+      outputBytes += chunk.byteLength
+      if (outputBytes > options.maxOutputBytes) {
+        stop(new Error(`${command} output exceeded the safe limit`))
+        return
+      }
+      target.push(chunk)
+    }
+    const onAbort = () => stop(new Error("Operation aborted"))
+    const timer = setTimeout(
+      () => stop(new Error(`${command} timed out`)),
+      HOST_PROCESS_TIMEOUT_MS,
+    )
+
+    options.signal?.addEventListener("abort", onAbort, { once: true })
+    if (options.signal?.aborted) {
+      onAbort()
+      return
+    }
+    child.stdout.on("data", collect(stdout))
+    child.stderr.on("data", collect(stderr))
+    child.on("error", (error) => finish(() => reject(error)))
+    child.on("close", (code) =>
+      finish(() =>
+        resolve({
+          stdout: Buffer.concat(stdout),
+          stderr: Buffer.concat(stderr),
+          exitCode: code ?? 1,
+        }),
+      ),
+    )
+    child.stdin.on("error", () => {})
+    child.stdin.end(options.input)
+  })
+}
+
+async function resolveTrustedExecutable(
+  command: string,
+  cwd: string,
+): Promise<{ executable: string; path: string }> {
+  const workspaceRoot = await realpath(cwd)
+  const searchPath = process.env.PATH ?? "/usr/bin:/bin"
+  const directories: string[] = []
+
+  for (const entry of searchPath.split(path.delimiter)) {
+    const candidateDirectory = path.resolve(cwd, entry || ".")
+    let resolvedDirectory: string
+    try {
+      resolvedDirectory = await realpath(candidateDirectory)
+      if (!(await stat(resolvedDirectory)).isDirectory()) continue
+    } catch (error) {
+      const code =
+        typeof error === "object" && error !== null && "code" in error
+          ? error.code
+          : undefined
+      if (code === "ENOENT" || code === "ENOTDIR" || code === "EACCES") {
+        continue
+      }
+      throw error
+    }
+
+    const relative = path.relative(workspaceRoot, resolvedDirectory)
+    const insideWorkspace =
+      relative === "" ||
+      (relative !== ".." &&
+        !relative.startsWith(`..${path.sep}`) &&
+        !path.isAbsolute(relative))
+    if (!insideWorkspace && !directories.includes(resolvedDirectory)) {
+      directories.push(resolvedDirectory)
+    }
+  }
+
+  const suffixes =
+    process.platform === "win32" && path.extname(command) === ""
+      ? (process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD")
+          .split(path.delimiter)
+          .filter(Boolean)
+      : [""]
+  for (const directory of directories) {
+    for (const suffix of suffixes) {
+      const candidate = path.join(directory, `${command}${suffix}`)
+      try {
+        await access(candidate, fsConstants.X_OK)
+        if (!(await stat(candidate)).isFile()) continue
+        return {
+          executable: await realpath(candidate),
+          path: directories.join(path.delimiter),
+        }
+      } catch (error) {
+        const code =
+          typeof error === "object" && error !== null && "code" in error
+            ? error.code
+            : undefined
+        if (code === "ENOENT" || code === "ENOTDIR" || code === "EACCES") {
+          continue
+        }
+        throw error
+      }
+    }
+  }
+
+  throw new Error(
+    `Could not find trusted host executable ${command}; workspace-controlled PATH entries are excluded`,
+  )
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${Math.ceil(bytes / 1024)} KiB`
+  return `${Math.ceil(bytes / (1024 * 1024))} MiB`
+}

--- a/packages/pi/tests/extension.test.ts
+++ b/packages/pi/tests/extension.test.ts
@@ -1,0 +1,696 @@
+import type {
+  ExtensionAPI,
+  ExtensionContext,
+  SlashCommandInfo,
+  SourceInfo,
+  ToolInfo,
+} from "@earendil-works/pi-coding-agent"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  createSuperservePiExtension,
+  type SuperservePiInvocationState,
+  type SandboxBootstrap,
+  type SandboxProvider,
+} from "../src/index.js"
+
+const LOCAL_CWD = "/host/private/project"
+const ROUTED_TOOLS = ["read", "write", "edit", "bash", "grep", "find", "ls"]
+const SANDBOX_EXISTING_ID = "00000000-0000-4000-8000-000000000001"
+
+type RecordedHandler = (event: unknown, context: ExtensionContext) => unknown
+
+interface RecordedFlag {
+  description?: string
+  type: "boolean" | "string"
+  default?: boolean | string
+}
+
+interface RecordedCommand {
+  description?: string
+  handler: (argumentsText: string, context: ExtensionContext) => Promise<void>
+}
+
+interface ExtensionHarness {
+  api: ExtensionAPI
+  handlers: Map<string, RecordedHandler>
+  flags: Map<string, RecordedFlag>
+  commands: Map<string, RecordedCommand>
+  getActiveTools: ReturnType<typeof vi.fn>
+  getAllTools: ReturnType<typeof vi.fn>
+  tools: string[]
+  setActiveTools: ReturnType<typeof vi.fn>
+}
+
+interface LoadExtensionOptions {
+  argv?: readonly string[]
+  branch?: readonly unknown[]
+  invocationState?: SuperservePiInvocationState
+  piVersion?: string
+  transformCommands?: (commands: SlashCommandInfo[]) => SlashCommandInfo[]
+  transformTools?: (tools: ToolInfo[]) => ToolInfo[]
+}
+
+const EXTENSION_SOURCE: SourceInfo = {
+  path: "/extensions/superserve-pi.js",
+  source: "cli",
+  scope: "temporary",
+  origin: "top-level",
+  baseDir: "/extensions",
+}
+
+function createHarness(
+  flagValues: Record<string, boolean | string | undefined> = {},
+  transformCommands: (commands: SlashCommandInfo[]) => SlashCommandInfo[] = (
+    commands,
+  ) => commands,
+  transformTools: (tools: ToolInfo[]) => ToolInfo[] = (tools) => tools,
+): ExtensionHarness {
+  const handlers = new Map<string, RecordedHandler>()
+  const flags = new Map<string, RecordedFlag>()
+  const commands = new Map<string, RecordedCommand>()
+  const tools: string[] = []
+  const definitions: Array<Omit<ToolInfo, "sourceInfo">> = []
+  let activeTools: string[] = []
+  const getActiveTools = vi.fn(() => [...activeTools])
+  const setActiveTools = vi.fn((names: string[]) => {
+    activeTools = [...names]
+  })
+  const getAllTools = vi.fn(() =>
+    transformTools(
+      definitions.map((definition) => ({
+        name: definition.name,
+        description: definition.description,
+        parameters: definition.parameters,
+        promptGuidelines: definition.promptGuidelines,
+        sourceInfo: {
+          path: EXTENSION_SOURCE.path,
+          source: EXTENSION_SOURCE.source,
+          scope: EXTENSION_SOURCE.scope,
+          origin: EXTENSION_SOURCE.origin,
+          baseDir: EXTENSION_SOURCE.baseDir,
+        },
+      })),
+    ),
+  )
+
+  const api = {
+    on: vi.fn((event: string, handler: RecordedHandler) => {
+      handlers.set(event, handler)
+    }),
+    registerFlag: vi.fn((name: string, options: RecordedFlag) => {
+      flags.set(name, options)
+    }),
+    getFlag: vi.fn((name: string) => flagValues[name]),
+    registerCommand: vi.fn((name: string, command: RecordedCommand) => {
+      commands.set(name, command)
+    }),
+    getCommands: vi.fn(() =>
+      transformCommands(
+        [...commands].map(([name, command]) => ({
+          name,
+          description: command.description,
+          source: "extension" as const,
+          sourceInfo: {
+            path: EXTENSION_SOURCE.path,
+            source: EXTENSION_SOURCE.source,
+            scope: EXTENSION_SOURCE.scope,
+            origin: EXTENSION_SOURCE.origin,
+            baseDir: EXTENSION_SOURCE.baseDir,
+          },
+        })),
+      ),
+    ),
+    registerTool: vi.fn((tool: Omit<ToolInfo, "sourceInfo">) => {
+      tools.push(tool.name)
+      definitions.push(tool)
+      activeTools = [...new Set([...activeTools, tool.name])]
+    }),
+    getActiveTools,
+    getAllTools,
+    appendEntry: vi.fn(),
+    setActiveTools,
+  } as unknown as ExtensionAPI
+
+  return {
+    api,
+    handlers,
+    flags,
+    commands,
+    getActiveTools,
+    getAllTools,
+    tools,
+    setActiveTools,
+  }
+}
+
+function createContext(branch: readonly unknown[] = []): ExtensionContext {
+  return {
+    cwd: LOCAL_CWD,
+    mode: "print",
+    hasUI: false,
+    signal: undefined,
+    sessionManager: {
+      getSessionId: () => "session-1",
+      getSessionFile: () => "/sessions/session-1.jsonl",
+      getBranch: () => [...branch],
+    },
+    ui: {
+      notify: vi.fn(),
+      setStatus: vi.fn(),
+      theme: {
+        fg: (_color: string, text: string) => text,
+      },
+    },
+  } as unknown as ExtensionContext
+}
+
+function createFailingDependencies(): {
+  provider: SandboxProvider
+  bootstrap: SandboxBootstrap
+} {
+  return {
+    provider: {
+      create: vi.fn(async () => {
+        throw new Error("provider offline")
+      }),
+      connect: vi.fn(async () => {
+        throw new Error("unexpected connect")
+      }),
+      list: vi.fn(async () => []),
+      killById: vi.fn(async () => undefined),
+    },
+    bootstrap: vi.fn(async () => {
+      throw new Error("unexpected bootstrap")
+    }),
+  }
+}
+
+function loadExtension(
+  flagValues: Record<string, boolean | string | undefined> = {},
+  options: LoadExtensionOptions = {},
+): {
+  harness: ExtensionHarness
+  context: ExtensionContext
+  dependencies: ReturnType<typeof createFailingDependencies>
+} {
+  const harness = createHarness(
+    flagValues,
+    options.transformCommands,
+    options.transformTools,
+  )
+  const context = createContext(options.branch)
+  const dependencies = createFailingDependencies()
+  createSuperservePiExtension({
+    ...dependencies,
+    argv: options.argv ?? [],
+    invocationState: options.invocationState ?? { routingRequested: false },
+    localCwd: LOCAL_CWD,
+    piVersion: options.piVersion,
+  })(harness.api)
+  return { harness, context, dependencies }
+}
+
+async function invoke<TResult>(
+  harness: ExtensionHarness,
+  eventName: string,
+  event: unknown,
+  context: ExtensionContext,
+): Promise<TResult | undefined> {
+  const handler = harness.handlers.get(eventName)
+  if (!handler) throw new Error(`No handler registered for ${eventName}`)
+  return (await handler(event, context)) as TResult | undefined
+}
+
+async function enableSandboxMode(
+  harness: ExtensionHarness,
+  context: ExtensionContext,
+): Promise<void> {
+  await invoke(
+    harness,
+    "session_start",
+    { type: "session_start", reason: "startup" },
+    context,
+  )
+}
+
+describe("@superserve/pi extension", () => {
+  it("registers sandbox controls without overriding dormant tools", () => {
+    const { harness } = loadExtension()
+
+    expect([...harness.flags]).toEqual([
+      [
+        "superserve",
+        expect.objectContaining({ type: "boolean", default: false }),
+      ],
+      [
+        "superserve-template",
+        expect.objectContaining({
+          type: "string",
+          default: "superserve/node-22",
+        }),
+      ],
+      ["superserve-sandbox", expect.objectContaining({ type: "string" })],
+      [
+        "superserve-timeout",
+        expect.objectContaining({ type: "string", default: "3600" }),
+      ],
+      [
+        "superserve-auto-delete",
+        expect.objectContaining({ type: "string", default: "86400" }),
+      ],
+      [
+        "superserve-sync",
+        expect.objectContaining({ type: "string", default: "tracked" }),
+      ],
+    ])
+    expect([...harness.commands]).toEqual([
+      [
+        "superserve",
+        expect.objectContaining({
+          description: expect.stringContaining("Superserve sandbox"),
+          handler: expect.any(Function),
+        }),
+      ],
+    ])
+    expect(harness.tools).toEqual([])
+  })
+
+  it.each([
+    { superserve: true },
+    { "superserve-sandbox": SANDBOX_EXISTING_ID },
+  ])(
+    "rejects host project trust when sandbox intent is present",
+    async (flags) => {
+      const { harness, context } = loadExtension(flags)
+
+      const result = await invoke<{ trusted: string; remember?: boolean }>(
+        harness,
+        "project_trust",
+        { type: "project_trust", cwd: LOCAL_CWD },
+        context,
+      )
+
+      expect(result).toEqual({ trusted: "no", remember: false })
+    },
+  )
+
+  it.each([
+    ["--superserve"],
+    ["--superserve=true"],
+    ["--superserve-sandbox", SANDBOX_EXISTING_ID],
+    [`--superserve-sandbox=${SANDBOX_EXISTING_ID}`],
+  ])(
+    "rejects host project trust from raw argv before Pi binds extension flags",
+    async (...argv) => {
+      const { harness, context } = loadExtension({}, { argv })
+
+      const result = await invoke<{ trusted: string; remember?: boolean }>(
+        harness,
+        "project_trust",
+        { type: "project_trust", cwd: LOCAL_CWD },
+        context,
+      )
+
+      expect(result).toEqual({ trusted: "no", remember: false })
+    },
+  )
+
+  it("leaves project trust undecided without sandbox intent", async () => {
+    const { harness, context } = loadExtension({}, { argv: ["--print"] })
+
+    const result = await invoke<{ trusted: string }>(
+      harness,
+      "project_trust",
+      { type: "project_trust", cwd: LOCAL_CWD },
+      context,
+    )
+
+    expect(result).toEqual({ trusted: "undecided" })
+  })
+
+  it("activates only the seven sandbox-routed tools", async () => {
+    const { harness, context } = loadExtension({ superserve: true })
+
+    await enableSandboxMode(harness, context)
+
+    expect(new Set(harness.tools)).toEqual(new Set(ROUTED_TOOLS))
+    expect(harness.tools).toHaveLength(ROUTED_TOOLS.length)
+    expect(harness.setActiveTools).toHaveBeenCalledWith(ROUTED_TOOLS)
+    expect(harness.setActiveTools).toHaveBeenCalledTimes(1)
+    expect(harness.getActiveTools()).toEqual(ROUTED_TOOLS)
+  })
+
+  it("preserves active tools in dormant local sessions", async () => {
+    const { harness, context } = loadExtension()
+    const activeTools = harness.getActiveTools()
+
+    await enableSandboxMode(harness, context)
+
+    expect(harness.tools).toEqual([])
+    expect(harness.getActiveTools()).toEqual(activeTools)
+    expect(harness.setActiveTools).not.toHaveBeenCalled()
+  })
+
+  it("registers routed tools idempotently across repeated starts", async () => {
+    const { harness, context } = loadExtension({ superserve: true })
+
+    await enableSandboxMode(harness, context)
+    await enableSandboxMode(harness, context)
+
+    expect(new Set(harness.tools)).toEqual(new Set(ROUTED_TOOLS))
+    expect(harness.tools).toHaveLength(ROUTED_TOOLS.length)
+  })
+
+  it("registers tools when a dormant session opts in through a command", async () => {
+    const { harness, context } = loadExtension()
+    await enableSandboxMode(harness, context)
+
+    await harness.commands.get("superserve")?.handler("new", context)
+    await harness.commands.get("superserve")?.handler("new", context)
+
+    expect(new Set(harness.tools)).toEqual(new Set(ROUTED_TOOLS))
+    expect(harness.tools).toHaveLength(ROUTED_TOOLS.length)
+  })
+
+  it("carries verified command opt-in into a fresh extension instance", async () => {
+    const invocationState: SuperservePiInvocationState = {
+      routingRequested: false,
+    }
+    const first = loadExtension({}, { invocationState })
+    await enableSandboxMode(first.harness, first.context)
+    await first.harness.commands
+      .get("superserve")
+      ?.handler("new", first.context)
+
+    expect(invocationState.routingRequested).toBe(true)
+
+    const second = loadExtension({}, { invocationState })
+    expect(second.harness.tools).toEqual([])
+    await enableSandboxMode(second.harness, second.context)
+
+    expect(new Set(second.harness.tools)).toEqual(new Set(ROUTED_TOOLS))
+    expect(second.harness.setActiveTools).toHaveBeenCalledWith(ROUTED_TOOLS)
+    expect(second.dependencies.provider.create).toHaveBeenCalledTimes(1)
+  })
+
+  it("registers and verifies tools before handling a malformed binding entry", async () => {
+    const hostileSource: SourceInfo = {
+      path: "/extensions/host-tools.js",
+      source: "local",
+      scope: "user",
+      origin: "top-level",
+    }
+    const { harness, context, dependencies } = loadExtension(
+      {},
+      {
+        branch: [
+          {
+            type: "custom",
+            customType: "superserve-sandbox",
+            data: { malformed: true },
+          },
+        ],
+        transformTools: (tools) =>
+          tools.map((tool) =>
+            tool.name === "read"
+              ? { ...tool, sourceInfo: hostileSource }
+              : tool,
+          ),
+      },
+    )
+
+    await enableSandboxMode(harness, context)
+
+    expect(new Set(harness.tools)).toEqual(new Set(ROUTED_TOOLS))
+    expect(harness.getActiveTools()).toEqual([])
+    expect(dependencies.provider.create).not.toHaveBeenCalled()
+  })
+
+  it("fails closed when a routed tool comes from another extension", async () => {
+    const hostileSource: SourceInfo = {
+      path: "/extensions/host-tools.js",
+      source: "local",
+      scope: "user",
+      origin: "top-level",
+    }
+    const { harness, context, dependencies } = loadExtension(
+      { superserve: true },
+      {
+        transformTools: (tools) =>
+          tools.map((tool) =>
+            tool.name === "read"
+              ? { ...tool, sourceInfo: hostileSource }
+              : tool,
+          ),
+      },
+    )
+
+    await enableSandboxMode(harness, context)
+
+    expect(dependencies.provider.create).not.toHaveBeenCalled()
+    expect(harness.getActiveTools()).toEqual([])
+    const toolCall = await invoke<{ block?: boolean; reason?: string }>(
+      harness,
+      "tool_call",
+      {
+        type: "tool_call",
+        toolCallId: "call-read",
+        toolName: "read",
+        input: { path: "README.md" },
+      },
+      context,
+    )
+    expect(toolCall).toEqual({
+      block: true,
+      reason: expect.stringMatching(/source verification failed.*read/is),
+    })
+
+    const userBash = await invoke<{
+      result?: { output: string; exitCode: number }
+    }>(
+      harness,
+      "user_bash",
+      {
+        type: "user_bash",
+        command: "pwd",
+        excludeFromContext: false,
+        cwd: LOCAL_CWD,
+      },
+      context,
+    )
+    expect(userBash?.result).toEqual(
+      expect.objectContaining({
+        output: expect.stringMatching(
+          /source verification failed.*not run on the host/is,
+        ),
+        exitCode: 1,
+      }),
+    )
+  })
+
+  it("fails closed when the command source anchor is unavailable", async () => {
+    const { harness, context, dependencies } = loadExtension(
+      { superserve: true },
+      {
+        transformCommands: () => [],
+      },
+    )
+
+    await enableSandboxMode(harness, context)
+
+    expect(dependencies.provider.create).not.toHaveBeenCalled()
+    expect(harness.getActiveTools()).toEqual([])
+    expect(context.ui.notify).toHaveBeenCalledWith(
+      expect.stringMatching(/command source anchor is missing or ambiguous/i),
+      "error",
+    )
+  })
+
+  it("fails closed when provenance inspection throws", async () => {
+    const { harness, context, dependencies } = loadExtension({
+      superserve: true,
+    })
+    harness.getAllTools.mockImplementation(() => {
+      throw new Error("tool registry unavailable")
+    })
+
+    await expect(enableSandboxMode(harness, context)).resolves.toBeUndefined()
+
+    expect(dependencies.provider.create).not.toHaveBeenCalled()
+    expect(harness.getActiveTools()).toEqual([])
+    const toolCall = await invoke<{ block?: boolean; reason?: string }>(
+      harness,
+      "tool_call",
+      {
+        type: "tool_call",
+        toolCallId: "call-read",
+        toolName: "read",
+        input: { path: "README.md" },
+      },
+      context,
+    )
+    expect(toolCall).toEqual({
+      block: true,
+      reason: expect.stringMatching(
+        /source verification failed.*tool registry unavailable/is,
+      ),
+    })
+
+    const userBash = await invoke<{
+      result?: { output: string; exitCode: number }
+    }>(
+      harness,
+      "user_bash",
+      {
+        type: "user_bash",
+        command: "pwd",
+        excludeFromContext: false,
+        cwd: LOCAL_CWD,
+      },
+      context,
+    )
+    expect(userBash?.result).toEqual(
+      expect.objectContaining({
+        output: expect.stringMatching(
+          /tool registry unavailable.*not run on the host/is,
+        ),
+        exitCode: 1,
+      }),
+    )
+  })
+
+  it("fails closed before tool registration on an unsupported Pi version", async () => {
+    const { harness, context, dependencies } = loadExtension(
+      { superserve: true },
+      { piVersion: "0.81.0" },
+    )
+
+    await enableSandboxMode(harness, context)
+
+    expect(harness.tools).toEqual([])
+    expect(harness.getActiveTools()).toEqual([])
+    expect(dependencies.provider.create).not.toHaveBeenCalled()
+    const userBash = await invoke<{
+      result?: { output: string; exitCode: number }
+    }>(
+      harness,
+      "user_bash",
+      {
+        type: "user_bash",
+        command: "pwd",
+        excludeFromContext: false,
+        cwd: LOCAL_CWD,
+      },
+      context,
+    )
+    expect(userBash?.result).toEqual(
+      expect.objectContaining({
+        output: expect.stringMatching(
+          /unsupported Pi version 0\.81\.0.*not run on the host/is,
+        ),
+        exitCode: 1,
+      }),
+    )
+  })
+
+  it("blocks unknown model tools while allowing the routed tool names", async () => {
+    const { harness, context } = loadExtension({ superserve: true })
+    await enableSandboxMode(harness, context)
+
+    const blocked = await invoke<{ block?: boolean; reason?: string }>(
+      harness,
+      "tool_call",
+      {
+        type: "tool_call",
+        toolCallId: "call-1",
+        toolName: "host_exec",
+        input: {},
+      },
+      context,
+    )
+
+    expect(blocked).toEqual({
+      block: true,
+      reason: expect.stringMatching(/blocked.*host/i),
+    })
+
+    for (const toolName of ROUTED_TOOLS) {
+      await expect(
+        invoke(
+          harness,
+          "tool_call",
+          {
+            type: "tool_call",
+            toolCallId: `call-${toolName}`,
+            toolName,
+            input: {},
+          },
+          context,
+        ),
+      ).resolves.toBeUndefined()
+    }
+  })
+
+  it("returns a failed replacement for user bash when the sandbox is unavailable", async () => {
+    const { harness, context } = loadExtension({ superserve: true })
+    await enableSandboxMode(harness, context)
+
+    const result = await invoke<{
+      operations?: unknown
+      result?: {
+        output: string
+        exitCode: number
+        cancelled: boolean
+        truncated: boolean
+      }
+    }>(
+      harness,
+      "user_bash",
+      {
+        type: "user_bash",
+        command: "cat /etc/passwd",
+        excludeFromContext: false,
+        cwd: LOCAL_CWD,
+      },
+      context,
+    )
+
+    expect(result).toBeDefined()
+    expect(result?.operations).toBeUndefined()
+    expect(result?.result).toEqual({
+      output: expect.stringMatching(/provider offline.*not run on the host/is),
+      exitCode: 1,
+      cancelled: false,
+      truncated: false,
+    })
+  })
+
+  it("rewrites the agent prompt to the guest workspace and states the network caveat", async () => {
+    const { harness, context } = loadExtension({ superserve: true })
+    await enableSandboxMode(harness, context)
+
+    const result = await invoke<{ systemPrompt?: string }>(
+      harness,
+      "before_agent_start",
+      {
+        type: "before_agent_start",
+        prompt: "inspect the repository",
+        systemPrompt: `You are Pi.\nCurrent working directory: ${LOCAL_CWD}`,
+        systemPromptOptions: {},
+      },
+      context,
+    )
+
+    expect(result?.systemPrompt).toContain(
+      "Current working directory: /workspace (Superserve sandbox)",
+    )
+    expect(result?.systemPrompt).not.toContain(LOCAL_CWD)
+    expect(result?.systemPrompt).toContain(
+      "The host workspace is not directly available to tools.",
+    )
+    expect(result?.systemPrompt).toContain(
+      "Network egress uses the provider default and is currently unrestricted.",
+    )
+  })
+})

--- a/packages/pi/tests/lifecycle.test.ts
+++ b/packages/pi/tests/lifecycle.test.ts
@@ -1,0 +1,996 @@
+import { mkdtemp, readFile, rm, stat, symlink } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+
+import type {
+  ExtensionAPI,
+  ExtensionContext,
+} from "@earendil-works/pi-coding-agent"
+import {
+  AuthenticationError,
+  NotFoundError,
+  type SandboxInfo,
+} from "@superserve/sdk"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import {
+  CREATED_BY,
+  DEFAULT_AUTO_DELETE_SECONDS,
+  DEFAULT_TEMPLATE,
+  DEFAULT_TIMEOUT_SECONDS,
+  GUEST_WORKSPACE,
+  ROUTED_TOOL_NAMES,
+  SESSION_ENTRY_TYPE,
+  SESSION_ENTRY_VERSION,
+} from "../src/constants.js"
+import { parseBinding, SandboxLifecycle } from "../src/lifecycle.js"
+import type {
+  SandboxBinding,
+  SandboxBootstrap,
+  SandboxHandle,
+  SandboxProvider,
+} from "../src/types.js"
+
+const LOCAL_CWD = "/repo/project"
+const OTHER_CWD = "/repo/other-project"
+const NOW = new Date("2026-07-17T00:00:00.000Z")
+const SANDBOX_EXISTING_ID = sandboxId(1)
+const SANDBOX_CREATED_ID = sandboxId(2)
+const SANDBOX_FORK_ID = sandboxId(3)
+const SANDBOX_REPLACEMENT_ID = sandboxId(4)
+const SANDBOX_EPHEMERAL_ID = sandboxId(5)
+
+interface CustomEntry {
+  customType: string
+  data: unknown
+}
+
+interface HarnessOptions {
+  binding?: SandboxBinding
+  cwd?: string
+  flags?: Record<string, boolean | string | undefined>
+  persistent?: boolean
+  sessionId?: string
+}
+
+function makeBinding(overrides: Partial<SandboxBinding> = {}): SandboxBinding {
+  return {
+    version: SESSION_ENTRY_VERSION,
+    ownerSessionId: "session-1",
+    clientId: "client-existing",
+    bindingId: "binding-existing",
+    state: "paused",
+    managed: true,
+    sandboxId: SANDBOX_EXISTING_ID,
+    workspacePath: GUEST_WORKSPACE,
+    guestHome: "/root",
+    template: DEFAULT_TEMPLATE,
+    timeoutSeconds: DEFAULT_TIMEOUT_SECONDS,
+    autoDeleteSeconds: DEFAULT_AUTO_DELETE_SECONDS,
+    sync: "tracked",
+    createdAt: "2026-07-16T00:00:00.000Z",
+    updatedAt: "2026-07-16T00:00:00.000Z",
+    ...overrides,
+  }
+}
+
+function makeHarness(options: HarnessOptions = {}) {
+  const sessionId = options.sessionId ?? "session-1"
+  const flags = { ...options.flags }
+  const appended: CustomEntry[] = []
+  const branch: Array<Record<string, unknown>> = []
+  if (options.binding) {
+    branch.push({
+      type: "custom",
+      customType: SESSION_ENTRY_TYPE,
+      data: options.binding,
+    })
+  }
+
+  const getFlag = vi.fn((name: string) => flags[name])
+  const setActiveTools = vi.fn((_toolNames: string[]) => undefined)
+  const appendEntry = vi.fn((customType: string, data?: unknown) => {
+    appended.push({ customType, data })
+    branch.push({ type: "custom", customType, data })
+  })
+  const pi = {
+    appendEntry,
+    getFlag,
+    setActiveTools,
+  } as unknown as ExtensionAPI
+  const ctx = {
+    cwd: options.cwd ?? LOCAL_CWD,
+    hasUI: false,
+    sessionManager: {
+      getBranch: () => branch,
+      getSessionFile: () =>
+        options.persistent === false ? undefined : "/tmp/session.jsonl",
+      getSessionId: () => sessionId,
+    },
+    signal: undefined,
+    ui: {
+      notify: vi.fn(),
+      setStatus: vi.fn(),
+      theme: { fg: (_color: string, message: string) => message },
+    },
+  } as unknown as ExtensionContext
+
+  return {
+    appendEntry,
+    appended,
+    branch,
+    ctx,
+    flags,
+    getFlag,
+    pi,
+    setActiveTools,
+  }
+}
+
+function makeSandboxInfo(
+  id: string,
+  createdAt = NOW,
+  metadata: Record<string, string> = {},
+): SandboxInfo {
+  return {
+    id,
+    name: `sandbox-${id}`,
+    status: "active",
+    vcpuCount: 1,
+    memoryMib: 512,
+    createdAt,
+    metadata,
+  }
+}
+
+function makeSandbox(id: string) {
+  const info = makeSandboxInfo(id)
+  const pause = vi.fn(async () => undefined)
+  const resume = vi.fn(async () => undefined)
+  const kill = vi.fn(async () => undefined)
+  const getInfo = vi.fn(async () => info)
+  const handle: SandboxHandle = {
+    id,
+    name: info.name,
+    status: info.status,
+    metadata: info.metadata,
+    commands: {} as SandboxHandle["commands"],
+    files: {} as SandboxHandle["files"],
+    getInfo,
+    pause,
+    resume,
+    kill,
+  }
+  return { getInfo, handle, kill, pause, resume }
+}
+
+function makeProvider(
+  createdSandbox = makeSandbox(SANDBOX_CREATED_ID).handle,
+  connectedSandbox = makeSandbox(SANDBOX_EXISTING_ID).handle,
+) {
+  const create = vi.fn<SandboxProvider["create"]>(async () => createdSandbox)
+  const connect = vi.fn<SandboxProvider["connect"]>(
+    async () => connectedSandbox,
+  )
+  const list = vi.fn<SandboxProvider["list"]>(async () => [])
+  const killById = vi.fn<SandboxProvider["killById"]>(async () => undefined)
+  const provider = { connect, create, killById, list } satisfies SandboxProvider
+  return { connect, create, killById, list, provider }
+}
+
+function makeBootstrap() {
+  return vi.fn<SandboxBootstrap>(async () => ({
+    guestHome: "/root",
+    syncedFiles: 0,
+    syncedBytes: 0,
+  }))
+}
+
+function makeLifecycle(
+  pi: ExtensionAPI,
+  provider: SandboxProvider,
+  bootstrap: SandboxBootstrap,
+  randomIds: string[] = ["client-new", "binding-new"],
+): SandboxLifecycle {
+  const ids = [...randomIds]
+  return new SandboxLifecycle(pi, LOCAL_CWD, {
+    provider,
+    bootstrap,
+    now: () => NOW,
+    randomId: () => {
+      const id = ids.shift()
+      if (!id) throw new Error("Test exhausted deterministic IDs")
+      return id
+    },
+    sleep: async () => undefined,
+  })
+}
+
+function latestBinding(appended: CustomEntry[]): SandboxBinding {
+  const entry = appended.at(-1)
+  const binding = parseBinding(entry?.data)
+  if (!binding) throw new Error("Expected a persisted sandbox binding")
+  return binding
+}
+
+function appendedStates(appended: CustomEntry[]): string[] {
+  return appended.map((entry) => {
+    const binding = parseBinding(entry.data)
+    if (!binding) throw new Error("Expected a persisted sandbox binding")
+    return binding.state
+  })
+}
+
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+  vi.unstubAllEnvs()
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) =>
+      rm(directory, {
+        recursive: true,
+        force: true,
+      }),
+    ),
+  )
+})
+
+function sandboxId(index: number): string {
+  return `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`
+}
+
+describe("SandboxLifecycle", () => {
+  it("stays dormant without an opt-in flag or persisted binding", async () => {
+    const harness = makeHarness()
+    const provider = makeProvider()
+    const bootstrap = makeBootstrap()
+    const lifecycle = makeLifecycle(harness.pi, provider.provider, bootstrap)
+
+    await lifecycle.start("startup", harness.ctx)
+
+    expect(lifecycle.isEnabled()).toBe(false)
+    expect(lifecycle.getActive()).toBeUndefined()
+    expect(provider.create).not.toHaveBeenCalled()
+    expect(provider.connect).not.toHaveBeenCalled()
+    expect(provider.list).not.toHaveBeenCalled()
+    expect(bootstrap).not.toHaveBeenCalled()
+    expect(harness.setActiveTools).not.toHaveBeenCalled()
+    expect(harness.appendEntry).not.toHaveBeenCalled()
+    await expect(lifecycle.requireSandbox(harness.ctx)).rejects.toThrow(
+      "Superserve sandbox mode is not enabled",
+    )
+  })
+
+  it.each([
+    ["restored", "session-1"],
+    ["foreign", "session-parent"],
+  ])(
+    "keeps a fresh process fail-closed for a %s binding without an explicit flag",
+    async (_label, bindingOwnerSessionId) => {
+      const binding = makeBinding({ ownerSessionId: bindingOwnerSessionId })
+      const harness = makeHarness({ binding })
+      const provider = makeProvider()
+      const bootstrap = makeBootstrap()
+      const lifecycle = makeLifecycle(harness.pi, provider.provider, bootstrap)
+
+      await lifecycle.start("resume", harness.ctx)
+
+      expect(lifecycle.isEnabled()).toBe(true)
+      expect(lifecycle.getActive()).toBeUndefined()
+      expect(harness.setActiveTools).toHaveBeenCalledWith([
+        ...ROUTED_TOOL_NAMES,
+      ])
+      expect(provider.connect).not.toHaveBeenCalled()
+      expect(provider.create).not.toHaveBeenCalled()
+      expect(bootstrap).not.toHaveBeenCalled()
+      await expect(lifecycle.requireSandbox(harness.ctx)).rejects.toThrow(
+        "Restart Pi with --superserve",
+      )
+    },
+  )
+
+  it("carries explicit intent across an in-process reload and refreshes cwd", async () => {
+    const harness = makeHarness({ flags: { superserve: true } })
+    const sandbox = makeSandbox(SANDBOX_CREATED_ID)
+    const provider = makeProvider(sandbox.handle, sandbox.handle)
+    const bootstrap = makeBootstrap()
+    const lifecycle = makeLifecycle(harness.pi, provider.provider, bootstrap)
+
+    await lifecycle.start("startup", harness.ctx)
+    await lifecycle.shutdown("reload", harness.ctx)
+    harness.flags.superserve = undefined
+    ;(harness.ctx as ExtensionContext & { cwd: string }).cwd = OTHER_CWD
+
+    await lifecycle.start("reload", harness.ctx)
+
+    expect(provider.create).toHaveBeenCalledOnce()
+    expect(provider.connect).toHaveBeenCalledOnce()
+    expect(provider.connect).toHaveBeenCalledWith(SANDBOX_CREATED_ID, {
+      signal: undefined,
+    })
+    expect(bootstrap).toHaveBeenNthCalledWith(2, sandbox.handle, {
+      localCwd: OTHER_CWD,
+      sync: "none",
+      uploadWorkspace: false,
+      signal: undefined,
+    })
+    expect(lifecycle.getActive()?.sandbox.id).toBe(SANDBOX_CREATED_ID)
+  })
+
+  it("uses command context cwd when creating a new sandbox", async () => {
+    const harness = makeHarness({ cwd: OTHER_CWD })
+    const created = makeSandbox(SANDBOX_CREATED_ID)
+    const provider = makeProvider(created.handle)
+    const bootstrap = makeBootstrap()
+    const lifecycle = makeLifecycle(harness.pi, provider.provider, bootstrap)
+
+    await lifecycle.createNew(harness.ctx)
+
+    expect(provider.create.mock.calls[0]?.[0].name).toMatch(
+      /^pi-other-project-/,
+    )
+    expect(bootstrap).toHaveBeenCalledWith(created.handle, {
+      localCwd: OTHER_CWD,
+      sync: "tracked",
+      uploadWorkspace: true,
+      signal: undefined,
+    })
+  })
+
+  it("creates and persists a managed sandbox with exact non-secret metadata", async () => {
+    const secret = "ss_live_must_not_be_persisted"
+    vi.stubEnv("SUPERSERVE_API_KEY", secret)
+    const harness = makeHarness({ flags: { superserve: true } })
+    const created = makeSandbox(SANDBOX_CREATED_ID)
+    const provider = makeProvider(created.handle)
+    const bootstrap = makeBootstrap()
+    const lifecycle = makeLifecycle(harness.pi, provider.provider, bootstrap, [
+      "client-new",
+      "binding-new",
+    ])
+
+    await lifecycle.start("startup", harness.ctx)
+
+    expect(provider.create).toHaveBeenCalledTimes(1)
+    const createOptions = provider.create.mock.calls[0]?.[0]
+    expect(createOptions).toMatchObject({
+      fromTemplate: DEFAULT_TEMPLATE,
+      timeoutSeconds: DEFAULT_TIMEOUT_SECONDS,
+      autoDeleteSeconds: DEFAULT_AUTO_DELETE_SECONDS,
+      metadata: {
+        "created-by": CREATED_BY,
+        "pi-client-id": "client-new",
+        "pi-session-id": "session-1",
+        "pi-binding-id": "binding-new",
+        "entry-version": String(SESSION_ENTRY_VERSION),
+      },
+    })
+    expect(createOptions?.name).toMatch(/^pi-project-/)
+    expect(createOptions).not.toHaveProperty("apiKey")
+    expect(createOptions).not.toHaveProperty("baseUrl")
+    expect(createOptions).not.toHaveProperty("envVars")
+    expect(createOptions).not.toHaveProperty("secrets")
+    expect(bootstrap).toHaveBeenCalledWith(created.handle, {
+      localCwd: LOCAL_CWD,
+      sync: "tracked",
+      uploadWorkspace: true,
+      signal: undefined,
+    })
+    expect(appendedStates(harness.appended)).toEqual(["provisioning", "active"])
+    expect(latestBinding(harness.appended)).toMatchObject({
+      ownerSessionId: "session-1",
+      clientId: "client-new",
+      bindingId: "binding-new",
+      sandboxId: SANDBOX_CREATED_ID,
+      state: "active",
+      managed: true,
+      workspacePath: GUEST_WORKSPACE,
+      guestHome: "/root",
+    })
+    expect(
+      JSON.stringify({ createOptions, entries: harness.appended }),
+    ).not.toContain(secret)
+    expect(lifecycle.getActive()?.sandbox.id).toBe(SANDBOX_CREATED_ID)
+    expect(harness.setActiveTools).toHaveBeenCalledWith([...ROUTED_TOOL_NAMES])
+  })
+
+  it("resumes a persisted sandbox using the current cross-project cwd", async () => {
+    const binding = makeBinding({ state: "paused" })
+    const harness = makeHarness({
+      binding,
+      cwd: OTHER_CWD,
+      flags: { superserve: true },
+    })
+    const connected = makeSandbox(SANDBOX_EXISTING_ID)
+    const provider = makeProvider(undefined, connected.handle)
+    const bootstrap = makeBootstrap()
+    const lifecycle = makeLifecycle(harness.pi, provider.provider, bootstrap)
+
+    await lifecycle.start("resume", harness.ctx)
+
+    expect(provider.connect).toHaveBeenCalledOnce()
+    expect(provider.connect).toHaveBeenCalledWith(SANDBOX_EXISTING_ID, {
+      signal: undefined,
+    })
+    expect(provider.create).not.toHaveBeenCalled()
+    expect(provider.list).not.toHaveBeenCalled()
+    expect(bootstrap).toHaveBeenCalledWith(connected.handle, {
+      localCwd: OTHER_CWD,
+      sync: "none",
+      uploadWorkspace: false,
+      signal: undefined,
+    })
+    expect(latestBinding(harness.appended).state).toBe("active")
+    expect(lifecycle.getActive()?.sandbox.id).toBe(SANDBOX_EXISTING_ID)
+  })
+
+  it("persists a command-selected target before connecting and only retries that target", async () => {
+    const targetId = sandboxId(20)
+    const binding = makeBinding({ state: "active" })
+    const harness = makeHarness({ binding, flags: { superserve: true } })
+    const connected = makeSandbox(SANDBOX_EXISTING_ID)
+    const provider = makeProvider(undefined, connected.handle)
+    const failure = new Error("target control plane unavailable")
+    provider.connect
+      .mockResolvedValueOnce(connected.handle)
+      .mockRejectedValue(failure)
+    const bootstrap = makeBootstrap()
+    const lifecycle = makeLifecycle(harness.pi, provider.provider, bootstrap)
+    await lifecycle.start("startup", harness.ctx)
+
+    await expect(lifecycle.connect(targetId, harness.ctx)).rejects.toThrow(
+      failure.message,
+    )
+
+    expect(connected.pause).toHaveBeenCalledOnce()
+    expect(latestBinding(harness.appended)).toMatchObject({
+      state: "attaching",
+      managed: false,
+      sandboxId: targetId,
+    })
+    expect(lifecycle.getActive()).toBeUndefined()
+    await expect(lifecycle.requireSandbox(harness.ctx)).rejects.toThrow(
+      failure.message,
+    )
+
+    const replacementLifecycle = makeLifecycle(
+      harness.pi,
+      provider.provider,
+      bootstrap,
+    )
+    await replacementLifecycle.start("startup", harness.ctx)
+
+    expect(provider.connect.mock.calls.map(([id]) => id)).toEqual([
+      SANDBOX_EXISTING_ID,
+      targetId,
+      targetId,
+      targetId,
+    ])
+    expect(replacementLifecycle.getBinding()).toMatchObject({
+      state: "attaching",
+      sandboxId: targetId,
+    })
+  })
+
+  it("persists a --superserve-sandbox target before a failed startup attach", async () => {
+    const targetId = sandboxId(21)
+    const binding = makeBinding({ state: "paused" })
+    const harness = makeHarness({
+      binding,
+      flags: { "superserve-sandbox": targetId },
+    })
+    const provider = makeProvider()
+    const failure = new NotFoundError("target unavailable")
+    provider.connect.mockRejectedValue(failure)
+    const bootstrap = makeBootstrap()
+    const lifecycle = makeLifecycle(harness.pi, provider.provider, bootstrap)
+
+    await lifecycle.start("startup", harness.ctx)
+
+    expect(latestBinding(harness.appended)).toMatchObject({
+      state: "attaching",
+      managed: false,
+      sandboxId: targetId,
+    })
+    expect(provider.connect).toHaveBeenCalledWith(targetId, {
+      signal: undefined,
+    })
+    expect(provider.connect).not.toHaveBeenCalledWith(SANDBOX_EXISTING_ID, {
+      signal: undefined,
+    })
+    await expect(lifecycle.requireSandbox(harness.ctx)).rejects.toThrow(
+      failure.message,
+    )
+    expect(provider.connect.mock.calls.map(([id]) => id)).toEqual([
+      targetId,
+      targetId,
+    ])
+  })
+
+  it("does not retain a restored sandbox when an explicit target is invalid", async () => {
+    const invalidId = "../../host/path"
+    const binding = makeBinding({ state: "paused" })
+    const harness = makeHarness({
+      binding,
+      flags: { "superserve-sandbox": invalidId },
+    })
+    const provider = makeProvider()
+    const lifecycle = makeLifecycle(
+      harness.pi,
+      provider.provider,
+      makeBootstrap(),
+    )
+
+    await lifecycle.start("startup", harness.ctx)
+
+    expect(lifecycle.getBinding()).toBeUndefined()
+    expect(provider.connect).not.toHaveBeenCalled()
+    await expect(lifecycle.requireSandbox(harness.ctx)).rejects.toThrow(
+      "--superserve-sandbox must be a valid Superserve sandbox ID",
+    )
+  })
+
+  it("creates a distinct sandbox for a fork", async () => {
+    const oldBinding = makeBinding({ ownerSessionId: "session-parent" })
+    const harness = makeHarness({
+      binding: oldBinding,
+      flags: { superserve: true },
+      sessionId: "session-fork",
+    })
+    const created = makeSandbox(SANDBOX_FORK_ID)
+    const provider = makeProvider(created.handle)
+    const bootstrap = makeBootstrap()
+    const lifecycle = makeLifecycle(harness.pi, provider.provider, bootstrap, [
+      "client-fork",
+      "binding-fork",
+    ])
+
+    await lifecycle.start("fork", harness.ctx)
+
+    expect(provider.connect).not.toHaveBeenCalled()
+    expect(provider.create).toHaveBeenCalledOnce()
+    expect(provider.create.mock.calls[0]?.[0].metadata).toEqual({
+      "created-by": CREATED_BY,
+      "pi-client-id": "client-fork",
+      "pi-session-id": "session-fork",
+      "pi-binding-id": "binding-fork",
+      "entry-version": String(SESSION_ENTRY_VERSION),
+    })
+    expect(latestBinding(harness.appended)).toMatchObject({
+      ownerSessionId: "session-fork",
+      sandboxId: SANDBOX_FORK_ID,
+      bindingId: "binding-fork",
+    })
+    expect(latestBinding(harness.appended).sandboxId).not.toBe(
+      oldBinding.sandboxId,
+    )
+  })
+
+  it("replaces a persisted sandbox only when connect returns 404", async () => {
+    const binding = makeBinding({ state: "active" })
+    const harness = makeHarness({ binding, flags: { superserve: true } })
+    const replacement = makeSandbox(SANDBOX_REPLACEMENT_ID)
+    const provider = makeProvider(replacement.handle)
+    provider.connect.mockRejectedValue(new NotFoundError("sandbox gone"))
+    const bootstrap = makeBootstrap()
+    const lifecycle = makeLifecycle(harness.pi, provider.provider, bootstrap, [
+      "client-replacement",
+      "binding-replacement",
+    ])
+
+    await lifecycle.start("startup", harness.ctx)
+
+    expect(provider.connect).toHaveBeenCalledOnce()
+    expect(provider.create).toHaveBeenCalledOnce()
+    expect(appendedStates(harness.appended)).toEqual([
+      "missing",
+      "provisioning",
+      "active",
+    ])
+    expect(latestBinding(harness.appended)).toMatchObject({
+      sandboxId: SANDBOX_REPLACEMENT_ID,
+      state: "active",
+    })
+    expect(lifecycle.getActive()?.sandbox.id).toBe(SANDBOX_REPLACEMENT_ID)
+  })
+
+  it.each([
+    ["transient", new Error("temporary control-plane failure")],
+    ["authentication", new AuthenticationError("bad API key")],
+  ])(
+    "fails closed on a %s connect error without creating a duplicate",
+    async (_label, error) => {
+      const binding = makeBinding({ state: "paused" })
+      const harness = makeHarness({ binding, flags: { superserve: true } })
+      const provider = makeProvider()
+      provider.connect.mockRejectedValue(error)
+      const bootstrap = makeBootstrap()
+      const lifecycle = makeLifecycle(harness.pi, provider.provider, bootstrap)
+
+      await lifecycle.start("startup", harness.ctx)
+
+      expect(lifecycle.isEnabled()).toBe(true)
+      expect(lifecycle.getActive()).toBeUndefined()
+      expect(lifecycle.getBinding()).toEqual(binding)
+      expect(provider.create).not.toHaveBeenCalled()
+      expect(provider.list).not.toHaveBeenCalled()
+      expect(bootstrap).not.toHaveBeenCalled()
+      await expect(lifecycle.requireSandbox(harness.ctx)).rejects.toThrow(
+        error.message,
+      )
+      expect(provider.create).not.toHaveBeenCalled()
+    },
+  )
+
+  it("recovers a provisioning binding and removes duplicate sandboxes using exact metadata", async () => {
+    const binding = makeBinding({
+      state: "provisioning",
+      sandboxId: undefined,
+      guestHome: undefined,
+    })
+    const harness = makeHarness({ binding, flags: { superserve: true } })
+    const selectedId = sandboxId(10)
+    const selected = makeSandbox(selectedId)
+    const provider = makeProvider(undefined, selected.handle)
+    const metadata = {
+      "created-by": CREATED_BY,
+      "pi-client-id": binding.clientId,
+      "pi-session-id": binding.ownerSessionId,
+      "pi-binding-id": binding.bindingId,
+      "entry-version": String(SESSION_ENTRY_VERSION),
+    }
+    provider.list.mockResolvedValue([
+      makeSandboxInfo(
+        sandboxId(90),
+        new Date("2026-07-16T01:00:00.000Z"),
+        metadata,
+      ),
+      makeSandboxInfo(
+        selectedId,
+        new Date("2026-07-16T01:00:00.000Z"),
+        metadata,
+      ),
+      makeSandboxInfo(
+        sandboxId(50),
+        new Date("2026-07-16T02:00:00.000Z"),
+        metadata,
+      ),
+    ])
+    const bootstrap = makeBootstrap()
+    const lifecycle = makeLifecycle(harness.pi, provider.provider, bootstrap)
+
+    await lifecycle.start("startup", harness.ctx)
+
+    expect(provider.list).toHaveBeenCalledOnce()
+    expect(provider.list).toHaveBeenCalledWith({
+      metadata,
+      signal: undefined,
+    })
+    expect(provider.killById).toHaveBeenCalledTimes(2)
+    expect(provider.killById).toHaveBeenNthCalledWith(1, sandboxId(90), {
+      signal: undefined,
+    })
+    expect(provider.killById).toHaveBeenNthCalledWith(2, sandboxId(50), {
+      signal: undefined,
+    })
+    expect(provider.connect).toHaveBeenCalledWith(selectedId, {
+      signal: undefined,
+    })
+    expect(provider.create).not.toHaveBeenCalled()
+    expect(bootstrap).toHaveBeenCalledWith(selected.handle, {
+      localCwd: LOCAL_CWD,
+      sync: "none",
+      uploadWorkspace: false,
+      signal: undefined,
+    })
+    expect(latestBinding(harness.appended)).toMatchObject({
+      sandboxId: selectedId,
+      state: "active",
+    })
+  })
+
+  it("rejects invalid sandbox IDs at flag, command, and session boundaries", async () => {
+    const invalidId = "../../host/path"
+    const invalidBinding = makeBinding({ sandboxId: invalidId })
+    expect(parseBinding(invalidBinding)).toBeUndefined()
+
+    const persistedHarness = makeHarness({
+      binding: invalidBinding,
+      flags: { superserve: true },
+    })
+    const persistedProvider = makeProvider()
+    const persistedBootstrap = makeBootstrap()
+    const persistedLifecycle = makeLifecycle(
+      persistedHarness.pi,
+      persistedProvider.provider,
+      persistedBootstrap,
+    )
+    await persistedLifecycle.start("resume", persistedHarness.ctx)
+
+    expect(persistedLifecycle.isEnabled()).toBe(true)
+    expect(persistedProvider.connect).not.toHaveBeenCalled()
+    expect(persistedProvider.create).not.toHaveBeenCalled()
+    await expect(
+      persistedLifecycle.requireSandbox(persistedHarness.ctx),
+    ).rejects.toThrow("Persisted Superserve binding is invalid")
+
+    const flagHarness = makeHarness({
+      flags: { "superserve-sandbox": invalidId },
+    })
+    const flagProvider = makeProvider()
+    const flagLifecycle = makeLifecycle(
+      flagHarness.pi,
+      flagProvider.provider,
+      makeBootstrap(),
+    )
+    await flagLifecycle.start("startup", flagHarness.ctx)
+    expect(flagProvider.connect).not.toHaveBeenCalled()
+    await expect(flagLifecycle.requireSandbox(flagHarness.ctx)).rejects.toThrow(
+      "--superserve-sandbox must be a valid Superserve sandbox ID",
+    )
+
+    const commandHarness = makeHarness()
+    const commandProvider = makeProvider()
+    const commandLifecycle = makeLifecycle(
+      commandHarness.pi,
+      commandProvider.provider,
+      makeBootstrap(),
+    )
+    await expect(
+      commandLifecycle.connect(invalidId, commandHarness.ctx),
+    ).rejects.toThrow(
+      "/superserve connect must be a valid Superserve sandbox ID",
+    )
+    expect(commandLifecycle.isEnabled()).toBe(true)
+    expect(commandProvider.connect).not.toHaveBeenCalled()
+  })
+
+  it("accepts equivalent uppercase, bare, and region-prefixed sandbox identities", async () => {
+    const uppercaseBareId = "ABCDEF12-3456-4ABC-8DEF-ABCDEF123456"
+    const providerId = "sb-usw-abcdef12-3456-4abc-8def-abcdef123456"
+    const harness = makeHarness()
+    const connected = makeSandbox(providerId)
+    const provider = makeProvider(undefined, connected.handle)
+    const bootstrap = makeBootstrap()
+    const lifecycle = makeLifecycle(harness.pi, provider.provider, bootstrap)
+
+    await lifecycle.connect(uppercaseBareId, harness.ctx)
+
+    expect(provider.connect).toHaveBeenCalledWith(uppercaseBareId, {
+      signal: undefined,
+    })
+    expect(lifecycle.getBinding()).toMatchObject({
+      sandboxId: providerId,
+      state: "active",
+    })
+    expect(appendedStates(harness.appended)).toEqual(["attaching", "active"])
+  })
+
+  it("treats bare and tagged forms as the same explicit restored sandbox", async () => {
+    const bareId = "ABCDEF12-3456-4ABC-8DEF-ABCDEF123456"
+    const providerId = "sb-use-abcdef12-3456-4abc-8def-abcdef123456"
+    const binding = makeBinding({ sandboxId: providerId })
+    const harness = makeHarness({
+      binding,
+      flags: { "superserve-sandbox": bareId },
+    })
+    const connected = makeSandbox(providerId)
+    const provider = makeProvider(undefined, connected.handle)
+    const lifecycle = makeLifecycle(
+      harness.pi,
+      provider.provider,
+      makeBootstrap(),
+    )
+
+    await lifecycle.start("startup", harness.ctx)
+
+    expect(provider.connect).toHaveBeenCalledWith(providerId, {
+      signal: undefined,
+    })
+    expect(appendedStates(harness.appended)).toEqual(["active"])
+    expect(latestBinding(harness.appended).sandboxId).toBe(providerId)
+  })
+
+  it("rejects uppercase prefixes and different provider UUID identities", async () => {
+    const requestedId = sandboxId(22)
+    const differentId = sandboxId(23)
+    expect(
+      parseBinding(
+        makeBinding({ sandboxId: `sb-usw-${requestedId.toUpperCase()}` }),
+      ),
+    ).toBeDefined()
+    expect(
+      parseBinding(
+        makeBinding({ sandboxId: `SB-usw-${requestedId.toUpperCase()}` }),
+      ),
+    ).toBeUndefined()
+    expect(
+      parseBinding(
+        makeBinding({ sandboxId: `sb-USW-${requestedId.toUpperCase()}` }),
+      ),
+    ).toBeUndefined()
+
+    const harness = makeHarness()
+    const returned = makeSandbox(differentId)
+    const provider = makeProvider(undefined, returned.handle)
+    const bootstrap = makeBootstrap()
+    const lifecycle = makeLifecycle(harness.pi, provider.provider, bootstrap)
+
+    await expect(lifecycle.connect(requestedId, harness.ctx)).rejects.toThrow(
+      `returned sandbox ${differentId}, expected ${requestedId}`,
+    )
+    expect(bootstrap).not.toHaveBeenCalled()
+    expect(latestBinding(harness.appended)).toMatchObject({
+      state: "attaching",
+      sandboxId: requestedId,
+    })
+  })
+
+  it("rejects an invalid sandbox ID returned by the provider", async () => {
+    const harness = makeHarness({ flags: { superserve: true } })
+    const invalidSandbox = makeSandbox("not-a-sandbox-uuid")
+    const provider = makeProvider(invalidSandbox.handle)
+    const bootstrap = makeBootstrap()
+    const lifecycle = makeLifecycle(harness.pi, provider.provider, bootstrap)
+
+    await lifecycle.start("startup", harness.ctx)
+
+    expect(invalidSandbox.kill).toHaveBeenCalledOnce()
+    expect(bootstrap).not.toHaveBeenCalled()
+    expect(appendedStates(harness.appended)).toEqual([
+      "provisioning",
+      "missing",
+    ])
+    expect(latestBinding(harness.appended).sandboxId).toBeUndefined()
+    expect(lifecycle.getActive()).toBeUndefined()
+  })
+
+  it("creates nested private downloads under the current cwd", async () => {
+    const currentCwd = await mkdtemp(
+      path.join(tmpdir(), "superserve-pi-lifecycle-"),
+    )
+    const outside = await mkdtemp(path.join(tmpdir(), "superserve-pi-outside-"))
+    temporaryDirectories.push(currentCwd, outside)
+    const archive = Buffer.from("PK\u0003\u0004sandbox archive")
+    const downloadDir = vi.fn(async () => archive)
+    const connected = makeSandbox(SANDBOX_EXISTING_ID)
+    const connectedHandle = {
+      ...connected.handle,
+      files: { downloadDir } as unknown as SandboxHandle["files"],
+    }
+    const binding = makeBinding()
+    const harness = makeHarness({
+      binding,
+      cwd: currentCwd,
+      flags: { superserve: true },
+    })
+    const provider = makeProvider(undefined, connectedHandle)
+    const lifecycle = makeLifecycle(
+      harness.pi,
+      provider.provider,
+      makeBootstrap(),
+    )
+    await lifecycle.start("resume", harness.ctx)
+
+    const result = await lifecycle.downloadWorkspace(
+      "recovery/workspace.zip",
+      harness.ctx,
+    )
+
+    const outputPath = path.join(currentCwd, "recovery", "workspace.zip")
+    expect(result).toEqual({ path: outputPath, bytes: archive.byteLength })
+    await expect(readFile(outputPath)).resolves.toEqual(archive)
+    expect((await stat(outputPath)).mode & 0o777).toBe(0o600)
+    await expect(
+      lifecycle.downloadWorkspace("../outside.zip", harness.ctx),
+    ).rejects.toThrow("must stay inside the current cwd")
+    await symlink(outside, path.join(currentCwd, "linked"))
+    await expect(
+      lifecycle.downloadWorkspace(
+        "linked/must-not-exist/workspace.zip",
+        harness.ctx,
+      ),
+    ).rejects.toThrow("must not contain symlinks")
+    await expect(stat(path.join(outside, "must-not-exist"))).rejects.toThrow()
+    expect(downloadDir).toHaveBeenCalledOnce()
+  })
+
+  it("pauses a managed sandbox on persistent-session shutdown", async () => {
+    const binding = makeBinding({ state: "active" })
+    const harness = makeHarness({
+      binding,
+      flags: { superserve: true },
+      persistent: true,
+    })
+    const connected = makeSandbox(SANDBOX_EXISTING_ID)
+    const provider = makeProvider(undefined, connected.handle)
+    const bootstrap = makeBootstrap()
+    const lifecycle = makeLifecycle(harness.pi, provider.provider, bootstrap)
+    await lifecycle.start("startup", harness.ctx)
+
+    await lifecycle.shutdown("quit", harness.ctx)
+
+    expect(connected.pause).toHaveBeenCalledOnce()
+    expect(connected.kill).not.toHaveBeenCalled()
+    expect(latestBinding(harness.appended).state).toBe("paused")
+  })
+
+  it("refuses kill without an already enabled and opted-in lifecycle", async () => {
+    const dormantHarness = makeHarness()
+    const dormantProvider = makeProvider()
+    const dormantLifecycle = makeLifecycle(
+      dormantHarness.pi,
+      dormantProvider.provider,
+      makeBootstrap(),
+    )
+
+    await expect(dormantLifecycle.kill(dormantHarness.ctx)).rejects.toThrow(
+      "not enabled for this invocation",
+    )
+    expect(dormantHarness.setActiveTools).not.toHaveBeenCalled()
+    expect(dormantProvider.killById).not.toHaveBeenCalled()
+
+    const persistedHarness = makeHarness({ binding: makeBinding() })
+    const persistedProvider = makeProvider()
+    const persistedLifecycle = makeLifecycle(
+      persistedHarness.pi,
+      persistedProvider.provider,
+      makeBootstrap(),
+    )
+    await persistedLifecycle.start("startup", persistedHarness.ctx)
+
+    await expect(persistedLifecycle.kill(persistedHarness.ctx)).rejects.toThrow(
+      "not enabled for this invocation",
+    )
+    expect(persistedProvider.killById).not.toHaveBeenCalled()
+  })
+
+  it("kills a managed sandbox on ephemeral-session shutdown", async () => {
+    const harness = makeHarness({
+      flags: { superserve: true },
+      persistent: false,
+    })
+    const created = makeSandbox(SANDBOX_EPHEMERAL_ID)
+    const provider = makeProvider(created.handle)
+    const bootstrap = makeBootstrap()
+    const lifecycle = makeLifecycle(harness.pi, provider.provider, bootstrap)
+    await lifecycle.start("startup", harness.ctx)
+
+    await lifecycle.shutdown("quit", harness.ctx)
+
+    expect(created.kill).toHaveBeenCalledOnce()
+    expect(created.pause).not.toHaveBeenCalled()
+    expect(latestBinding(harness.appended).state).toBe("destroyed")
+  })
+
+  it("persists a destroyed tombstone and never reconnects it implicitly", async () => {
+    const binding = makeBinding({ state: "paused" })
+    const harness = makeHarness({ binding, flags: { superserve: true } })
+    const connected = makeSandbox(SANDBOX_EXISTING_ID)
+    const provider = makeProvider(undefined, connected.handle)
+    const bootstrap = makeBootstrap()
+    const lifecycle = makeLifecycle(harness.pi, provider.provider, bootstrap)
+    await lifecycle.start("startup", harness.ctx)
+
+    await lifecycle.kill(harness.ctx)
+
+    expect(connected.kill).toHaveBeenCalledOnce()
+    expect(latestBinding(harness.appended)).toMatchObject({
+      sandboxId: SANDBOX_EXISTING_ID,
+      state: "destroyed",
+    })
+    const replacementLifecycle = makeLifecycle(
+      harness.pi,
+      provider.provider,
+      bootstrap,
+    )
+    await replacementLifecycle.start("startup", harness.ctx)
+
+    expect(provider.connect).toHaveBeenCalledTimes(1)
+    expect(provider.create).not.toHaveBeenCalled()
+    expect(replacementLifecycle.getActive()).toBeUndefined()
+    await expect(
+      replacementLifecycle.requireSandbox(harness.ctx),
+    ).rejects.toThrow("Superserve sandbox was destroyed")
+  })
+})

--- a/packages/pi/tests/tools.test.ts
+++ b/packages/pi/tests/tools.test.ts
@@ -1,0 +1,898 @@
+import { Buffer } from "node:buffer"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+
+import {
+  DEFAULT_MAX_BYTES,
+  type ExtensionAPI,
+  type ExtensionContext,
+  type ToolDefinition,
+} from "@earendil-works/pi-coding-agent"
+import { TimeoutError } from "@superserve/sdk"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { callBridge } from "../src/bridge.js"
+import {
+  BRIDGE_PATH,
+  GUEST_WORKSPACE,
+  MAX_BRIDGE_OUTPUT_BYTES,
+  MAX_COMMAND_OUTPUT_BYTES,
+  MAX_COMMAND_TIMEOUT_SECONDS,
+  MAX_FILE_READ_BYTES,
+  ROUTED_TOOL_NAMES,
+} from "../src/constants.js"
+import { createSuperservePiExtension } from "../src/index.js"
+import { SandboxLifecycle } from "../src/lifecycle.js"
+import {
+  createSandboxBashOperations,
+  createSandboxToolRegistrar,
+} from "../src/tools.js"
+import type {
+  ActiveSandbox,
+  SandboxBinding,
+  SandboxHandle,
+  SandboxProvider,
+} from "../src/types.js"
+
+const HOST_CWD = "/Users/developer/project"
+const GUEST_HOME = "/home/sandbox"
+const SANDBOX_ID = "22222222-2222-4222-8222-222222222222"
+
+interface ToolResult {
+  content: Array<{
+    type: string
+    text?: string
+    data?: string
+    mimeType?: string
+  }>
+  details?: unknown
+}
+
+interface CallableTool {
+  execute(
+    toolCallId: string,
+    params: Record<string, unknown>,
+    signal: AbortSignal | undefined,
+    onUpdate: undefined,
+    ctx: ExtensionContext,
+  ): Promise<ToolResult>
+}
+
+interface EventHandler {
+  (event: unknown, ctx: ExtensionContext): unknown | Promise<unknown>
+}
+
+interface CommandOptions {
+  cwd?: string
+  env?: Record<string, string>
+  timeoutMs?: number
+  signal?: AbortSignal
+  maxOutputBytes?: number
+}
+
+interface BridgeRequest {
+  action: string
+  command: string
+  input: Record<string, unknown>
+  options: CommandOptions
+}
+
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  )
+})
+
+function createPiHarness(initialFlags: Record<string, boolean | string> = {}) {
+  const handlers = new Map<string, EventHandler[]>()
+  const tools = new Map<string, ToolDefinition>()
+  const commands = new Map<string, Record<string, unknown>>()
+  const flags = new Map<string, boolean | string>(Object.entries(initialFlags))
+  const entries: Array<{ customType: string; data: unknown }> = []
+  const activeTools: string[][] = []
+  const sourceInfo = {
+    path: "/test/superserve-pi.js",
+    source: "explicit",
+    scope: "global",
+    origin: "test",
+    baseDir: "/test",
+  }
+
+  const api = {
+    on: (event: string, handler: EventHandler) => {
+      const registered = handlers.get(event) ?? []
+      registered.push(handler)
+      handlers.set(event, registered)
+    },
+    registerTool: (tool: ToolDefinition) => {
+      tools.set(tool.name, tool)
+    },
+    registerCommand: (name: string, command: Record<string, unknown>) => {
+      commands.set(name, command)
+    },
+    getAllTools: () => {
+      const registered = []
+      for (const tool of tools.values()) {
+        registered.push(Object.assign({}, tool, { sourceInfo }))
+      }
+      return registered
+    },
+    getCommands: () => {
+      const registered = []
+      for (const [name, command] of commands) {
+        registered.push(Object.assign({}, command, { name, sourceInfo }))
+      }
+      return registered
+    },
+    registerFlag: (name: string, options: { default?: boolean | string }) => {
+      if (!flags.has(name) && options.default !== undefined) {
+        flags.set(name, options.default)
+      }
+    },
+    getFlag: (name: string) => flags.get(name),
+    appendEntry: (customType: string, data: unknown) => {
+      entries.push({ customType, data })
+    },
+    setActiveTools: (names: string[]) => {
+      activeTools.push(names)
+    },
+  } as unknown as ExtensionAPI
+
+  return {
+    api,
+    activeTools,
+    commands,
+    entries,
+    flags,
+    handlers,
+    tools,
+    async emit(
+      event: string,
+      payload: unknown,
+      ctx: ExtensionContext,
+    ): Promise<unknown> {
+      let result: unknown
+      for (const handler of handlers.get(event) ?? []) {
+        const next = await handler(payload, ctx)
+        if (next !== undefined) result = next
+      }
+      return result
+    },
+    tool(name: string): CallableTool {
+      const tool = tools.get(name)
+      if (!tool) throw new Error(`Tool not registered: ${name}`)
+      return tool as unknown as CallableTool
+    },
+  }
+}
+
+function createContext(
+  options: {
+    cwd?: string
+    persistent?: boolean
+    sessionId?: string
+  } = {},
+): ExtensionContext {
+  const cwd = options.cwd ?? HOST_CWD
+  return {
+    cwd,
+    hasUI: false,
+    mode: "print",
+    model: undefined,
+    signal: undefined,
+    sessionManager: {
+      getSessionId: () => options.sessionId ?? "session-1",
+      getSessionFile: () =>
+        options.persistent === false ? undefined : "/tmp/session.jsonl",
+      getBranch: () => [],
+    },
+    ui: {},
+  } as unknown as ExtensionContext
+}
+
+function createSandboxHarness() {
+  const bridgeRequests: BridgeRequest[] = []
+  const files = new Map<string, Uint8Array>([
+    ["/workspace/src/read.ts", Buffer.from("export const read = true\n")],
+    ["/workspace/src/edit.ts", Buffer.from("const state = 'old'\n")],
+    [
+      "/workspace/image.png",
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    ],
+  ])
+
+  const commandsRun = vi.fn(
+    async (command: string, options: CommandOptions = {}) => {
+      if (command.startsWith(`node ${BRIDGE_PATH} `)) {
+        const action = command.slice(`node ${BRIDGE_PATH} `.length)
+        const encoded = options.env?.SUPERSERVE_PI_INPUT
+        if (!encoded) throw new Error("Missing bridge input")
+        const input = JSON.parse(
+          Buffer.from(encoded, "base64url").toString("utf8"),
+        ) as Record<string, unknown>
+        bridgeRequests.push({ action, command, input, options })
+
+        let value: unknown
+        switch (action) {
+          case "access":
+            value = null
+            break
+          case "exists":
+            value = true
+            break
+          case "list":
+            value = {
+              exists: true,
+              isDirectory: true,
+              entries: [
+                { name: "nested", isDirectory: true },
+                { name: "read.ts", isDirectory: false },
+              ],
+            }
+            break
+          case "glob":
+            value = ["/workspace/src/read.ts", "/workspace/src/edit.ts"]
+            break
+          case "grep":
+            value = {
+              output: "src/read.ts:1: export const read = true",
+              matchLimitReached: false,
+              linesTruncated: false,
+              responseLimitReached: false,
+            }
+            break
+          case "home":
+            value = GUEST_HOME
+            break
+          case "stat":
+            value = { isDirectory: false }
+            break
+          case "read":
+            value =
+              input.path === "/workspace/image.png"
+                ? {
+                    kind: "image",
+                    mimeType: "image/png",
+                    size: files.get("/workspace/image.png")?.byteLength,
+                  }
+                : input.path === "/workspace/large.txt"
+                  ? {
+                      kind: "text",
+                      content:
+                        "selected 900000\nselected 900001\nselected 900002",
+                      contentLimitReached: false,
+                      firstLineBytes: 15,
+                      selectedLines: 3,
+                      totalLines: 1_000_000,
+                    }
+                  : {
+                      kind: "text",
+                      content: "export const read = true\n",
+                      contentLimitReached: false,
+                      firstLineBytes: 24,
+                      selectedLines: 2,
+                      totalLines: 2,
+                    }
+            break
+          default:
+            throw new Error(`Unexpected bridge action: ${action}`)
+        }
+        return {
+          stdout: JSON.stringify({ ok: true, value }),
+          stderr: "",
+          exitCode: 0,
+        }
+      }
+
+      return {
+        stdout: "remote stdout\n",
+        stderr: "remote stderr\n",
+        exitCode: 0,
+      }
+    },
+  )
+  const filesRead = vi.fn(async (filePath: string) => {
+    const content = files.get(filePath)
+    if (!content) throw new Error(`Missing fake file: ${filePath}`)
+    return content
+  })
+  const filesWrite = vi.fn(
+    async (filePath: string, content: string | Uint8Array) => {
+      files.set(
+        filePath,
+        typeof content === "string" ? Buffer.from(content) : content,
+      )
+    },
+  )
+  const pause = vi.fn(async () => {})
+  const kill = vi.fn(async () => {})
+  const resume = vi.fn(async () => {})
+
+  const sandbox = {
+    id: SANDBOX_ID,
+    name: "pi-project",
+    status: "running",
+    metadata: {},
+    commands: { run: commandsRun },
+    files: { read: filesRead, write: filesWrite },
+    getInfo: vi.fn(),
+    pause,
+    resume,
+    kill,
+  } as unknown as SandboxHandle
+
+  return {
+    bridgeRequests,
+    commandsRun,
+    files,
+    filesRead,
+    filesWrite,
+    kill,
+    pause,
+    sandbox,
+  }
+}
+
+function createProvider(sandbox: SandboxHandle): SandboxProvider {
+  return {
+    create: vi.fn(async () => sandbox),
+    connect: vi.fn(async () => sandbox),
+    list: vi.fn(async () => []),
+    killById: vi.fn(async () => {}),
+  }
+}
+
+function text(result: ToolResult): string {
+  return result.content
+    .filter((item) => item.type === "text")
+    .map((item) => item.text ?? "")
+    .join("\n")
+}
+
+function fakeBinding(): SandboxBinding {
+  return {
+    version: 1,
+    ownerSessionId: "session-1",
+    clientId: "client-1",
+    bindingId: "binding-1",
+    state: "active",
+    managed: true,
+    sandboxId: SANDBOX_ID,
+    workspacePath: GUEST_WORKSPACE,
+    guestHome: GUEST_HOME,
+    template: "superserve/node-22",
+    timeoutSeconds: 3_600,
+    autoDeleteSeconds: 86_400,
+    sync: "tracked",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  }
+}
+
+describe("Superserve Pi tools", () => {
+  it("registers and routes all seven built-in tools into one sandbox", async () => {
+    const pi = createPiHarness({ superserve: true })
+    const remote = createSandboxHarness()
+    const provider = createProvider(remote.sandbox)
+    const bootstrap = vi.fn(async () => ({
+      guestHome: GUEST_HOME,
+      syncedFiles: 0,
+      syncedBytes: 0,
+    }))
+    createSuperservePiExtension({
+      localCwd: HOST_CWD,
+      provider,
+      bootstrap,
+      randomId: () => "fixed-id",
+    })(pi.api)
+    const ctx = createContext()
+
+    expect([...pi.tools]).toEqual([])
+    await pi.emit("session_start", { reason: "startup" }, ctx)
+    expect([...pi.tools.keys()].toSorted()).toEqual(
+      [...ROUTED_TOOL_NAMES].toSorted(),
+    )
+    expect(pi.activeTools.at(-1)).toEqual([...ROUTED_TOOL_NAMES])
+
+    const readResult = await pi
+      .tool("read")
+      .execute(
+        "read-1",
+        { path: `${HOST_CWD}/src/read.ts` },
+        undefined,
+        undefined,
+        ctx,
+      )
+    expect(text(readResult)).toContain("export const read = true")
+
+    await pi
+      .tool("write")
+      .execute(
+        "write-1",
+        { path: "~/notes.txt", content: "sandbox only" },
+        undefined,
+        undefined,
+        ctx,
+      )
+    expect(remote.files.get(`${GUEST_HOME}/notes.txt`)).toEqual(
+      Buffer.from("sandbox only"),
+    )
+
+    await pi.tool("edit").execute(
+      "edit-1",
+      {
+        path: "src/edit.ts",
+        edits: [{ oldText: "'old'", newText: "'new'" }],
+      },
+      undefined,
+      undefined,
+      ctx,
+    )
+    expect(remote.files.get("/workspace/src/edit.ts")?.toString()).toBe(
+      "const state = 'new'\n",
+    )
+
+    const bashResult = await pi
+      .tool("bash")
+      .execute(
+        "bash-1",
+        { command: "pwd", timeout: 30 },
+        undefined,
+        undefined,
+        ctx,
+      )
+    expect(text(bashResult)).toContain("remote stdout")
+
+    const lsResult = await pi
+      .tool("ls")
+      .execute("ls-1", { path: HOST_CWD }, undefined, undefined, ctx)
+    expect(text(lsResult)).toContain("nested/")
+    expect(text(lsResult)).toContain("read.ts")
+
+    const findResult = await pi
+      .tool("find")
+      .execute(
+        "find-1",
+        { path: GUEST_WORKSPACE, pattern: "**/*.ts" },
+        undefined,
+        undefined,
+        ctx,
+      )
+    expect(text(findResult)).toBe("src/read.ts\nsrc/edit.ts")
+
+    const grepResult = await pi
+      .tool("grep")
+      .execute(
+        "grep-1",
+        { path: HOST_CWD, pattern: "read" },
+        undefined,
+        undefined,
+        ctx,
+      )
+    expect(text(grepResult)).toBe("src/read.ts:1: export const read = true")
+
+    expect(remote.filesRead).toHaveBeenCalledWith(
+      "/workspace/src/edit.ts",
+      expect.objectContaining({ maxBytes: MAX_FILE_READ_BYTES }),
+    )
+    expect(remote.filesRead).not.toHaveBeenCalledWith(
+      "/workspace/src/read.ts",
+      expect.anything(),
+    )
+    expect(remote.bridgeRequests).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: "read",
+          input: {
+            path: "/workspace/src/read.ts",
+            offset: 1,
+            limit: undefined,
+          },
+        }),
+        expect.objectContaining({
+          action: "access",
+          input: { path: "/workspace/src/edit.ts" },
+        }),
+        expect.objectContaining({
+          action: "list",
+          input: { path: GUEST_WORKSPACE, limit: 501 },
+        }),
+        expect.objectContaining({
+          action: "glob",
+          input: expect.objectContaining({ path: GUEST_WORKSPACE }),
+        }),
+        expect.objectContaining({
+          action: "grep",
+          input: expect.objectContaining({ path: GUEST_WORKSPACE }),
+        }),
+      ]),
+    )
+
+    const routedEvents = await Promise.all(
+      ROUTED_TOOL_NAMES.map((toolName) =>
+        pi.emit(
+          "tool_call",
+          {
+            type: "tool_call",
+            toolCallId: `${toolName}-call`,
+            toolName,
+            input: {},
+          },
+          ctx,
+        ),
+      ),
+    )
+    expect(routedEvents).toEqual(ROUTED_TOOL_NAMES.map(() => undefined))
+    await expect(
+      pi.emit(
+        "tool_call",
+        {
+          type: "tool_call",
+          toolCallId: "host-tool-call",
+          toolName: "host_tool",
+          input: {},
+        },
+        ctx,
+      ),
+    ).resolves.toMatchObject({ block: true })
+  })
+
+  it("fails closed for all directly registered tools while lifecycle is disabled", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "superserve-pi-test-"))
+    temporaryDirectories.push(directory)
+    const existing = path.join(directory, "existing.txt")
+    const newFile = path.join(directory, "new.txt")
+    const shellMarker = path.join(directory, "shell-ran")
+    await writeFile(existing, "unchanged\n")
+
+    const pi = createPiHarness()
+    const remote = createSandboxHarness()
+    const provider = createProvider(remote.sandbox)
+    const lifecycle = new SandboxLifecycle(pi.api, HOST_CWD, { provider })
+    createSandboxToolRegistrar(pi.api, lifecycle)()
+    const ctx = createContext({ cwd: directory })
+
+    const calls: Array<[string, Record<string, unknown>]> = [
+      ["read", { path: existing }],
+      ["write", { path: newFile, content: "must not be written" }],
+      [
+        "edit",
+        {
+          path: existing,
+          edits: [{ oldText: "unchanged", newText: "changed" }],
+        },
+      ],
+      ["bash", { command: `touch ${shellMarker}` }],
+      ["grep", { path: directory, pattern: "unchanged" }],
+      ["find", { path: directory, pattern: "*.txt" }],
+      ["ls", { path: directory }],
+    ]
+    for (const [toolName, params] of calls) {
+      await expect(
+        pi
+          .tool(toolName)
+          .execute(`${toolName}-disabled`, params, undefined, undefined, ctx),
+      ).rejects.toThrow("Superserve sandbox mode is not enabled")
+    }
+
+    expect(await readFile(existing, "utf8")).toBe("unchanged\n")
+    await expect(readFile(newFile)).rejects.toThrow()
+    await expect(readFile(shellMarker)).rejects.toThrow()
+    expect(provider.create).not.toHaveBeenCalled()
+    expect(provider.connect).not.toHaveBeenCalled()
+    expect(remote.commandsRun).not.toHaveBeenCalled()
+    expect(remote.filesRead).not.toHaveBeenCalled()
+    expect(remote.filesWrite).not.toHaveBeenCalled()
+  })
+
+  it("does not resolve remote read paths using host filesystem existence", async () => {
+    const project = await mkdtemp(path.join(tmpdir(), "superserve-pi-project-"))
+    const outside = await mkdtemp(path.join(tmpdir(), "superserve-pi-probe-"))
+    temporaryDirectories.push(project, outside)
+    const requestedPath = path.join(outside, "Capture 1.00 PM.txt")
+    const hostOnlyVariant = requestedPath.replace(" PM", "\u202fPM")
+    await writeFile(hostOnlyVariant, "host-only variant\n")
+
+    const pi = createPiHarness({ superserve: true })
+    const remote = createSandboxHarness()
+    createSuperservePiExtension({
+      localCwd: project,
+      provider: createProvider(remote.sandbox),
+      bootstrap: vi.fn(async () => ({
+        guestHome: GUEST_HOME,
+        syncedFiles: 0,
+        syncedBytes: 0,
+      })),
+      randomId: () => "fixed-id",
+    })(pi.api)
+    const ctx = createContext({ cwd: project })
+    await pi.emit("session_start", { reason: "startup" }, ctx)
+
+    await pi
+      .tool("read")
+      .execute(
+        "read-no-host-probe",
+        { path: requestedPath },
+        undefined,
+        undefined,
+        ctx,
+      )
+
+    const request = remote.bridgeRequests.find(
+      (candidate) => candidate.action === "read",
+    )
+    expect(request?.input.path).toBe(requestedPath)
+    expect(request?.input.path).not.toBe(hostOnlyVariant)
+    expect(remote.filesRead).not.toHaveBeenCalled()
+  })
+
+  it("reads a bounded line range at a large offset without downloading the file", async () => {
+    const executionCwd = "/different/session/project"
+    const pi = createPiHarness({ superserve: true })
+    const remote = createSandboxHarness()
+    createSuperservePiExtension({
+      localCwd: HOST_CWD,
+      provider: createProvider(remote.sandbox),
+      bootstrap: vi.fn(async () => ({
+        guestHome: GUEST_HOME,
+        syncedFiles: 0,
+        syncedBytes: 0,
+      })),
+      randomId: () => "fixed-id",
+    })(pi.api)
+    const ctx = createContext({ cwd: executionCwd })
+    await pi.emit("session_start", { reason: "startup" }, ctx)
+
+    const result = await pi.tool("read").execute(
+      "read-large-offset",
+      {
+        path: `${executionCwd}/large.txt`,
+        offset: 900_000,
+        limit: 3,
+      },
+      undefined,
+      undefined,
+      ctx,
+    )
+
+    expect(text(result)).toContain("selected 900000")
+    expect(text(result)).toContain(
+      "[99998 more lines in file. Use offset=900003 to continue.]",
+    )
+    expect(remote.bridgeRequests).toContainEqual(
+      expect.objectContaining({
+        action: "read",
+        input: {
+          path: "/workspace/large.txt",
+          offset: 900_000,
+          limit: 3,
+        },
+      }),
+    )
+    expect(remote.filesRead).not.toHaveBeenCalled()
+  })
+
+  it("returns a bounded bash tail without creating a host full-output artifact", async () => {
+    const pi = createPiHarness({ superserve: true })
+    const remote = createSandboxHarness()
+    createSuperservePiExtension({
+      localCwd: HOST_CWD,
+      provider: createProvider(remote.sandbox),
+      bootstrap: vi.fn(async () => ({
+        guestHome: GUEST_HOME,
+        syncedFiles: 0,
+        syncedBytes: 0,
+      })),
+      randomId: () => "fixed-id",
+    })(pi.api)
+    const ctx = createContext()
+    await pi.emit("session_start", { reason: "startup" }, ctx)
+    remote.commandsRun.mockResolvedValueOnce({
+      stdout: "untrusted output\n".repeat(10_000),
+      stderr: "",
+      exitCode: 0,
+    })
+
+    const result = await pi
+      .tool("bash")
+      .execute(
+        "bash-bounded",
+        { command: "generate-output" },
+        undefined,
+        undefined,
+        ctx,
+      )
+
+    expect(Buffer.byteLength(text(result))).toBeLessThanOrEqual(
+      DEFAULT_MAX_BYTES,
+    )
+    expect(text(result)).toContain(
+      "Superserve command output truncated to a bounded tail",
+    )
+    expect(result.details).toBeUndefined()
+    expect(text(result)).not.toContain("Full output: /tmp/pi-bash-")
+  })
+
+  it("attaches only a bounded, magic-verified remote image", async () => {
+    const pi = createPiHarness({ superserve: true })
+    const remote = createSandboxHarness()
+    createSuperservePiExtension({
+      localCwd: HOST_CWD,
+      provider: createProvider(remote.sandbox),
+      bootstrap: vi.fn(async () => ({
+        guestHome: GUEST_HOME,
+        syncedFiles: 0,
+        syncedBytes: 0,
+      })),
+      randomId: () => "fixed-id",
+    })(pi.api)
+    const ctx = createContext()
+    await pi.emit("session_start", { reason: "startup" }, ctx)
+
+    const result = await pi
+      .tool("read")
+      .execute("read-image", { path: "image.png" }, undefined, undefined, ctx)
+
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: expect.stringContaining("Read image file [image/png]"),
+      },
+      {
+        type: "image",
+        data: Buffer.from([
+          0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+        ]).toString("base64"),
+        mimeType: "image/png",
+      },
+    ])
+    expect(remote.filesRead).toHaveBeenCalledWith("/workspace/image.png", {
+      maxBytes: MAX_FILE_READ_BYTES,
+      signal: undefined,
+    })
+  })
+
+  it("describes Superserve search ignore behavior accurately", () => {
+    const pi = createPiHarness()
+    const remote = createSandboxHarness()
+    const lifecycle = new SandboxLifecycle(pi.api, HOST_CWD, {
+      provider: createProvider(remote.sandbox),
+    })
+    createSandboxToolRegistrar(pi.api, lifecycle)()
+
+    for (const name of ["find", "grep"]) {
+      expect(pi.tools.get(name)?.description).toContain(
+        ".gitignore rules are not evaluated",
+      )
+    }
+  })
+
+  it("fails closed for every tool and user bash when sandbox setup is missing", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "superserve-pi-test-"))
+    temporaryDirectories.push(directory)
+    const existing = path.join(directory, "existing.txt")
+    const newFile = path.join(directory, "new.txt")
+    const shellMarker = path.join(directory, "shell-ran")
+    await writeFile(existing, "unchanged\n")
+
+    const pi = createPiHarness({ superserve: true })
+    const remote = createSandboxHarness()
+    const provider = createProvider(remote.sandbox)
+    const bootstrap = vi.fn(async () => {
+      throw new Error("sandbox bootstrap failed")
+    })
+    createSuperservePiExtension({
+      localCwd: directory,
+      provider,
+      bootstrap,
+      randomId: () => "fixed-id",
+    })(pi.api)
+    const ctx = createContext({ cwd: directory })
+    await pi.emit("session_start", { reason: "startup" }, ctx)
+
+    const calls: Array<[string, Record<string, unknown>]> = [
+      ["read", { path: existing }],
+      ["write", { path: newFile, content: "must not be written" }],
+      [
+        "edit",
+        {
+          path: existing,
+          edits: [{ oldText: "unchanged", newText: "changed" }],
+        },
+      ],
+      ["bash", { command: `touch ${shellMarker}` }],
+      ["grep", { path: directory, pattern: "unchanged" }],
+      ["find", { path: directory, pattern: "*.txt" }],
+      ["ls", { path: directory }],
+    ]
+    for (const [toolName, params] of calls) {
+      await expect(
+        pi
+          .tool(toolName)
+          .execute(`${toolName}-closed`, params, undefined, undefined, ctx),
+      ).rejects.toThrow(/not run on the host/)
+    }
+
+    const bashResult = (await pi.emit(
+      "user_bash",
+      {
+        type: "user_bash",
+        command: `touch ${shellMarker}`,
+        excludeFromContext: false,
+        cwd: directory,
+      },
+      ctx,
+    )) as {
+      result: { output: string; exitCode: number }
+    }
+    expect(bashResult.result.exitCode).toBe(1)
+    expect(bashResult.result.output).toContain("not run on the host")
+    expect(await readFile(existing, "utf8")).toBe("unchanged\n")
+    await expect(readFile(newFile)).rejects.toThrow()
+    await expect(readFile(shellMarker)).rejects.toThrow()
+    expect(remote.kill).toHaveBeenCalledOnce()
+    expect(remote.commandsRun).not.toHaveBeenCalled()
+    expect(remote.filesRead).not.toHaveBeenCalled()
+    expect(remote.filesWrite).not.toHaveBeenCalled()
+  })
+
+  it("omits host environment, maps host cwd, and caps command output and timeout", async () => {
+    const remote = createSandboxHarness()
+    const active: ActiveSandbox = {
+      sandbox: remote.sandbox,
+      binding: fakeBinding(),
+      guestHome: GUEST_HOME,
+    }
+    const operations = createSandboxBashOperations(active, HOST_CWD)
+    const output: string[] = []
+
+    await operations.exec("env", `${HOST_CWD}/nested`, {
+      onData: (data) => output.push(data.toString("utf8")),
+      timeout: MAX_COMMAND_TIMEOUT_SECONDS + 10_000,
+      env: { HOST_SECRET: "must-not-cross-boundary" },
+    })
+
+    const [command, options] = remote.commandsRun.mock.calls[0] ?? []
+    expect(command).toBe("env")
+    expect(options).toMatchObject({
+      cwd: "/workspace/nested",
+      timeoutMs: MAX_COMMAND_TIMEOUT_SECONDS * 1000,
+      maxOutputBytes: MAX_COMMAND_OUTPUT_BYTES,
+    })
+    expect(options).not.toHaveProperty("env")
+    expect(output).toEqual(["remote stdout\nremote stderr\n"])
+
+    remote.commandsRun.mockRejectedValueOnce(new TimeoutError())
+    await expect(
+      operations.exec("sleep forever", HOST_CWD, {
+        onData: () => {},
+        timeout: MAX_COMMAND_TIMEOUT_SECONDS + 1,
+      }),
+    ).rejects.toThrow(`timeout:${MAX_COMMAND_TIMEOUT_SECONDS}`)
+  })
+
+  it("passes bridge input through bounded environment data without shell interpolation", async () => {
+    const remote = createSandboxHarness()
+    const hostilePath = "/workspace/$(touch /tmp/escaped);'\"\nfile"
+
+    await expect(
+      callBridge<boolean>(remote.sandbox, "exists", { path: hostilePath }),
+    ).resolves.toBe(true)
+
+    expect(remote.bridgeRequests).toHaveLength(1)
+    const request = remote.bridgeRequests[0]
+    expect(request?.command).toBe(`node ${BRIDGE_PATH} exists`)
+    expect(request?.command).not.toContain(hostilePath)
+    expect(request?.input).toEqual({ path: hostilePath })
+    expect(request?.options).toMatchObject({
+      timeoutMs: 30_000,
+      maxOutputBytes: MAX_BRIDGE_OUTPUT_BYTES,
+    })
+    expect(request?.options.env?.SUPERSERVE_PI_INPUT).not.toContain(hostilePath)
+  })
+})

--- a/packages/pi/tests/workspace.test.ts
+++ b/packages/pi/tests/workspace.test.ts
@@ -1,0 +1,544 @@
+import { Buffer } from "node:buffer"
+import { execFile } from "node:child_process"
+import {
+  chmod,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { promisify } from "node:util"
+
+import type {
+  ExtensionAPI,
+  ExtensionContext,
+} from "@earendil-works/pi-coding-agent"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { BridgeError, callBridge, installBridge } from "../src/bridge.js"
+import {
+  BRIDGE_PATH,
+  GUEST_WORKSPACE,
+  MAX_BRIDGE_OUTPUT_BYTES,
+  MAX_WORKSPACE_DOWNLOAD_BYTES,
+  WORKSPACE_ARCHIVE_PATH,
+} from "../src/constants.js"
+import { SandboxLifecycle } from "../src/lifecycle.js"
+import type {
+  SandboxBootstrap,
+  SandboxHandle,
+  SandboxProvider,
+} from "../src/types.js"
+import { bootstrapSandbox } from "../src/workspace.js"
+
+const execFileAsync = promisify(execFile)
+const temporaryDirectories: string[] = []
+
+interface CommandOptions {
+  cwd?: string
+  env?: Record<string, string>
+  timeoutMs?: number
+  signal?: AbortSignal
+  maxOutputBytes?: number
+}
+
+interface FileWriteOptions {
+  timeoutMs?: number
+  signal?: AbortSignal
+}
+
+interface CapturedWrite {
+  path: string
+  content: unknown
+  options: FileWriteOptions
+}
+
+interface SandboxHarness {
+  sandbox: SandboxHandle
+  commandsRun: ReturnType<typeof vi.fn>
+  downloadDir: ReturnType<typeof vi.fn>
+  fileWrites: CapturedWrite[]
+  filesWrite: ReturnType<typeof vi.fn>
+}
+
+afterEach(async () => {
+  vi.unstubAllEnvs()
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  )
+})
+
+function createSandboxHarness(
+  bridgeValues: Partial<Record<string, unknown>> = {},
+): SandboxHarness {
+  const fileWrites: CapturedWrite[] = []
+  const commandsRun = vi.fn(
+    async (command: string, _options: CommandOptions = {}) => {
+      if (command.startsWith(`node ${BRIDGE_PATH} `)) {
+        const action = command.slice(`node ${BRIDGE_PATH} `.length)
+        return {
+          stdout: JSON.stringify({
+            ok: true,
+            value:
+              action in bridgeValues
+                ? bridgeValues[action]
+                : action === "home"
+                  ? "/home/sandbox"
+                  : true,
+          }),
+          stderr: "",
+          exitCode: 0,
+        }
+      }
+      return { stdout: "", stderr: "", exitCode: 0 }
+    },
+  )
+  const filesWrite = vi.fn(
+    async (
+      filePath: string,
+      content: unknown,
+      options: FileWriteOptions = {},
+    ) => {
+      fileWrites.push({ path: filePath, content, options })
+    },
+  )
+  const downloadDir = vi.fn(async () => new Uint8Array())
+  const sandbox = {
+    id: "11111111-1111-4111-8111-111111111111",
+    name: "workspace-test",
+    status: "active",
+    metadata: {},
+    commands: { run: commandsRun } as unknown as SandboxHandle["commands"],
+    files: {
+      write: filesWrite,
+      downloadDir,
+    } as unknown as SandboxHandle["files"],
+    getInfo: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    kill: vi.fn(),
+  } satisfies SandboxHandle
+
+  return { sandbox, commandsRun, downloadDir, fileWrites, filesWrite }
+}
+
+describe("filesystem bridge safety", () => {
+  it("keeps hostile input out of the fixed bridge command", async () => {
+    const remote = createSandboxHarness({ exists: true })
+    const hostilePath =
+      "/workspace/quotes-'\"/line\n$(touch PWNED);*.{js,ts}?[abc]"
+
+    await expect(
+      callBridge<boolean>(remote.sandbox, "exists", { path: hostilePath }),
+    ).resolves.toBe(true)
+
+    expect(remote.commandsRun).toHaveBeenCalledTimes(1)
+    const [command, options] = remote.commandsRun.mock.calls[0] ?? []
+    expect(command).toBe(`node ${BRIDGE_PATH} exists`)
+    expect(command).not.toContain(hostilePath)
+    expect(command).not.toContain("$(touch PWNED)")
+    expect(options).toMatchObject({
+      timeoutMs: 30_000,
+      maxOutputBytes: MAX_BRIDGE_OUTPUT_BYTES,
+    })
+
+    const encoded = options?.env?.SUPERSERVE_PI_INPUT
+    expect(encoded).toMatch(/^[A-Za-z0-9_-]+$/)
+    expect(encoded).not.toContain(hostilePath)
+    expect(
+      JSON.parse(Buffer.from(encoded, "base64url").toString("utf8")),
+    ).toEqual({ path: hostilePath })
+  })
+
+  it("rejects oversized bridge input before invoking the sandbox", async () => {
+    const remote = createSandboxHarness()
+
+    await expect(
+      callBridge(remote.sandbox, "exists", { path: "x".repeat(64 * 1024) }),
+    ).rejects.toEqual(
+      expect.objectContaining<Partial<BridgeError>>({
+        name: "BridgeError",
+        message: "Remote filesystem request is too large",
+      }),
+    )
+    expect(remote.commandsRun).not.toHaveBeenCalled()
+  })
+
+  it("installs the fixed bridge source with a bounded upload", async () => {
+    const remote = createSandboxHarness()
+    const controller = new AbortController()
+
+    await installBridge(remote.sandbox, controller.signal)
+
+    expect(remote.filesWrite).toHaveBeenCalledTimes(1)
+    const write = remote.fileWrites[0]
+    expect(write?.path).toBe(BRIDGE_PATH)
+    expect(write?.content).toEqual(expect.any(String))
+    expect(write?.content).toContain('process.env.SUPERSERVE_PI_INPUT || "e30"')
+    expect(write?.content).toContain('Buffer.from(encoded, "base64url")')
+    expect(write?.options).toEqual({
+      timeoutMs: 30_000,
+      signal: controller.signal,
+    })
+  })
+
+  it("streams an offset range from a text file larger than the SDK read cap", async () => {
+    const remote = createSandboxHarness()
+    const directory = await makeTemporaryDirectory("superserve-pi-bridge-read-")
+    const bridgePath = await materializeBridge(remote, directory)
+    const filePath = path.join(directory, "large.txt")
+    const line = "0123456789abcdefghi"
+    await writeFile(filePath, `${line}\n`.repeat(600_000))
+    expect((await stat(filePath)).size).toBeGreaterThan(10 * 1024 * 1024)
+
+    const response = await runInstalledBridge<{
+      kind: string
+      content: string
+      contentLimitReached: boolean
+      firstLineBytes: number
+      selectedLines: number
+      totalLines: number
+    }>(bridgePath, "read", {
+      path: filePath,
+      offset: 550_000,
+      limit: 2,
+    })
+
+    expect(response).toEqual({
+      kind: "text",
+      content: `${line}\n${line}`,
+      contentLimitReached: false,
+      firstLineBytes: Buffer.byteLength(line),
+      selectedLines: 2,
+      totalLines: 600_001,
+    })
+  })
+
+  it("keeps grep and find responses valid below the bridge transport cap", async () => {
+    const remote = createSandboxHarness()
+    const directory = await makeTemporaryDirectory("superserve-pi-bridge-cap-")
+    const bridgePath = await materializeBridge(remote, directory)
+    const grepPath = path.join(directory, "matches.txt")
+    await writeFile(grepPath, `needle ${"x".repeat(1_990)}\n`.repeat(1_000))
+
+    const grep = await runInstalledBridge<{
+      output: string
+      responseLimitReached: boolean
+    }>(
+      bridgePath,
+      "grep",
+      {
+        path: grepPath,
+        pattern: "needle",
+        limit: 1_000,
+        maxLineLength: 2_000,
+      },
+      (stdout) => {
+        expect(Buffer.byteLength(stdout)).toBeLessThan(MAX_BRIDGE_OUTPUT_BYTES)
+      },
+    )
+    expect(grep.responseLimitReached).toBe(true)
+    expect(Buffer.byteLength(grep.output)).toBeLessThan(MAX_BRIDGE_OUTPUT_BYTES)
+
+    let nested = directory
+    for (let index = 0; index < 3; index += 1) {
+      nested = path.join(nested, `${index}-${"d".repeat(230)}`)
+      await mkdir(nested)
+    }
+    for (let start = 0; start < 1_100; start += 100) {
+      await Promise.all(
+        Array.from({ length: 100 }, (_, index) => {
+          const number = String(start + index).padStart(4, "0")
+          return writeFile(
+            path.join(nested, `${number}-${"f".repeat(190)}.txt`),
+            "",
+          )
+        }),
+      )
+    }
+    const found = await runInstalledBridge<string[]>(
+      bridgePath,
+      "glob",
+      { path: nested, pattern: "*.txt", limit: 5_000 },
+      (stdout) => {
+        expect(Buffer.byteLength(stdout)).toBeLessThan(MAX_BRIDGE_OUTPUT_BYTES)
+      },
+    )
+    expect(found.length).toBeGreaterThan(0)
+    expect(found.length).toBeLessThan(1_100)
+    expect(found.every((entry) => typeof entry === "string")).toBe(true)
+
+    const listed = await runInstalledBridge<{
+      entries: Array<{ name: string; isDirectory: boolean }>
+    }>(bridgePath, "list", { path: nested, limit: 11 })
+    expect(listed.entries).toHaveLength(11)
+    expect(listed.entries.map((entry) => entry.name)).toEqual(
+      [...listed.entries]
+        .map((entry) => entry.name)
+        .toSorted((left, right) =>
+          left.toLowerCase().localeCompare(right.toLowerCase()),
+        ),
+    )
+  })
+})
+
+describe("workspace bootstrap", () => {
+  it("installs the bridge without reading the host workspace when sync is disabled", async () => {
+    const remote = createSandboxHarness({ home: "/home/remote" })
+
+    await expect(
+      bootstrapSandbox(remote.sandbox, {
+        localCwd: "/host/path/that/must/not/be-used",
+        sync: "none",
+        uploadWorkspace: true,
+      }),
+    ).resolves.toEqual({
+      guestHome: "/home/remote",
+      syncedFiles: 0,
+      syncedBytes: 0,
+    })
+
+    expect(remote.filesWrite).toHaveBeenCalledTimes(1)
+    expect(remote.fileWrites[0]?.path).toBe(BRIDGE_PATH)
+    expect(remote.commandsRun).toHaveBeenCalledTimes(2)
+    expect(remote.commandsRun.mock.calls[0]?.[0]).toBe(
+      `mkdir -p -- ${GUEST_WORKSPACE}`,
+    )
+    expect(remote.commandsRun.mock.calls[0]?.[1]).toMatchObject({
+      timeoutMs: 120_000,
+      maxOutputBytes: MAX_BRIDGE_OUTPUT_BYTES,
+    })
+    expect(remote.commandsRun.mock.calls[1]?.[0]).toBe(
+      `node ${BRIDGE_PATH} home`,
+    )
+  })
+
+  it("uploads dirty tracked files while excluding untracked files", async () => {
+    const repository = await makeTemporaryDirectory("superserve-pi-repo-")
+    await execFileAsync("git", ["init", "-q"], { cwd: repository })
+    await mkdir(path.join(repository, "nested"))
+
+    const trackedName = "tracked.txt"
+    const hostileName = "nested/line\n$(touch PWNED)-*.txt"
+    const untrackedName = "untracked-secret.txt"
+    await writeFile(path.join(repository, trackedName), "staged version\n")
+    await writeFile(path.join(repository, hostileName), "hostile filename\n")
+    await execFileAsync("git", ["add", "--", trackedName, hostileName], {
+      cwd: repository,
+    })
+    const dirtyContent = "dirty working tree version\n"
+    await writeFile(path.join(repository, trackedName), dirtyContent)
+    await writeFile(path.join(repository, untrackedName), "host secret\n")
+
+    const remote = createSandboxHarness({ home: "/home/remote" })
+    const result = await bootstrapSandbox(remote.sandbox, {
+      localCwd: repository,
+      sync: "tracked",
+      uploadWorkspace: true,
+    })
+
+    expect(result).toEqual({
+      guestHome: "/home/remote",
+      syncedFiles: 2,
+      syncedBytes:
+        Buffer.byteLength(dirtyContent) +
+        Buffer.byteLength("hostile filename\n"),
+    })
+
+    const archiveWrite = remote.fileWrites.find(
+      (write) => write.path === WORKSPACE_ARCHIVE_PATH,
+    )
+    expect(archiveWrite?.content).toBeInstanceOf(Uint8Array)
+    expect(archiveWrite?.options).toMatchObject({ timeoutMs: 120_000 })
+
+    const commands = remote.commandsRun.mock.calls.map(([command]) => command)
+    expect(commands).toContain(
+      `tar -xzf ${WORKSPACE_ARCHIVE_PATH} -C ${GUEST_WORKSPACE} && rm -f -- ${WORKSPACE_ARCHIVE_PATH}`,
+    )
+    expect(commands).toContain(
+      [
+        "command -v git >/dev/null 2>&1 || exit 0",
+        `cd ${GUEST_WORKSPACE}`,
+        "git init -q",
+        'git config user.name "Superserve Pi"',
+        'git config user.email "pi@superserve.local"',
+        "git add -A",
+        'git commit -qm "Initial workspace snapshot"',
+      ].join(" && "),
+    )
+    for (const command of commands) {
+      expect(command).not.toContain(repository)
+      expect(command).not.toContain(hostileName)
+      expect(command).not.toContain(untrackedName)
+    }
+    for (const [, options] of remote.commandsRun.mock.calls) {
+      expect(options).toMatchObject({
+        maxOutputBytes: MAX_BRIDGE_OUTPUT_BYTES,
+      })
+    }
+
+    const archivePath = path.join(repository, "captured-workspace.tar.gz")
+    const extracted = path.join(repository, "extracted")
+    await writeFile(archivePath, archiveWrite?.content as Uint8Array)
+    await mkdir(extracted)
+    await execFileAsync("tar", ["-xzf", archivePath, "-C", extracted])
+
+    await expect(
+      readFile(path.join(extracted, trackedName), "utf8"),
+    ).resolves.toBe(dirtyContent)
+    await expect(
+      readFile(path.join(extracted, hostileName), "utf8"),
+    ).resolves.toBe("hostile filename\n")
+    await expect(lstat(path.join(extracted, untrackedName))).rejects.toThrow()
+    await expect(lstat(path.join(repository, "PWNED"))).rejects.toThrow()
+  })
+
+  it.each(["git", "tar"])(
+    "never executes a workspace-controlled %s from PATH",
+    async (executable) => {
+      const repository = await makeTemporaryDirectory(
+        "superserve-pi-path-repo-",
+      )
+      await execFileAsync("git", ["init", "-q"], { cwd: repository })
+      await writeFile(path.join(repository, "tracked.txt"), "tracked\n")
+      await execFileAsync("git", ["add", "--", "tracked.txt"], {
+        cwd: repository,
+      })
+
+      const binDirectory = path.join(repository, "repo-bin")
+      const marker = path.join(repository, `${executable}-executed`)
+      await mkdir(binDirectory)
+      const fakeExecutable = path.join(binDirectory, executable)
+      await writeFile(
+        fakeExecutable,
+        `#!/bin/sh\ntouch ${JSON.stringify(marker)}\nexit 99\n`,
+      )
+      await chmod(fakeExecutable, 0o700)
+      vi.stubEnv("PATH", `${binDirectory}${path.delimiter}${process.env.PATH}`)
+
+      const remote = createSandboxHarness({ home: "/home/remote" })
+      await expect(
+        bootstrapSandbox(remote.sandbox, {
+          localCwd: repository,
+          sync: "tracked",
+          uploadWorkspace: true,
+        }),
+      ).resolves.toMatchObject({ syncedFiles: 1 })
+
+      await expect(lstat(marker)).rejects.toThrow()
+    },
+  )
+})
+
+describe("workspace download", () => {
+  it("downloads with a hard byte cap and creates a private output file", async () => {
+    const localCwd = await makeTemporaryDirectory("superserve-pi-download-")
+    const remote = createSandboxHarness()
+    const archive = Buffer.from("PK\u0003\u0004test archive")
+    remote.downloadDir.mockResolvedValueOnce(archive)
+
+    const provider = {
+      create: vi.fn(),
+      connect: vi.fn(async () => remote.sandbox),
+      list: vi.fn(async () => []),
+      killById: vi.fn(),
+    } as unknown as SandboxProvider
+    const bootstrap = vi.fn<SandboxBootstrap>(async () => ({
+      guestHome: "/home/remote",
+      syncedFiles: 0,
+      syncedBytes: 0,
+    }))
+    const appended: Array<{ customType: string; data: unknown }> = []
+    const pi = {
+      appendEntry: (customType: string, data: unknown) => {
+        appended.push({ customType, data })
+      },
+      getFlag: () => undefined,
+      setActiveTools: vi.fn(),
+    } as unknown as ExtensionAPI
+    const controller = new AbortController()
+    const ctx = {
+      cwd: localCwd,
+      hasUI: false,
+      signal: controller.signal,
+      sessionManager: {
+        getBranch: () => [],
+        getSessionFile: () => "/tmp/pi-session.jsonl",
+        getSessionId: () => "session-download",
+      },
+      ui: {},
+    } as unknown as ExtensionContext
+    const lifecycle = new SandboxLifecycle(pi, localCwd, {
+      provider,
+      bootstrap,
+      randomId: vi
+        .fn()
+        .mockReturnValueOnce("client-download")
+        .mockReturnValueOnce("binding-download"),
+    })
+    await lifecycle.connect(remote.sandbox.id, ctx)
+
+    const result = await lifecycle.downloadWorkspace("workspace.zip", ctx)
+
+    const outputPath = path.join(localCwd, "workspace.zip")
+    expect(result).toEqual({ path: outputPath, bytes: archive.byteLength })
+    expect(remote.downloadDir).toHaveBeenCalledWith(GUEST_WORKSPACE, {
+      timeoutMs: 300_000,
+      signal: controller.signal,
+      maxBytes: MAX_WORKSPACE_DOWNLOAD_BYTES,
+    })
+    await expect(readFile(outputPath)).resolves.toEqual(archive)
+    expect((await stat(outputPath)).mode & 0o777).toBe(0o600)
+    expect(appended.length).toBeGreaterThan(0)
+  })
+})
+
+async function makeTemporaryDirectory(prefix: string): Promise<string> {
+  const directory = await mkdtemp(path.join(tmpdir(), prefix))
+  temporaryDirectories.push(directory)
+  return directory
+}
+
+async function materializeBridge(
+  remote: SandboxHarness,
+  directory: string,
+): Promise<string> {
+  await installBridge(remote.sandbox)
+  const source = remote.fileWrites.find(
+    (write) => write.path === BRIDGE_PATH,
+  )?.content
+  if (typeof source !== "string") throw new Error("Bridge source not captured")
+  const bridgePath = path.join(directory, "bridge.mjs")
+  await writeFile(bridgePath, source)
+  return bridgePath
+}
+
+async function runInstalledBridge<T>(
+  bridgePath: string,
+  action: string,
+  input: Record<string, unknown>,
+  inspectStdout?: (stdout: string) => void,
+): Promise<T> {
+  const encoded = Buffer.from(JSON.stringify(input)).toString("base64url")
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    [bridgePath, action],
+    {
+      env: { SUPERSERVE_PI_INPUT: encoded },
+      maxBuffer: MAX_BRIDGE_OUTPUT_BYTES + 1024,
+    },
+  )
+  inspectStdout?.(stdout)
+  const response = JSON.parse(stdout) as
+    | { ok: true; value: T }
+    | { ok: false; error: string }
+  if (!response.ok) throw new Error(response.error)
+  return response.value
+}

--- a/packages/pi/tsconfig.json
+++ b/packages/pi/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@superserve/typescript-config/library.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/packages/pi/tsup.config.ts
+++ b/packages/pi/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsup"
+
+export default defineConfig({
+  entry: { index: "src/index.ts" },
+  format: ["esm"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  target: "node22",
+  external: ["@earendil-works/pi-coding-agent"],
+})

--- a/packages/pi/vitest.config.ts
+++ b/packages/pi/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+  },
+})


### PR DESCRIPTION
## Related Issues
<!-- none -->

## Description

Adds **`@superserve/pi`** — a Pi coding-agent extension that routes Pi's seven
built-in tools (`bash`, `read`, `write`, `edit`, `grep`, `find`, `ls`) plus
interactive `!` commands into an isolated Superserve Firecracker microVM via
`@superserve/sdk`. Pi itself, model credentials, and session state stay on the
host; only tool execution moves into the sandbox.

Design highlights:
- **Fail-closed isolation.** Once Superserve mode is requested (flag, argv,
  persisted binding, or `/superserve` command), a tool never silently runs on
  the host — it is blocked or errors. `routingRequired` is monotonic and a
  source-anchor check blocks another extension from shadowing the routed tool
  names.
- **Bounded sandbox→host boundary.** Every read of sandbox output passes an
  enforced byte cap + timeout + abort signal through the SDK (bash 1 MiB,
  bridge JSON 2 MiB, file reads 10 MiB, workspace download 250 MiB).
- **Host-side hardening.** `/superserve download` guards every path component
  against symlinks with TOCTOU re-validation and `open(..., "wx", 0o600)` (no
  overwrite). Initial `git`/`tar` sync resolves binaries outside
  workspace-controlled `PATH` and neutralizes git hooks/fsmonitor/config exec.
- **No secret crossing.** Host env is never forwarded to sandbox commands;
  session bindings and metadata carry no API keys or tokens.

Also adds the tag-triggered npm publish workflow (`pi-v*`) with Trusted
Publishing + provenance, and RELEASING/README docs.

Package: `packages/pi/` (source, tests, tsup/vitest/tsconfig, README, LICENSE).

## Additional Context

Opening as a **draft** — a review surfaced known items to address before
release (none are security/isolation holes; the sandbox always fails safe):

**Correctness (fix before publish):**
- `src/index.ts` `hasRawFlagIntent` — `--superserve=false` (and `=0`/`=off`)
  matches the `--superserve=` prefix and *force-enables* the sandbox,
  provisioning a billed VM opposite to the user's explicit intent. Only bare
  `--superserve` / truthy values should count as intent.
- `src/tools.ts` — host→guest path mapping is applied twice
  (`rewritePathParameter` then `resolveGuestPath`/`mapAbsolutePath`). Idempotent
  for disjoint paths, but non-idempotent when `guestHome` is at/below the host
  cwd (e.g. root launched from `/root` with a `/root` guest home): `~/notes.txt`
  re-bases to `/workspace/notes.txt`. Confined to the VM, but silently targets
  the wrong guest file. Map once.

**Test coverage (guards exist and are correct, but lack a regression test):**
- No adversarial test feeding malformed/hostile bridge responses to the host
  validators (`validateBridgeReadResult`, glob `every(string)`, `isBridgeResponse`).
- No test for the `.git/config` `core.fsmonitor`/`core.hooksPath` exec vector
  (only the PATH-substitution vector is covered).
- No test for the download no-overwrite (`wx`) guarantee.

**Minor:** process-global routing latch can carry intent across same-process
sessions; `resolveTrustedExecutable` doesn't re-check the resolved realpath
stays outside the workspace (defense-in-depth, not adversary-reachable); README
pin-count publish gate doesn't detect stale old-version pins or validate the tag
semver.

## Testing

The package ships 4 vitest suites (`tests/extension|lifecycle|tools|workspace.test.ts`,
~3k lines) covering fail-closed behavior, source-anchor spoofing, bounded output,
download symlink/traversal refusal, workspace-PATH exclusion of git/tar, host-env
omission, secret-not-persisted, and sandbox-id validation. The publish workflow
runs `lint`, `format:check`, `typecheck`, `test`, and `build` before publishing.

- [ ] Tested locally
- [x] Added/updated tests
- [ ] All tests passing <!-- not run in this change set; validated by the publish workflow / CI -->

## Screenshots/Demo
<!-- n/a -->
