### PR TITLE
docs: add Agno integration guide

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -262,6 +262,7 @@
           {
             "group": "Agent Harnesses",
             "pages": [
+              "integrations/agent-harnesses/agno",
               "integrations/agent-harnesses/claude-agent-sdk",
               "integrations/agent-harnesses/openai-agents-sdk"
             ]

--- a/docs/integrations/agent-harnesses/agno.mdx
+++ b/docs/integrations/agent-harnesses/agno.mdx
@@ -1,0 +1,88 @@
+---
+title: "Agno"
+sidebarTitle: Agno
+description: Run code from Agno agents in isolated Superserve sandboxes with SuperserveTools.
+icon: "/logos/integrations/agno.svg"
+---
+
+Agno includes a `SuperserveTools` toolkit for running agent-generated code in isolated cloud sandboxes. The sandbox persists across tool calls, so files and installed packages remain available throughout the session.
+
+<Note>
+  `SuperserveTools` is available in Agno 2.7.4 and later.
+</Note>
+
+## Setup
+
+Install Agno, the OpenAI model provider, and the Superserve SDK:
+
+```bash
+uv pip install -U "agno>=2.7.4" openai superserve
+export OPENAI_API_KEY=sk-...
+export SUPERSERVE_API_KEY=ss_live_...
+```
+
+See [API keys](/api-key) to create a Superserve API key.
+
+## Run an Agno agent in a sandbox
+
+`SuperserveTools` gives the agent tools for Python and shell execution, file operations, sandbox inspection, preview URLs, and lifecycle management.
+
+```python
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.tools.superserve import SuperserveTools
+
+agent = Agent(
+    name="Sandboxed Python Agent",
+    model=OpenAIResponses(id="gpt-5.5"),
+    tools=[SuperserveTools(timeout=600)],
+    instructions=[
+        "Execute requested code with run_python_code or run_command.",
+        "Return the code and its actual execution output.",
+    ],
+)
+
+agent.print_response(
+    "Generate the first 10 Fibonacci numbers, then calculate their sum and average."
+)
+```
+
+The toolkit creates a Python-ready sandbox on the first tool call. With `persistent=True`, the default, Agno stores its ID in session state and reuses the same sandbox across tool calls and runs in that session. Sync and async agents use the same sandbox automatically.
+
+## Configure the sandbox
+
+Pass Superserve sandbox options directly to the toolkit:
+
+```python
+tools = [
+    SuperserveTools(
+        template="superserve/node-22",
+        timeout=600,
+        auto_delete_seconds=3600,
+        secrets={"OPENAI_API_KEY": "openai-prod"},
+        enable_pause_sandbox=True,
+        enable_resume_sandbox=True,
+    )
+]
+```
+
+| Option | Purpose |
+| --- | --- |
+| `template` | Select the sandbox runtime. The default is `superserve/code-interpreter`. |
+| `sandbox_id` | Connect the toolkit to an existing sandbox. |
+| `timeout` | Set the sandbox lifetime before it is automatically stopped. |
+| `auto_delete_seconds` | Set a hard time-to-live after which the sandbox is deleted. |
+| `secrets` | Bind [team secrets](/secrets/binding) without exposing their values in the sandbox. |
+| `enable_pause_sandbox` and `enable_resume_sandbox` | Let the agent pause and resume its current sandbox. |
+| `all` | Enable every toolkit function, including opt-in lifecycle and secret tools. |
+
+## Resources
+
+<CardGroup cols={2}>
+  <Card title="Agno toolkit reference" icon="book" href="https://docs.agno.com/tools/toolkits/others/superserve">
+    Review every toolkit option and function.
+  </Card>
+  <Card title="Agno cookbook example" icon="github" href="https://github.com/agno-agi/agno/blob/main/cookbook/91_tools/superserve_tools.py">
+    Open the runnable example in the Agno repository.
+  </Card>
+</CardGroup>

--- a/docs/logos/integrations/agno.svg
+++ b/docs/logos/integrations/agno.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 69 59" fill="none">
+  <path d="M44.9802 0.200195H16.5703V10.1702H38.0442L56.3442 58.8102H68.1658L44.9802 0.200195Z" fill="white"/>
+  <path d="M29.59 48.8403H0.5V58.8103H29.59V48.8403Z" fill="white"/>
+</svg>


### PR DESCRIPTION
## Summary

- add an Agno guide under Cookbook → Agent Harnesses
- document installation, sandbox execution, session reuse, lifecycle options, and secret binding
- add the official Agno mark and link to Agno's toolkit reference and runnable cookbook example

## Why

Agno's Superserve toolkit has merged upstream and shipped in Agno 2.7.4. Superserve users should be able to discover and configure the integration from our own cookbook.

## Impact

Users can follow a runnable example to execute Agno agent code in Superserve sandboxes and find the complete upstream reference when they need advanced toolkit options.

## Validation

- `bun run docs:check-nav`
- `bunx --bun mintlify validate`
- `bunx --bun mintlify broken-links`
- local Mintlify preview returned HTTP 200 for the Agno route