### PR TITLE
console: read live sandbox counts from the sharded-counter view

### DIFF
--- a/apps/console/src/lib/api/quota-actions.ts
+++ b/apps/console/src/lib/api/quota-actions.ts
@@ -40,15 +40,23 @@ export async function getQuotaUsageAction(): Promise<QuotaUsageResponse | null> 
   if (!team) return null
 
   const admin = cellFor(team.region).createAdminClient()
-  const { data, error } = await admin
-    .from("team")
-    .select("active_sandbox_count, max_sandboxes")
-    .eq("id", team.teamId)
-    .single()
-  if (error) throw new Error(error.message)
+  // Live counts come from the sharded-counter view (team.active_sandbox_count
+  // is frozen); a team with no counter rows is absent from the view — zero.
+  // Admin client required: the view is security_invoker over an RLS-deny
+  // table, and a user-scoped client reads empty rows, not an error.
+  const [teamRes, countRes] = await Promise.all([
+    admin.from("team").select("max_sandboxes").eq("id", team.teamId).single(),
+    admin
+      .from("team_active_sandbox_counts")
+      .select("active_sandbox_count")
+      .eq("team_id", team.teamId)
+      .maybeSingle(),
+  ])
+  if (teamRes.error) throw new Error(teamRes.error.message)
+  if (countRes.error) throw new Error(countRes.error.message)
 
-  const activeSandboxes = data.active_sandbox_count ?? 0
-  const maxSandboxes = data.max_sandboxes ?? 0
+  const activeSandboxes = countRes.data?.active_sandbox_count ?? 0
+  const maxSandboxes = teamRes.data.max_sandboxes ?? 0
   // Floor via integer division, matching the watcher's `used*100 >= limit*pct`,
   // so the banner never shows "80%" or fires below the email threshold.
   const pct =

--- a/apps/console/src/lib/api/team-directory.test.ts
+++ b/apps/console/src/lib/api/team-directory.test.ts
@@ -4,11 +4,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 let regions: string[] = ["use"]
 let cellClients: Record<string, ReturnType<typeof cellClient>> = {}
 
-// Minimal per-cell client: team_member memberships and team name lookups.
+// Minimal per-cell client: team_member memberships, team name lookups, and
+// the sharded sandbox-count view.
 function cellClient(
   memberships: Array<{ team_id: string }>,
   teams: Array<{ id: string; name: string; home_region?: string | null }> = [],
   rbac: Array<{ team_id: string; status: string }> = [],
+  counts: Array<{ team_id: string; active_sandbox_count: number }> = [],
 ) {
   const from = vi.fn((table: string) => {
     if (table === "team_memberships") {
@@ -32,6 +34,18 @@ function cellClient(
           eq: (_col: string, id: string) => ({
             limit: async () => ({
               data: teams.filter((t) => t.id === id),
+              error: null,
+            }),
+          }),
+        }),
+      }
+    }
+    if (table === "team_active_sandbox_counts") {
+      return {
+        select: () => ({
+          eq: (_col: string, id: string) => ({
+            maybeSingle: async () => ({
+              data: counts.find((c) => c.team_id === id) ?? null,
               error: null,
             }),
           }),
@@ -352,10 +366,26 @@ describe("findTeamById home-region preference", () => {
   const team = (home_region: string | null) => ({
     id: "t-1",
     name: "acme",
-    active_sandbox_count: 0,
     max_sandboxes: 10,
     created_at: "2026-01-01",
     home_region,
+  })
+
+  it("reads the sandbox count from the sharded-counter view, defaulting to zero", async () => {
+    regions = ["use"]
+    cellClients = {
+      use: cellClient(
+        [],
+        [team(null)],
+        [],
+        [{ team_id: "t-1", active_sandbox_count: 7 }],
+      ),
+    }
+    expect((await findTeamById("t-1"))?.active_sandbox_count).toBe(7)
+
+    cellClients = { use: cellClient([], [team(null)]) }
+    clearMembershipDirectoryCache()
+    expect((await findTeamById("t-1"))?.active_sandbox_count).toBe(0)
   })
 
   it("prefers the cell the team names as home over an earlier pointer row", async () => {

--- a/apps/console/src/lib/api/team-directory.test.ts
+++ b/apps/console/src/lib/api/team-directory.test.ts
@@ -49,6 +49,10 @@ function cellClient(
               error: null,
             }),
           }),
+          in: async (_col: string, ids: string[]) => ({
+            data: counts.filter((c) => ids.includes(c.team_id)),
+            error: null,
+          }),
         }),
       }
     }

--- a/apps/console/src/lib/api/team-directory.ts
+++ b/apps/console/src/lib/api/team-directory.ts
@@ -228,12 +228,16 @@ export async function listTeamsForUser(
 export async function listAllTeams(): Promise<TeamRecord[]> {
   const { items } = await acrossCells(async (region) => {
     const admin = cellFor(region).createAdminClient()
-    const [{ data: teams, error }, counts] = await Promise.all([
-      admin.from("team").select("id, name, max_sandboxes, created_at"),
-      sandboxCounts(admin),
-    ])
+    const { data: teams, error } = await admin
+      .from("team")
+      .select("id, name, max_sandboxes, created_at")
 
     if (error) throw new Error(error.message)
+
+    const counts = await sandboxCounts(
+      admin,
+      (teams ?? []).map((team) => team.id as string),
+    )
 
     return (teams ?? []).map((team) => ({
       id: team.id as string,
@@ -282,19 +286,30 @@ async function findTeamInRegion(
 // sharded counter. The view is security_invoker over an RLS-deny table, so
 // these reads must stay on the admin (service-role) client; a user-scoped
 // client reads empty rows, not an error.
+//
+// Queried per id-chunk, never unbounded: the API's max-rows cap silently
+// truncates an unbounded select, and a truncated map here would render the
+// dropped teams as 0 active sandboxes. Chunked .in() keeps every response
+// under both the row cap and URL-length limits at any team count.
+const sandboxCountsChunk = 200
+
 async function sandboxCounts(
   admin: SupabaseClient,
+  teamIds: string[],
 ): Promise<Map<string, number>> {
-  const { data, error } = await admin
-    .from("team_active_sandbox_counts")
-    .select("team_id, active_sandbox_count")
-  if (error) throw new Error(error.message)
-  return new Map(
-    (data ?? []).map((row) => [
-      row.team_id as string,
-      row.active_sandbox_count as number,
-    ]),
-  )
+  const counts = new Map<string, number>()
+  for (let i = 0; i < teamIds.length; i += sandboxCountsChunk) {
+    const chunk = teamIds.slice(i, i + sandboxCountsChunk)
+    const { data, error } = await admin
+      .from("team_active_sandbox_counts")
+      .select("team_id, active_sandbox_count")
+      .in("team_id", chunk)
+    if (error) throw new Error(error.message)
+    for (const row of data ?? []) {
+      counts.set(row.team_id as string, row.active_sandbox_count as number)
+    }
+  }
+  return counts
 }
 
 // A team with no counter rows yet is absent from the view: zero sandboxes.

--- a/apps/console/src/lib/api/team-directory.ts
+++ b/apps/console/src/lib/api/team-directory.ts
@@ -228,16 +228,17 @@ export async function listTeamsForUser(
 export async function listAllTeams(): Promise<TeamRecord[]> {
   const { items } = await acrossCells(async (region) => {
     const admin = cellFor(region).createAdminClient()
-    const { data: teams, error } = await admin
-      .from("team")
-      .select("id, name, active_sandbox_count, max_sandboxes, created_at")
+    const [{ data: teams, error }, counts] = await Promise.all([
+      admin.from("team").select("id, name, max_sandboxes, created_at"),
+      sandboxCounts(admin),
+    ])
 
     if (error) throw new Error(error.message)
 
     return (teams ?? []).map((team) => ({
       id: team.id as string,
       name: team.name as string,
-      active_sandbox_count: team.active_sandbox_count as number,
+      active_sandbox_count: counts.get(team.id as string) ?? 0,
       max_sandboxes: team.max_sandboxes as number,
       created_at: team.created_at as string,
       region,
@@ -256,9 +257,7 @@ async function findTeamInRegion(
   const admin = cellFor(region).createAdminClient()
   const { data: teams, error } = await admin
     .from("team")
-    .select(
-      "id, name, active_sandbox_count, max_sandboxes, created_at, home_region",
-    )
+    .select("id, name, max_sandboxes, created_at, home_region")
     .eq("id", teamId)
     .limit(1)
 
@@ -270,12 +269,46 @@ async function findTeamInRegion(
   return {
     id: team.id as string,
     name: team.name as string,
-    active_sandbox_count: team.active_sandbox_count as number,
+    active_sandbox_count: await sandboxCountFor(admin, teamId),
     max_sandboxes: team.max_sandboxes as number,
     created_at: team.created_at as string,
     region,
     home_region: (team.home_region as string | null) ?? null,
   }
+}
+
+// Live sandbox counts come from the team_active_sandbox_counts view —
+// team.active_sandbox_count is frozen since the control plane moved to a
+// sharded counter. The view is security_invoker over an RLS-deny table, so
+// these reads must stay on the admin (service-role) client; a user-scoped
+// client reads empty rows, not an error.
+async function sandboxCounts(
+  admin: SupabaseClient,
+): Promise<Map<string, number>> {
+  const { data, error } = await admin
+    .from("team_active_sandbox_counts")
+    .select("team_id, active_sandbox_count")
+  if (error) throw new Error(error.message)
+  return new Map(
+    (data ?? []).map((row) => [
+      row.team_id as string,
+      row.active_sandbox_count as number,
+    ]),
+  )
+}
+
+// A team with no counter rows yet is absent from the view: zero sandboxes.
+async function sandboxCountFor(
+  admin: SupabaseClient,
+  teamId: string,
+): Promise<number> {
+  const { data, error } = await admin
+    .from("team_active_sandbox_counts")
+    .select("active_sandbox_count")
+    .eq("team_id", teamId)
+    .maybeSingle()
+  if (error) throw new Error(error.message)
+  return (data?.active_sandbox_count as number | undefined) ?? 0
 }
 
 /**


### PR DESCRIPTION
The control plane is moving the per-team active-sandbox counter from the `team.active_sandbox_count` column to a sharded counter table; after that migration the column freezes at its pre-migration value and live counts are served by the `team_active_sandbox_counts` view. This repoints the console's three readers — the customer quota banner and the admin team directory (list + single-team lookup) — at the view, defaulting to zero for teams with no counter rows yet.

All reads stay on the admin (service-role) client: the view is `security_invoker` over an RLS-deny table, so a user-scoped client would read empty rows rather than erroring.

**Merge ordering**: this must deploy after the control-plane migration creates the view in every cell's database — before that, the view queries fail. The old column keeps its stale value either way, so there is no window where the current code shows wrong data that this PR would have shown correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)