### PR TITLE
Bump SDKs to 0.8.2

### DIFF
--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "superserve"
-version = "0.8.1"
+version = "0.8.2"
 description = "Python SDK for the Superserve sandbox API"
 license = "Apache-2.0"
 readme = "README.md"

--- a/packages/python-sdk/src/superserve/__init__.py
+++ b/packages/python-sdk/src/superserve/__init__.py
@@ -59,7 +59,7 @@ from .types import (
     WorkdirStep,
 )
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"
 
 __all__ = [
     "AsyncCommandSession",

--- a/packages/python-sdk/src/superserve/_http.py
+++ b/packages/python-sdk/src/superserve/_http.py
@@ -25,7 +25,7 @@ DEFAULT_MAX_DOWNLOAD_BYTES = (
     2 * 1024 * 1024 * 1024
 )  # 2 GiB; matches boxd's server-side zip cap
 
-SDK_VERSION = "0.8.1"
+SDK_VERSION = "0.8.2"
 USER_AGENT = (
     f"superserve-python/{SDK_VERSION} "
     f"(python/{sys.version_info.major}.{sys.version_info.minor})"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superserve/sdk",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "TypeScript SDK for the Superserve sandbox API",
   "keywords": [
     "firecracker",

--- a/packages/sdk/src/http.ts
+++ b/packages/sdk/src/http.ts
@@ -20,7 +20,7 @@ import type { ApiExecStreamEvent } from "./types.js"
 
 const DEFAULT_TIMEOUT_MS = 30_000
 
-const SDK_VERSION = "0.8.1"
+const SDK_VERSION = "0.8.2"
 const USER_AGENT = `@superserve/sdk/${SDK_VERSION} (node/${
   typeof process !== "undefined" && process.versions?.node
     ? `v${process.versions.node}`

--- a/uv.lock
+++ b/uv.lock
@@ -492,7 +492,7 @@ wheels = [
 
 [[package]]
 name = "superserve"
-version = "0.8.0"
+version = "0.8.2"
 source = { editable = "packages/python-sdk" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## What changed

- bumps `@superserve/sdk` from 0.8.1 to 0.8.2
- bumps the Python `superserve` package from 0.8.1 to 0.8.2
- keeps TypeScript and Python User-Agent versions in sync
- refreshes the editable Python package version in `uv.lock`

## Why

PR #287 added the complete preview URL authentication surface, but merging to `main` does not publish npm or PyPI packages. The release workflow requires the target version to be committed on `main` before publication.

This PR should be merged only after the corresponding backend stack is deployed and its production smoke test passes.

## Validation

- TypeScript build, lint, format check, typecheck, and 231 tests
- Python lock/sync, lint, mypy, 304 tests, and sdist/wheel build
- `git diff --check`
