### PR TITLE
mcp: bump to 0.1.3

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superserve/mcp",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Model Context Protocol (MCP) server for Superserve sandboxes — create, exec, and manage Firecracker microVMs from any MCP client",
   "keywords": [
     "agents",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.superserve-ai/mcp",
   "title": "Superserve",
   "description": "MCP server for Superserve sandboxes: create, exec, and manage Firecracker microVMs",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "websiteUrl": "https://superserve.ai",
   "repository": {
     "url": "https://github.com/superserve-ai/superserve",
@@ -15,7 +15,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@superserve/mcp",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "runtimeHint": "npx",
       "transport": { "type": "stdio" },
       "environmentVariables": [

--- a/packages/mcp/src/constants.ts
+++ b/packages/mcp/src/constants.ts
@@ -31,7 +31,7 @@ export const SERVER_INSTRUCTIONS =
  * Server version. Kept in sync with `package.json` `version`
  * (enforced by `tests/version.test.ts`).
  */
-export const SERVER_VERSION = "0.1.2"
+export const SERVER_VERSION = "0.1.3"
 
 /** Default per-command timeout when a tool call omits `timeout_ms`. */
 export const DEFAULT_EXEC_TIMEOUT_MS = 60_000


### PR DESCRIPTION
Bump the MCP server to 0.1.3 across all version surfaces: package.json, the SERVER_VERSION constant reported in the MCP initialize handshake and startup logs, and both fields of the registry manifest (server.json).

0.1.2 is skipped: that version is already on npm (published 2026-07-10) from a state where only package.json was bumped, so the installed server self-reports 0.1.1 while npm says 0.1.2. Publishing 0.1.3 with all surfaces aligned supersedes the mismatch; npm versions are immutable so 0.1.2 cannot be repaired in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)