### PR TITLE
console: enable multi-region team creation and switching for everyone

### DIFF
--- a/apps/console/src/components/settings/teams-section.tsx
+++ b/apps/console/src/components/settings/teams-section.tsx
@@ -22,9 +22,8 @@ import { regionLabel } from "@/lib/format"
  * user has more than one team or more than one cell is configured — a
  * multi-team user needs the Active marker regardless of region count
  * (switching itself lives in the sidebar team dropdown). The create-team
- * form stays multi-cell-only: the single-cell console has no team creation
- * surface, and that must stay true until a second region exists to choose
- * from.
+ * form stays multi-cell-only: with a single configured cell there's no
+ * region to choose, so the form has nothing to show.
  */
 export function TeamsSection() {
   const { data } = useTeams()

--- a/apps/console/src/components/sidebar/team-switcher.test.tsx
+++ b/apps/console/src/components/sidebar/team-switcher.test.tsx
@@ -18,7 +18,6 @@ vi.mock("@superserve/ui", async (importOriginal) => {
 import { TeamSwitcher } from "./team-switcher"
 
 const twoRegions = {
-  switchingEnabled: true,
   activeTeamId: "team-a",
   activeRegion: "use",
   teams: [
@@ -91,7 +90,6 @@ describe("TeamSwitcher", () => {
 describe("TeamSwitcher ordering", () => {
   it("lists the active team first, the rest alphabetical", async () => {
     teamsData = {
-      switchingEnabled: true,
       activeTeamId: "team-m",
       activeRegion: "use",
       teams: [

--- a/apps/console/src/components/sidebar/team-switcher.tsx
+++ b/apps/console/src/components/sidebar/team-switcher.tsx
@@ -21,15 +21,14 @@ function optionValue(team: { id: string; region: string }): string {
 /**
  * Sidebar control for the active team — the team every dashboard surface
  * (sandboxes, keys, snapshots, billing) operates on. Hidden for single-team
- * users (nothing to switch between) and off the multi-cell UI allowlist
- * (switching rolls out person-by-person; the server enforces this too).
+ * users (nothing to switch between).
  */
 export function TeamSwitcher() {
   const { data } = useTeams()
   const switchTeam = useSwitchTeam()
   const { addToast } = useToast()
 
-  if (!data || !data.switchingEnabled || data.teams.length < 2) return null
+  if (!data || data.teams.length < 2) return null
 
   const active = data.teams.find(
     (t) => t.id === data.activeTeamId && t.region === data.activeRegion,

--- a/apps/console/src/lib/api/teams-actions.test.ts
+++ b/apps/console/src/lib/api/teams-actions.test.ts
@@ -12,8 +12,6 @@ vi.mock("@/lib/supabase/server", () => ({
 
 // Per-test knobs read lazily by the cells mock.
 let regions: string[] = ["use", "usw"]
-let allowedRegions: string[] | null = null
-let switchingAllowed = true
 let cellClients: Record<string, ReturnType<typeof recordingCellClient>> = {}
 
 // Records every write per table so tests can assert the full create chain
@@ -81,8 +79,6 @@ function recordingCellClient() {
 vi.mock("@/lib/cells", () => ({
   DEFAULT_REGION: "use",
   configuredRegions: () => regions,
-  creatableRegions: () => allowedRegions ?? regions,
-  multiCellUiEnabled: () => switchingAllowed,
   cellFor: (region: string) => {
     if (!regions.includes(region)) {
       throw new Error(`Region ${region} is not configured`)
@@ -129,7 +125,6 @@ import {
 describe("createTeamAction", () => {
   beforeEach(() => {
     regions = ["use", "usw"]
-    allowedRegions = null
     directoryTeams = []
     cookieValue = undefined
     cookieSets.length = 0
@@ -197,30 +192,9 @@ describe("createTeamAction", () => {
   })
 })
 
-describe("multi-cell allowlist enforcement", () => {
-  beforeEach(() => {
-    regions = ["use", "usw"]
-  })
-
-  it("rejects creating in a configured region the user is not allowed into", async () => {
-    allowedRegions = ["use"]
-    await expect(createTeamAction("Pilot", "usw")).rejects.toThrow(
-      "Region usw is not available",
-    )
-  })
-
-  it("returns only the user's creatable regions from the directory action", async () => {
-    allowedRegions = ["use"]
-    const { regions: visible } = await listTeamsAction()
-    expect(visible).toEqual(["use"])
-  })
-})
-
 describe("active team", () => {
   beforeEach(() => {
     regions = ["use", "usw"]
-    allowedRegions = null
-    switchingAllowed = true
     cookieValue = undefined
     cookieSets.length = 0
     directoryTeams = [
@@ -254,19 +228,5 @@ describe("active team", () => {
       "not a member",
     )
     expect(cookieSets).toEqual([])
-  })
-
-  it("setActiveTeamAction requires the multi-cell UI allowlist", async () => {
-    switchingAllowed = false
-    await expect(setActiveTeamAction("team-w", "usw")).rejects.toThrow(
-      "not enabled",
-    )
-    expect(cookieSets).toEqual([])
-  })
-
-  it("directory reports switching availability", async () => {
-    switchingAllowed = false
-    const { switchingEnabled } = await listTeamsAction()
-    expect(switchingEnabled).toBe(false)
   })
 })

--- a/apps/console/src/lib/api/teams-actions.ts
+++ b/apps/console/src/lib/api/teams-actions.ts
@@ -15,12 +15,7 @@ import {
   membershipExistsInCell,
 } from "@/lib/api/team-directory"
 import { provisionTeam } from "@/lib/api/team-provisioning"
-import {
-  configuredRegions,
-  creatableRegions,
-  DEFAULT_REGION,
-  multiCellUiEnabled,
-} from "@/lib/cells"
+import { configuredRegions, DEFAULT_REGION } from "@/lib/cells"
 import { createServerClient } from "@/lib/supabase/server"
 
 export interface TeamSummary {
@@ -31,18 +26,13 @@ export interface TeamSummary {
 
 export interface TeamDirectoryResponse {
   teams: TeamSummary[]
-  // Regions THIS USER may create teams in. Length 1 unless a second cell is
-  // configured AND the user is on the multi-cell UI allowlist — which is
-  // what gates the region select in the UI.
+  // Regions available for team creation, i.e. every configured cell.
   regions: string[]
   // The team every dashboard surface operates on. Identified by id AND
   // region: during a cross-cell migration the same team id can appear in
   // two cells at once, and only one of them is active.
   activeTeamId: string | null
   activeRegion: string | null
-  // Whether this user may switch teams. Rolls out with the multi-cell UI
-  // allowlist, person by person, like region choice.
-  switchingEnabled: boolean
 }
 
 export async function listTeamsAction(): Promise<TeamDirectoryResponse> {
@@ -64,10 +54,9 @@ export async function listTeamsAction(): Promise<TeamDirectoryResponse> {
   )
   return {
     teams,
-    regions: creatableRegions(user.email),
+    regions: configuredRegions(),
     activeTeamId: active?.teamId ?? null,
     activeRegion: active?.region ?? null,
-    switchingEnabled: multiCellUiEnabled(user.email),
   }
 }
 
@@ -96,12 +85,6 @@ export async function setActiveTeamAction(
     data: { user },
   } = await supabase.auth.getUser()
   if (!user) throw new Error("Not authenticated")
-
-  // Server-side enforcement, not just UI hiding: switching rolls out with
-  // the multi-cell allowlist (internal-first), like region choice.
-  if (!multiCellUiEnabled(user.email)) {
-    throw new Error("Team switching is not enabled for your account")
-  }
 
   // The target names its cell, so validate the membership there alone — the
   // every-cell fan-out buys nothing here and doubles the action's latency.
@@ -133,10 +116,8 @@ export async function createTeamAction(
   const trimmed = name.trim()
   if (!trimmed) throw new Error("Team name is required")
 
-  // Server-side enforcement, not just UI hiding: non-default regions
-  // require the multi-cell allowlist (internal-first rollout).
   const targetRegion = region ?? DEFAULT_REGION
-  if (!creatableRegions(user.email).includes(targetRegion)) {
+  if (!configuredRegions().includes(targetRegion)) {
     throw new Error(`Region ${targetRegion} is not available`)
   }
 

--- a/apps/console/src/lib/cells.test.ts
+++ b/apps/console/src/lib/cells.test.ts
@@ -10,12 +10,7 @@ vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: () => mockCreateAdminClient(),
 }))
 
-import {
-  cellFor,
-  configuredRegions,
-  creatableRegions,
-  DEFAULT_REGION,
-} from "./cells"
+import { cellFor, configuredRegions, DEFAULT_REGION } from "./cells"
 
 const ORIGINAL_ENV = {
   SANDBOX_API_URL: process.env.SANDBOX_API_URL,
@@ -126,34 +121,5 @@ describe("admin client reuse", () => {
     process.env.SUPABASE_USWEST_SERVICE_ROLE_KEY = "svc-key-b"
     cellFor("usw").createAdminClient()
     expect(mockCreateClient).toHaveBeenCalledTimes(2)
-  })
-})
-
-describe("multi-cell UI allowlist", () => {
-  beforeEach(() => {
-    process.env.SUPABASE_USWEST_URL = "https://usw.supabase.test"
-    process.env.SUPABASE_USWEST_SERVICE_ROLE_KEY = "svc-key"
-    delete process.env.MULTI_CELL_UI_ALLOWLIST
-  })
-
-  it("offers only the default region without an allowlist, even with usw live", () => {
-    expect(creatableRegions("dev@superserve.ai")).toEqual(["use"])
-  })
-
-  it("matches @domain entries case-insensitively", () => {
-    process.env.MULTI_CELL_UI_ALLOWLIST = "@superserve.ai"
-    expect(creatableRegions("Dev@Superserve.AI")).toEqual(["use", "usw"])
-    expect(creatableRegions("someone@customer.com")).toEqual(["use"])
-  })
-
-  it("matches exact-email entries and ignores list whitespace", () => {
-    process.env.MULTI_CELL_UI_ALLOWLIST = " pilot@acme.com , @superserve.ai "
-    expect(creatableRegions("pilot@acme.com")).toEqual(["use", "usw"])
-    expect(creatableRegions("other@acme.com")).toEqual(["use"])
-  })
-
-  it("denies undefined emails", () => {
-    process.env.MULTI_CELL_UI_ALLOWLIST = "@superserve.ai"
-    expect(creatableRegions(undefined)).toEqual(["use"])
   })
 })

--- a/apps/console/src/lib/cells.ts
+++ b/apps/console/src/lib/cells.ts
@@ -76,31 +76,3 @@ export function cellFor(region: string): Cell {
   if (!cell) throw new Error(`Region ${region} is not configured`)
   return cell
 }
-
-// Multi-cell UI allowlist. Region choice (and later the team switcher)
-// rolls out person-by-person, independent of which cells are
-// configured: MULTI_CELL_UI_ALLOWLIST is a comma-separated list of email
-// addresses and/or @domain entries (e.g. "@superserve.ai,pilot@acme.com").
-// Absent or unmatched, users see only the default region even when other
-// cells are live — so wiring a cell's env vars alone exposes nothing.
-export function multiCellUiEnabled(email: string | undefined): boolean {
-  const allowlist = process.env.MULTI_CELL_UI_ALLOWLIST
-  if (!allowlist || !email) return false
-  const normalized = email.toLowerCase()
-  return allowlist
-    .split(",")
-    .map((entry) => entry.trim().toLowerCase())
-    .filter(Boolean)
-    .some((entry) =>
-      entry.startsWith("@") ? normalized.endsWith(entry) : normalized === entry,
-    )
-}
-
-// Regions the given user may create teams in: everyone gets the default
-// cell; other configured cells require the allowlist.
-export function creatableRegions(email: string | undefined): string[] {
-  const regions = configuredRegions()
-  return multiCellUiEnabled(email)
-    ? regions
-    : regions.filter((r) => r === DEFAULT_REGION)
-}

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -159,7 +159,9 @@
               "GET /sandboxes/{sandbox_id}/network",
               "GET /sandboxes/{sandbox_id}/preview-ports",
               "POST /sandboxes/{sandbox_id}/preview-ports",
-              "DELETE /sandboxes/{sandbox_id}/preview-ports/{port}"
+              "DELETE /sandboxes/{sandbox_id}/preview-ports/{port}",
+              "POST /sandboxes/{sandbox_id}/preview-ports/{port}/token",
+              "POST /sandboxes/{sandbox_id}/preview-ports/{port}/token/rotate"
             ]
           },
           {


### PR DESCRIPTION
## Summary

Both US East and US West cells are configured and running in prod now, so this removes the `MULTI_CELL_UI_ALLOWLIST` email allowlist that gated the region select on team creation (and team switching) to a handful of internal accounts. Every user now sees both regions and can create/switch teams across them.

## Technical decisions

- Deleted `multiCellUiEnabled`/`creatableRegions` entirely rather than defaulting the allowlist to match-all — there's no reason to keep the rollout scaffolding around now that it's GA.
- `listTeamsAction`'s `regions` and `createTeamAction`'s region check now read `configuredRegions()` directly (every configured cell, no per-user filtering).
- Dropped `switchingEnabled` from `TeamDirectoryResponse` — team switcher visibility now depends only on `teams.length`, since switching is no longer gated separately from region choice.

## Testing

- `bun run typecheck` and full console test suite pass (498 tests).
- Verified locally end-to-end: ran a local Supabase stack + the console dev server, signed in as a plain user with no allowlist entry, confirmed the region select shows both US East/US West, created a team in US West, and confirmed the sidebar team switcher lists/switches across both regions.