### PR TITLE
sdk: pre-warm the data-plane connection during create and connect

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superserve/sdk",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "TypeScript SDK for the Superserve sandbox API",
   "keywords": [
     "firecracker",

--- a/packages/sdk/src/Sandbox.ts
+++ b/packages/sdk/src/Sandbox.ts
@@ -15,10 +15,15 @@
  */
 
 import { Commands } from "./commands.js"
-import { previewUrl, type ResolvedConfig, resolveConfig } from "./config.js"
+import {
+  previewUrl,
+  type ResolvedConfig,
+  resolveConfig,
+  sharedDataPlaneOrigin,
+} from "./config.js"
 import { NotFoundError, SandboxError } from "./errors.js"
 import { Files } from "./files.js"
-import { request, requestVoid } from "./http.js"
+import { prewarmOrigin, request, requestVoid } from "./http.js"
 import type {
   ApiNetworkPage,
   ApiSandboxResponse,
@@ -39,6 +44,16 @@ import type {
   SignedPreviewUrlOptions,
 } from "./types.js"
 import { toNetworkLogPage, toSandboxInfo } from "./types.js"
+
+/**
+ * Warm the shared data-plane connection in parallel with the control-plane
+ * call. No-op on per-sandbox-subdomain hosts, where the origin isn't known
+ * until the sandbox exists.
+ */
+function prewarmDataPlane(sandboxHost: string): void {
+  const origin = sharedDataPlaneOrigin(sandboxHost)
+  if (origin !== undefined) prewarmOrigin(origin)
+}
 
 export class Sandbox {
   /** Unique sandbox ID (UUID). */
@@ -159,6 +174,7 @@ export class Sandbox {
    */
   static async create(options: SandboxCreateOptions): Promise<Sandbox> {
     const config = resolveConfig(options)
+    prewarmDataPlane(config.sandboxHost)
 
     const body: Record<string, unknown> = { name: options.name }
     if (options.timeoutSeconds !== undefined)
@@ -218,6 +234,7 @@ export class Sandbox {
     options: ConnectionOptions = {},
   ): Promise<Sandbox> {
     const config = resolveConfig(options)
+    prewarmDataPlane(config.sandboxHost)
 
     const raw = await request<ApiSandboxResponse>({
       method: "POST",

--- a/packages/sdk/src/config.ts
+++ b/packages/sdk/src/config.ts
@@ -136,6 +136,19 @@ export interface DataPlaneTarget {
 }
 
 /**
+ * The shared data-plane origin for a sandbox host, or `undefined` when
+ * requests use per-sandbox subdomains instead (browsers, unsupported hosts).
+ */
+export function sharedDataPlaneOrigin(sandboxHost: string): string | undefined {
+  const isBrowser = typeof window !== "undefined"
+  const host = sandboxHost.toLowerCase()
+  if (!isBrowser && SUPPORTED_SHARED_HOSTS.has(host)) {
+    return `https://${host}`
+  }
+  return undefined
+}
+
+/**
  * Resolve the data-plane base URL + routing headers for a sandbox.
  *
  * On a supported host (server-side), routes via the shared origin with
@@ -146,16 +159,15 @@ export function dataPlaneTarget(
   sandboxId: string,
   sandboxHost: string,
 ): DataPlaneTarget {
-  const isBrowser = typeof window !== "undefined"
-  const host = sandboxHost.toLowerCase()
-  if (!isBrowser && SUPPORTED_SHARED_HOSTS.has(host)) {
+  const origin = sharedDataPlaneOrigin(sandboxHost)
+  if (origin !== undefined) {
     return {
-      url: `https://${host}`,
+      url: origin,
       headers: { [SANDBOX_ID_HEADER]: sandboxId },
     }
   }
   return {
-    url: `https://boxd-${sandboxId}.${host}`,
+    url: `https://boxd-${sandboxId}.${sandboxHost.toLowerCase()}`,
     headers: {},
   }
 }

--- a/packages/sdk/src/http.ts
+++ b/packages/sdk/src/http.ts
@@ -304,6 +304,20 @@ export async function requestVoid(opts: RequestOptions): Promise<void> {
 }
 
 /**
+ * Fire-and-forget connection warm-up: opens a keep-alive connection to the
+ * origin so the next request skips the TCP/TLS handshake. The body is
+ * drained to return the connection to the pool; failures are swallowed.
+ */
+export function prewarmOrigin(origin: string): void {
+  void fetch(`${origin}/health`, {
+    headers: { "User-Agent": USER_AGENT },
+    signal: AbortSignal.timeout(5_000),
+  })
+    .then((res) => res.arrayBuffer())
+    .catch(() => {})
+}
+
+/**
  * Upload raw bytes to a URL. Used for file upload to the data plane.
  *
  * Not retried — POST is not idempotent.

--- a/packages/sdk/src/http.ts
+++ b/packages/sdk/src/http.ts
@@ -20,7 +20,7 @@ import type { ApiExecStreamEvent } from "./types.js"
 
 const DEFAULT_TIMEOUT_MS = 30_000
 
-const SDK_VERSION = "0.8.2"
+const SDK_VERSION = "0.8.3"
 const USER_AGENT = `@superserve/sdk/${SDK_VERSION} (node/${
   typeof process !== "undefined" && process.versions?.node
     ? `v${process.versions.node}`

--- a/packages/sdk/tests/config.test.ts
+++ b/packages/sdk/tests/config.test.ts
@@ -7,6 +7,7 @@ import {
   previewUrl,
   RESERVED_PREVIEW_PORT,
   resolveConfig,
+  sharedDataPlaneOrigin,
 } from "../src/config.js"
 import { AuthenticationError, ValidationError } from "../src/errors.js"
 
@@ -282,5 +283,20 @@ describe("previewUrl", () => {
   it("throws ValidationError for non-integer ports", () => {
     expect(() => previewUrl("a", "h", 3000.5)).toThrow(ValidationError)
     expect(() => previewUrl("a", "h", Number.NaN)).toThrow(ValidationError)
+  })
+})
+
+describe("sharedDataPlaneOrigin", () => {
+  it("returns the shared origin for supported hosts", () => {
+    expect(sharedDataPlaneOrigin("sandbox.superserve.ai")).toBe(
+      "https://sandbox.superserve.ai",
+    )
+    expect(sharedDataPlaneOrigin("Sandbox.SuperServe.AI")).toBe(
+      "https://sandbox.superserve.ai",
+    )
+  })
+
+  it("returns undefined for unsupported hosts (per-sandbox subdomains)", () => {
+    expect(sharedDataPlaneOrigin("self-hosted.example.org")).toBeUndefined()
   })
 })

--- a/packages/sdk/tests/network.test.ts
+++ b/packages/sdk/tests/network.test.ts
@@ -34,7 +34,11 @@ async function createSandbox(
     name: "agent-1",
     ...extra,
   })
-  const body = JSON.parse(mock.mock.calls[0][1].body as string)
+  // Skip the data-plane pre-warm ping; find the create POST.
+  const createCall = mock.mock.calls.find(([url]) =>
+    String(url).endsWith("/sandboxes"),
+  ) as [string, RequestInit]
+  const body = JSON.parse(createCall[1].body as string)
   vi.unstubAllGlobals()
   return { sandbox, body }
 }

--- a/packages/sdk/tests/sandbox.test.ts
+++ b/packages/sdk/tests/sandbox.test.ts
@@ -41,6 +41,14 @@ const commonOpts = {
   baseUrl: "https://api.superserve.ai",
 }
 
+/** The nth control-plane call, skipping the data-plane pre-warm ping. */
+function apiCall(mock: ReturnType<typeof vi.fn>, i = 0): [string, RequestInit] {
+  const calls = mock.mock.calls.filter(
+    ([url]) => !String(url).endsWith("/health"),
+  )
+  return calls[i] as [string, RequestInit]
+}
+
 describe("Sandbox#getPreviewUrl", () => {
   afterEach(() => {
     vi.unstubAllGlobals()
@@ -94,7 +102,7 @@ describe("Sandbox statics", () => {
     expect(sandbox.id).toBe("sbx-1")
     expect(sandbox.status).toBe("active")
 
-    const [url, init] = mock.mock.calls[0] as [string, RequestInit]
+    const [url, init] = apiCall(mock)
     expect(url).toBe("https://api.superserve.ai/sandboxes")
     expect(init.method).toBe("POST")
     const headers = init.headers as Record<string, string>
@@ -113,7 +121,7 @@ describe("Sandbox statics", () => {
       autoDeleteSeconds: 3600,
     })
 
-    const [, init] = mock.mock.calls[0] as [string, RequestInit]
+    const [, init] = apiCall(mock)
     const body = JSON.parse(init.body as string)
     expect(body).toEqual({ name: "my-sandbox", auto_delete_seconds: 3600 })
   })
@@ -130,7 +138,7 @@ describe("Sandbox statics", () => {
       previewAccess: "private",
     })
 
-    const [, init] = mock.mock.calls[0] as [string, RequestInit]
+    const [, init] = apiCall(mock)
     expect(JSON.parse(init.body as string)).toEqual({
       name: "my-sandbox",
       preview_access: "private",
@@ -219,6 +227,16 @@ describe("Sandbox statics", () => {
     })
   })
 
+  it("Sandbox.create pre-warms the shared data-plane origin", async () => {
+    const mock = vi.fn(async () => jsonResponse(baseSandbox))
+    vi.stubGlobal("fetch", mock)
+
+    await Sandbox.create({ ...commonOpts, name: "my-sandbox" })
+
+    const urls = mock.mock.calls.map(([url]) => String(url))
+    expect(urls).toContain("https://sandbox.superserve.ai/health")
+  })
+
   it("Sandbox.create throws when access_token missing", async () => {
     vi.stubGlobal(
       "fetch",
@@ -238,7 +256,7 @@ describe("Sandbox statics", () => {
     const sandbox = await Sandbox.connect("sbx-1", commonOpts)
     expect(sandbox.id).toBe("sbx-1")
 
-    const [url, init] = mock.mock.calls[0] as [string, RequestInit]
+    const [url, init] = apiCall(mock)
     expect(url).toBe("https://api.superserve.ai/sandboxes/sbx-1/activate")
     expect(init.method).toBe("POST")
   })
@@ -563,7 +581,7 @@ describe("Sandbox.create fromTemplate / fromSnapshot", () => {
       fromTemplate: "superserve/python-3.11",
     })
 
-    const [, init] = mock.mock.calls[0] as [string, RequestInit]
+    const [, init] = apiCall(mock)
     const body = JSON.parse(init.body as string)
     expect(body.from_template).toBe("superserve/python-3.11")
   })
@@ -578,7 +596,7 @@ describe("Sandbox.create fromTemplate / fromSnapshot", () => {
       fromTemplate: { name: "my-env", id: "t-1" },
     })
 
-    const [, init] = mock.mock.calls[0] as [string, RequestInit]
+    const [, init] = apiCall(mock)
     const body = JSON.parse(init.body as string)
     expect(body.from_template).toBe("my-env")
   })
@@ -593,7 +611,7 @@ describe("Sandbox.create fromTemplate / fromSnapshot", () => {
       fromTemplate: { id: "t-1" },
     })
 
-    const [, init] = mock.mock.calls[0] as [string, RequestInit]
+    const [, init] = apiCall(mock)
     const body = JSON.parse(init.body as string)
     expect(body.from_template).toBe("t-1")
   })
@@ -608,7 +626,7 @@ describe("Sandbox.create fromTemplate / fromSnapshot", () => {
       fromSnapshot: "snap-abc",
     })
 
-    const [, init] = mock.mock.calls[0] as [string, RequestInit]
+    const [, init] = apiCall(mock)
     const body = JSON.parse(init.body as string)
     expect(body.from_snapshot).toBe("snap-abc")
   })


### PR DESCRIPTION
`Sandbox.create()` and `Sandbox.connect()` now fire a fire-and-forget `GET /health` at the shared data-plane origin before their control-plane request, so the TCP/TLS handshake happens in parallel with sandbox creation/activation instead of in front of the first command or file operation.

- `sharedDataPlaneOrigin()` (config): the shared origin when shared-host routing applies, `undefined` in per-sandbox-subdomain mode (browsers, unsupported hosts). `dataPlaneTarget()` now delegates to it so the routing-mode logic exists once.
- `prewarmOrigin()` (http): fire-and-forget GET with a 5s abort; body drained so the keep-alive connection returns to the pool; all failures swallowed — if the ping fails, the first real request dials exactly as before.
- No-op in browsers and on self-hosted domains, where the per-sandbox origin isn't known until the sandbox exists.

Tests: new coverage for `sharedDataPlaneOrigin` and for the pre-warm call on create; existing assertions that indexed raw `fetch` mock calls now select the control-plane call explicitly.