### PR TITLE
sdk: desktop namespace and MCP computer tool

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -110,27 +110,28 @@ It serves the MCP endpoint at `/` (POST) and a `GET /health` liveness probe. Con
 
 ## Tools
 
-| Tool                         | Description                                                                            |
-| ---------------------------- | -------------------------------------------------------------------------------------- |
-| `sandbox_create`             | Create a sandbox; returns its `id`. Accepts `secrets` bindings and egress rules.       |
-| `sandbox_update`             | Change a sandbox's metadata or egress (`allow_out`/`deny_out`) rules after creation.   |
-| `sandbox_list`               | List sandboxes (active and paused), filterable by metadata.                            |
-| `sandbox_info`               | Get a sandbox's status, resources, metadata, network rules, and secret bindings.       |
-| `sandbox_exec`               | Run a shell command; returns stdout, stderr, exit code. Auto-resumes a paused sandbox. |
-| `sandbox_files_read`         | Read a file (UTF-8 text or base64). Rejects files over 1 MiB.                          |
-| `sandbox_files_write`        | Create or overwrite a file (inline content capped at 8 MiB).                           |
-| `sandbox_files_list`         | List a directory.                                                                      |
-| `sandbox_files_download_dir` | Download a directory as a base64 ZIP (symlinks skipped). Capped at 10 MiB.             |
-| `sandbox_pause`              | Pause a sandbox (state preserved).                                                     |
-| `sandbox_resume`             | Resume a paused sandbox (usually unnecessary — exec auto-resumes).                     |
-| `sandbox_kill`               | Delete a sandbox.                                                                      |
-| `sandbox_preview_url`        | Publish a port and return a public or private signed preview URL.                      |
-| `sandbox_network_log`        | Audit a sandbox's outbound connections.                                                |
-| `sandbox_template_list`      | List the templates (prebuilt base images) your team can create sandboxes from.         |
-| `sandbox_template_create`    | Build a custom template (vCPU/memory/disk shape, preinstalled software). Async.        |
-| `secret_list`                | List bindable team secrets (metadata only — never values).                             |
-| `sandbox_attach_secret`      | Bind a stored secret to a sandbox under an env var.                                    |
-| `sandbox_detach_secret`      | Remove a secret binding from a sandbox.                                                |
+| Tool                         | Description                                                                                                                         |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `sandbox_create`             | Create a sandbox; returns its `id`. Accepts `secrets` bindings and egress rules.                                                    |
+| `sandbox_update`             | Change a sandbox's metadata or egress (`allow_out`/`deny_out`) rules after creation.                                                |
+| `sandbox_list`               | List sandboxes (active and paused), filterable by metadata.                                                                         |
+| `sandbox_info`               | Get a sandbox's status, resources, metadata, network rules, and secret bindings.                                                    |
+| `sandbox_exec`               | Run a shell command; returns stdout, stderr, exit code. Auto-resumes a paused sandbox.                                              |
+| `sandbox_computer`           | Drive a GUI desktop sandbox: screenshot, mouse, keyboard, scroll, resize, live viewer URL. Input actions return a fresh screenshot. |
+| `sandbox_files_read`         | Read a file (UTF-8 text or base64). Rejects files over 1 MiB.                                                                       |
+| `sandbox_files_write`        | Create or overwrite a file (inline content capped at 8 MiB).                                                                        |
+| `sandbox_files_list`         | List a directory.                                                                                                                   |
+| `sandbox_files_download_dir` | Download a directory as a base64 ZIP (symlinks skipped). Capped at 10 MiB.                                                          |
+| `sandbox_pause`              | Pause a sandbox (state preserved).                                                                                                  |
+| `sandbox_resume`             | Resume a paused sandbox (usually unnecessary — exec auto-resumes).                                                                  |
+| `sandbox_kill`               | Delete a sandbox.                                                                                                                   |
+| `sandbox_preview_url`        | Publish a port and return a public or private signed preview URL.                                                                   |
+| `sandbox_network_log`        | Audit a sandbox's outbound connections.                                                                                             |
+| `sandbox_template_list`      | List the templates (prebuilt base images) your team can create sandboxes from.                                                      |
+| `sandbox_template_create`    | Build a custom template (vCPU/memory/disk shape, preinstalled software). Async.                                                     |
+| `secret_list`                | List bindable team secrets (metadata only — never values).                                                                          |
+| `sandbox_attach_secret`      | Bind a stored secret to a sandbox under an env var.                                                                                 |
+| `sandbox_detach_secret`      | Remove a secret binding from a sandbox.                                                                                             |
 
 All tools take a `sandbox_id` except `sandbox_create`, `sandbox_list`, `sandbox_template_list`, `sandbox_template_create`, and `secret_list`. Secret _creation_ is intentionally not exposed (the raw value belongs on the SDK/console, not an agent transcript); the server only binds existing secrets.
 

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -25,6 +25,8 @@ import {
 import type {
   BuildStep,
   CommandResult,
+  DesktopAction,
+  Screenshot,
   NetworkConfig,
   NetworkEvent,
   NetworkLogPage,
@@ -238,6 +240,13 @@ export interface SandboxClient {
   pause(id: string): Promise<void>
   resume(id: string): Promise<SandboxSummary>
   kill(id: string): Promise<void>
+  /** Capture the desktop as PNG bytes + dimensions (desktop templates only). */
+  desktopScreenshot(id: string): Promise<Screenshot>
+  /** Execute an ordered input batch under the sandbox's input lock. */
+  desktopActions(id: string, actions: DesktopAction[]): Promise<void>
+  desktopResize(id: string, width: number, height: number): Promise<void>
+  /** Publish the noVNC viewer port and return its browser URL. */
+  desktopStreamUrl(id: string): Promise<string>
 }
 
 function defaultName(): string {
@@ -553,6 +562,26 @@ export function createSdkClient(config: ClientConfig): SandboxClient {
       throw new SandboxError(
         `Could not list ${path}${detail ? `: ${detail}` : ""}`,
       )
+    },
+
+    async desktopScreenshot(id) {
+      const sb = await Sandbox.connect(id, conn)
+      return sb.desktop.screenshot()
+    },
+
+    async desktopActions(id, actions) {
+      const sb = await Sandbox.connect(id, conn)
+      await sb.desktop.actions(actions)
+    },
+
+    async desktopResize(id, width, height) {
+      const sb = await Sandbox.connect(id, conn)
+      await sb.desktop.resize(width, height)
+    },
+
+    async desktopStreamUrl(id) {
+      const sb = await Sandbox.connect(id, conn)
+      return sb.desktop.getStreamUrl()
     },
 
     async pause(id) {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -12,6 +12,7 @@ import {
   SERVER_VERSION,
 } from "./constants.js"
 import { McpServer } from "./lib/sdk.js"
+import { registerComputerTool } from "./tools/computer.js"
 import { registerExecTool } from "./tools/exec.js"
 import { registerFileTools } from "./tools/files.js"
 import { registerLifecycleTools } from "./tools/lifecycle.js"
@@ -31,6 +32,7 @@ export function createServer(client: SandboxClient): McpServer {
 
   registerLifecycleTools(server, client)
   registerExecTool(server, client)
+  registerComputerTool(server, client)
   registerFileTools(server, client)
   registerSecretTools(server, client)
 

--- a/packages/mcp/src/tools/computer.ts
+++ b/packages/mcp/src/tools/computer.ts
@@ -1,0 +1,272 @@
+/**
+ * `sandbox_computer` — drive a GUI desktop sandbox: screenshot, mouse,
+ * keyboard, scroll. One action per call, mirroring the action vocabulary
+ * computer-use models are trained on, so an agent loop needs zero glue code.
+ *
+ * Input actions return a fresh screenshot by default (`screenshot_after`),
+ * collapsing the model's act-then-look turn into one tool call.
+ */
+
+import type { DesktopAction, MouseButton } from "@superserve/sdk"
+import { z } from "zod"
+
+import type { SandboxClient } from "../client.js"
+import { formatSdkError } from "../lib/errors.js"
+import { toolError, toolOk } from "../lib/result.js"
+import type { CallToolResult, McpServer } from "../lib/sdk.js"
+import { defineTool } from "../lib/tool.js"
+
+/** Local wait cap — `wait` exists for UI settling, not scheduling. */
+const MAX_WAIT_MS = 10_000
+
+/**
+ * Pause before a post-action screenshot so the application has repainted.
+ * ponytail: fixed settle delay; replace with server-side changed-frame
+ * detection when it lands.
+ */
+const SETTLE_MS = 300
+
+const COMPUTER_ACTIONS = [
+  "screenshot",
+  "left_click",
+  "right_click",
+  "middle_click",
+  "double_click",
+  "triple_click",
+  "left_click_drag",
+  "left_mouse_down",
+  "left_mouse_up",
+  "mouse_move",
+  "key",
+  "type",
+  "scroll",
+  "wait",
+  "resize",
+  "stream_url",
+] as const
+
+type ComputerAction = (typeof COMPUTER_ACTIONS)[number]
+
+interface ComputerArgs {
+  sandbox_id: string
+  action: ComputerAction
+  coordinate?: [number, number]
+  start_coordinate?: [number, number]
+  text?: string
+  scroll_direction?: "up" | "down" | "left" | "right"
+  scroll_amount?: number
+  duration_ms?: number
+  width?: number
+  height?: number
+  screenshot_after?: boolean
+}
+
+const CLICK_BUTTONS: Partial<Record<ComputerAction, MouseButton>> = {
+  left_click: "left",
+  right_click: "right",
+  middle_click: "middle",
+}
+
+function need<T>(value: T | undefined, what: string, action: string): T {
+  if (value === undefined) {
+    throw new Error(`${action} requires ${what}`)
+  }
+  return value
+}
+
+/** Lower one tool call into the SDK's batch-action shape. */
+function toDesktopActions(args: ComputerArgs): DesktopAction[] {
+  const action = args.action
+  const coord = () => {
+    const [x, y] = need(args.coordinate, "coordinate [x, y]", action)
+    return { x, y }
+  }
+  switch (action) {
+    case "left_click":
+    case "right_click":
+    case "middle_click":
+      return [{ type: "click", ...coord(), button: CLICK_BUTTONS[action] }]
+    case "double_click":
+      return [{ type: "doubleClick", ...coord() }]
+    case "triple_click": {
+      const c = coord()
+      return [
+        { type: "click", ...c },
+        { type: "click", ...c },
+        { type: "click", ...c },
+      ]
+    }
+    case "left_click_drag": {
+      const [sx, sy] = need(
+        args.start_coordinate,
+        "start_coordinate [x, y]",
+        action,
+      )
+      const { x, y } = coord()
+      return [
+        { type: "mouseDown", x: sx, y: sy },
+        { type: "move", x, y },
+        { type: "mouseUp", x, y },
+      ]
+    }
+    case "left_mouse_down":
+      return [{ type: "mouseDown", ...coord() }]
+    case "left_mouse_up":
+      return [{ type: "mouseUp", ...coord() }]
+    case "mouse_move":
+      return [{ type: "move", ...coord() }]
+    case "key":
+      return [{ type: "press", key: need(args.text, "text", action) }]
+    case "type":
+      return [{ type: "write", text: need(args.text, "text", action) }]
+    case "scroll": {
+      const direction = need(args.scroll_direction, "scroll_direction", action)
+      const amount = args.scroll_amount ?? 3
+      const scroll: DesktopAction = {
+        type: "scroll",
+        dx: direction === "left" ? -amount : direction === "right" ? amount : 0,
+        dy: direction === "up" ? -amount : direction === "down" ? amount : 0,
+      }
+      // With a coordinate, position the pointer first — scroll targets
+      // whatever is under it.
+      return args.coordinate ? [{ type: "move", ...coord() }, scroll] : [scroll]
+    }
+    default:
+      throw new Error(`${action} is not an input action`)
+  }
+}
+
+function screenshotResult(
+  shot: { data: Uint8Array; width: number; height: number },
+  note: string,
+): CallToolResult {
+  return {
+    content: [
+      { type: "text", text: `${note} (${shot.width}x${shot.height})` },
+      {
+        type: "image",
+        data: Buffer.from(shot.data).toString("base64"),
+        mimeType: "image/png",
+      },
+    ],
+    structuredContent: { width: shot.width, height: shot.height },
+  }
+}
+
+export function registerComputerTool(
+  server: McpServer,
+  client: SandboxClient,
+): void {
+  defineTool<ComputerArgs>(
+    server,
+    "sandbox_computer",
+    {
+      title: "Control a desktop sandbox (computer use)",
+      description:
+        "Drive a GUI desktop in a Superserve sandbox (requires a desktop template, e.g. superserve/desktop): " +
+        "capture screenshots and send mouse/keyboard input. One action per call. " +
+        "Input actions return a fresh screenshot of the result by default. " +
+        "Screen coordinates are [x, y] pixels with the origin at the top-left. " +
+        "Paused sandboxes are resumed automatically.",
+      inputSchema: {
+        sandbox_id: z.string().describe("ID of the desktop sandbox."),
+        action: z
+          .enum(COMPUTER_ACTIONS)
+          .describe(
+            "screenshot: capture the screen. " +
+              "left_click / right_click / middle_click / double_click / triple_click: click at `coordinate`. " +
+              "left_click_drag: drag from `start_coordinate` to `coordinate`. " +
+              "left_mouse_down / left_mouse_up: press/release at `coordinate`. " +
+              "mouse_move: move the pointer to `coordinate`. " +
+              "key: press a key or chord from `text` (e.g. 'Return', 'ctrl+s'). " +
+              "type: type the literal `text`. " +
+              "scroll: scroll `scroll_direction` by `scroll_amount` clicks (optionally at `coordinate`). " +
+              "wait: pause `duration_ms` for the UI to settle. " +
+              "resize: set the display to `width` x `height`. " +
+              "stream_url: get a live browser viewer URL for the desktop.",
+          ),
+        coordinate: z
+          .tuple([z.number().int().min(0), z.number().int().min(0)])
+          .optional()
+          .describe("[x, y] target pixel for pointer actions."),
+        start_coordinate: z
+          .tuple([z.number().int().min(0), z.number().int().min(0)])
+          .optional()
+          .describe("[x, y] drag origin (left_click_drag only)."),
+        text: z
+          .string()
+          .optional()
+          .describe("Key/chord for `key`, literal text for `type`."),
+        scroll_direction: z.enum(["up", "down", "left", "right"]).optional(),
+        scroll_amount: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe("Scroll wheel clicks (default 3)."),
+        duration_ms: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe(`Wait duration in ms (clamped to ${MAX_WAIT_MS}).`),
+        width: z.number().int().positive().optional(),
+        height: z.number().int().positive().optional(),
+        screenshot_after: z
+          .boolean()
+          .optional()
+          .describe(
+            "Return a screenshot after input actions (default true). " +
+              "Set false when batching several actions back-to-back.",
+          ),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
+    },
+    async (args) => {
+      const { sandbox_id, action } = args
+      try {
+        switch (action) {
+          case "screenshot":
+            return screenshotResult(
+              await client.desktopScreenshot(sandbox_id),
+              "screenshot",
+            )
+          case "wait": {
+            const ms = Math.min(args.duration_ms ?? 1000, MAX_WAIT_MS)
+            // Local sleep — never a round trip to the sandbox.
+            await new Promise((resolve) => setTimeout(resolve, ms))
+            return toolOk(`waited ${ms}ms`, { waited_ms: ms })
+          }
+          case "resize": {
+            const width = need(args.width, "width", action)
+            const height = need(args.height, "height", action)
+            await client.desktopResize(sandbox_id, width, height)
+            return toolOk(`resized to ${width}x${height}`, { width, height })
+          }
+          case "stream_url": {
+            const url = await client.desktopStreamUrl(sandbox_id)
+            return toolOk(url, { url })
+          }
+          default: {
+            await client.desktopActions(sandbox_id, toDesktopActions(args))
+            if (args.screenshot_after === false) {
+              return toolOk(`${action} done`, { action })
+            }
+            await new Promise((resolve) => setTimeout(resolve, SETTLE_MS))
+            return screenshotResult(
+              await client.desktopScreenshot(sandbox_id),
+              `${action} done`,
+            )
+          }
+        }
+      } catch (e) {
+        return toolError(formatSdkError(e))
+      }
+    },
+  )
+}

--- a/packages/mcp/tests/computer.test.ts
+++ b/packages/mcp/tests/computer.test.ts
@@ -1,0 +1,163 @@
+/** `sandbox_computer` — action lowering, screenshots, and error paths. */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import { createFakeClient, type FakeClient } from "./fake-client.js"
+import { callTool, connect, type ConnectedClient } from "./harness.js"
+
+describe("sandbox_computer (in-memory, fake client)", () => {
+  let fake: FakeClient
+  let conn: ConnectedClient
+  let sandboxId: string
+
+  beforeEach(async () => {
+    fake = createFakeClient()
+    conn = await connect(fake.client)
+    const created = await callTool(conn.client, "sandbox_create", {
+      name: "desk",
+    })
+    sandboxId = created.structured.id as string
+  })
+
+  afterEach(async () => {
+    await conn.close()
+  })
+
+  /** Raw callTool so image content blocks are visible. */
+  async function callRaw(args: Record<string, unknown>) {
+    return (await conn.client.callTool({
+      name: "sandbox_computer",
+      arguments: { sandbox_id: sandboxId, ...args },
+    })) as {
+      content: Array<{ type: string; text?: string; mimeType?: string }>
+      structuredContent?: Record<string, unknown>
+      isError?: boolean
+    }
+  }
+
+  it("screenshot returns an image block with dimensions", async () => {
+    const res = await callRaw({ action: "screenshot" })
+    expect(res.isError).toBeFalsy()
+    const image = res.content.find((c) => c.type === "image")
+    expect(image?.mimeType).toBe("image/png")
+    expect(res.structuredContent).toEqual({ width: 1280, height: 800 })
+  })
+
+  it("left_click lowers to one click action and returns a screenshot", async () => {
+    const res = await callRaw({ action: "left_click", coordinate: [10, 20] })
+    expect(res.isError).toBeFalsy()
+    expect(fake.desktopBatches).toEqual([
+      [{ type: "click", x: 10, y: 20, button: "left" }],
+    ])
+    expect(res.content.some((c) => c.type === "image")).toBe(true)
+  })
+
+  it("screenshot_after: false skips the trailing screenshot", async () => {
+    const res = await callRaw({
+      action: "left_click",
+      coordinate: [1, 1],
+      screenshot_after: false,
+    })
+    expect(res.content.some((c) => c.type === "image")).toBe(false)
+  })
+
+  it("left_click_drag lowers to down-move-up in one batch", async () => {
+    await callRaw({
+      action: "left_click_drag",
+      start_coordinate: [5, 6],
+      coordinate: [50, 60],
+      screenshot_after: false,
+    })
+    expect(fake.desktopBatches).toEqual([
+      [
+        { type: "mouseDown", x: 5, y: 6 },
+        { type: "move", x: 50, y: 60 },
+        { type: "mouseUp", x: 50, y: 60 },
+      ],
+    ])
+  })
+
+  it("triple_click is three clicks in one batch", async () => {
+    await callRaw({
+      action: "triple_click",
+      coordinate: [7, 8],
+      screenshot_after: false,
+    })
+    expect(fake.desktopBatches[0]).toHaveLength(3)
+    expect(fake.desktopBatches[0][0]).toEqual({ type: "click", x: 7, y: 8 })
+  })
+
+  it("key and type lower to press and write", async () => {
+    await callRaw({ action: "key", text: "ctrl+s", screenshot_after: false })
+    await callRaw({ action: "type", text: "hello", screenshot_after: false })
+    expect(fake.desktopBatches).toEqual([
+      [{ type: "press", key: "ctrl+s" }],
+      [{ type: "write", text: "hello" }],
+    ])
+  })
+
+  it("scroll maps direction to signed deltas, with optional positioning", async () => {
+    await callRaw({
+      action: "scroll",
+      scroll_direction: "up",
+      scroll_amount: 5,
+      screenshot_after: false,
+    })
+    expect(fake.desktopBatches[0]).toEqual([{ type: "scroll", dx: 0, dy: -5 }])
+
+    await callRaw({
+      action: "scroll",
+      scroll_direction: "right",
+      coordinate: [100, 200],
+      screenshot_after: false,
+    })
+    expect(fake.desktopBatches[1]).toEqual([
+      { type: "move", x: 100, y: 200 },
+      { type: "scroll", dx: 3, dy: 0 },
+    ])
+  })
+
+  it("resize calls through and reports the new size", async () => {
+    const res = await callTool(conn.client, "sandbox_computer", {
+      sandbox_id: sandboxId,
+      action: "resize",
+      width: 1024,
+      height: 768,
+    })
+    expect(res.isError).toBe(false)
+    expect(fake.resizes).toEqual([{ width: 1024, height: 768 }])
+    expect(res.structured).toEqual({ width: 1024, height: 768 })
+  })
+
+  it("stream_url returns the viewer URL", async () => {
+    const res = await callTool(conn.client, "sandbox_computer", {
+      sandbox_id: sandboxId,
+      action: "stream_url",
+    })
+    expect(res.structured.url).toContain("/vnc.html")
+  })
+
+  it("wait sleeps locally without touching the sandbox", async () => {
+    const res = await callTool(conn.client, "sandbox_computer", {
+      sandbox_id: sandboxId,
+      action: "wait",
+      duration_ms: 10,
+    })
+    expect(res.structured).toEqual({ waited_ms: 10 })
+    expect(fake.desktopBatches).toEqual([])
+  })
+
+  it("missing required params is a tool error, not a crash", async () => {
+    const res = await callRaw({ action: "left_click" })
+    expect(res.isError).toBe(true)
+    expect(res.content[0].text).toContain("coordinate")
+  })
+
+  it("unknown sandbox is a tool error", async () => {
+    const res = await callTool(conn.client, "sandbox_computer", {
+      sandbox_id: "sbx-missing",
+      action: "screenshot",
+    })
+    expect(res.isError).toBe(true)
+  })
+})

--- a/packages/mcp/tests/fake-client.ts
+++ b/packages/mcp/tests/fake-client.ts
@@ -12,6 +12,7 @@ import type {
   SandboxSecretBinding,
   SandboxStatus,
 } from "@superserve/sdk"
+import type { DesktopAction, Screenshot } from "@superserve/sdk"
 
 import type {
   ExecInput,
@@ -48,6 +49,12 @@ export interface FakeClient {
   networkEvents: NetworkEvent[]
   /** The options the most recent `exec` call received (for asserting clamps). */
   lastExec: { command: string; opts: ExecInput } | undefined
+  /** Every desktopActions batch received, in order (for asserting lowering). */
+  desktopBatches: DesktopAction[][]
+  /** Screenshot returned by desktopScreenshot (seed-able). */
+  screenshot: Screenshot
+  /** Every desktopResize call received. */
+  resizes: Array<{ width: number; height: number }>
 }
 
 export function createFakeClient(): FakeClient {
@@ -56,6 +63,14 @@ export function createFakeClient(): FakeClient {
   const secrets: SecretSummary[] = []
   const networkEvents: NetworkEvent[] = []
   const fake: Pick<FakeClient, "lastExec"> = { lastExec: undefined }
+  const desktopBatches: DesktopAction[][] = []
+  const resizes: Array<{ width: number; height: number }> = []
+  // Not a decodable PNG — the MCP layer treats image bytes as opaque.
+  const screenshot: Screenshot = {
+    data: new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
+    width: 1280,
+    height: 800,
+  }
   let counter = 0
 
   const must = (id: string): FakeSandbox => {
@@ -303,6 +318,25 @@ export function createFakeClient(): FakeClient {
       // Idempotent: deleting a missing sandbox is a no-op.
       sandboxes.delete(id)
     },
+
+    async desktopScreenshot(id) {
+      must(id)
+      return screenshot
+    },
+
+    async desktopActions(id, actions) {
+      must(id)
+      desktopBatches.push(actions)
+    },
+
+    async desktopResize(id, width, height) {
+      must(id)
+      resizes.push({ width, height })
+    },
+
+    async desktopStreamUrl(id) {
+      return `https://6080-${must(id).id}.sandbox.example.com/vnc.html?autoconnect=1`
+    },
   }
 
   return {
@@ -314,5 +348,8 @@ export function createFakeClient(): FakeClient {
     get lastExec() {
       return fake.lastExec
     },
+    desktopBatches,
+    screenshot,
+    resizes,
   }
 }

--- a/packages/mcp/tests/schemas.test.ts
+++ b/packages/mcp/tests/schemas.test.ts
@@ -11,6 +11,7 @@ const EXPECTED_TOOLS = [
   "sandbox_list",
   "sandbox_info",
   "sandbox_exec",
+  "sandbox_computer",
   "sandbox_files_read",
   "sandbox_files_write",
   "sandbox_files_list",

--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -50,6 +50,31 @@ sandbox to strict `public`. `legacy_public` is returned only for pre-migration
 sandboxes.
 See the [preview URL guide](https://docs.superserve.ai/sandbox/preview-urls).
 
+## Desktop (computer use)
+
+Control a GUI desktop inside a sandbox — screenshot, mouse, keyboard, and a
+live browser viewer. Requires a desktop-enabled template.
+
+```python
+sandbox = Sandbox.create(template="superserve/desktop")
+
+shot = sandbox.desktop.screenshot()  # PNG bytes + dimensions
+sandbox.desktop.click(640, 400)
+sandbox.desktop.write("hello")  # no per-character pacing
+sandbox.desktop.press("ctrl+l")
+sandbox.desktop.drag((10, 10), (200, 200))  # one atomic request
+
+# Several model-emitted actions in a single round trip:
+sandbox.desktop.actions([
+    {"type": "click", "x": 640, "y": 32},
+    {"type": "write", "text": "https://example.com"},
+    {"type": "press", "key": "enter"},
+])
+
+sandbox.desktop.resize(1920, 1080)  # live, no restart
+viewer = sandbox.desktop.get_stream_url()  # noVNC URL
+```
+
 ## Authentication
 
 Set the `SUPERSERVE_API_KEY` environment variable:

--- a/packages/python-sdk/src/superserve/__init__.py
+++ b/packages/python-sdk/src/superserve/__init__.py
@@ -10,6 +10,7 @@ from .async_sandbox import AsyncSandbox
 from .async_secrets import AsyncSecret
 from .async_template import AsyncTemplate
 from .command_session import AsyncCommandSession
+from .desktop import DESKTOP_STREAM_PORT, AsyncDesktop, Desktop, Screenshot
 from .errors import (
     AuthenticationError,
     BuildError,
@@ -63,6 +64,10 @@ __version__ = "0.8.2"
 
 __all__ = [
     "AsyncCommandSession",
+    "AsyncDesktop",
+    "Desktop",
+    "DESKTOP_STREAM_PORT",
+    "Screenshot",
     "AsyncProvider",
     "AsyncSandbox",
     "AsyncSecret",

--- a/packages/python-sdk/src/superserve/async_sandbox.py
+++ b/packages/python-sdk/src/superserve/async_sandbox.py
@@ -12,6 +12,7 @@ import httpx
 from ._config import ResolvedConfig, preview_url, resolve_config
 from ._http import async_api_request
 from .commands import AsyncCommands, AsyncCommandsDeps
+from .desktop import DESKTOP_STREAM_PORT, AsyncDesktop, AsyncDesktopDeps
 from .errors import NotFoundError, SandboxError
 from .files import AsyncFiles, AsyncFilesDeps
 from .types import (
@@ -74,6 +75,21 @@ class AsyncSandbox:
                 sandbox_host=config.sandbox_host,
                 get_access_token=lambda: self._access_token,
                 refresh_activate=self._refresh_activate,
+            ),
+            client=self._http_client,
+        )
+
+        async def _publish_stream_port() -> None:
+            await self.publish_preview_port(DESKTOP_STREAM_PORT)
+
+        self.desktop = AsyncDesktop(
+            AsyncDesktopDeps(
+                sandbox_id=self.id,
+                sandbox_host=config.sandbox_host,
+                get_access_token=lambda: self._access_token,
+                refresh_activate=self._refresh_activate,
+                publish_stream_port=_publish_stream_port,
+                stream_base_url=lambda: self.get_preview_url(DESKTOP_STREAM_PORT),
             ),
             client=self._http_client,
         )

--- a/packages/python-sdk/src/superserve/desktop.py
+++ b/packages/python-sdk/src/superserve/desktop.py
@@ -1,0 +1,415 @@
+"""``sandbox.desktop`` - control a GUI desktop inside a sandbox.
+
+Requires a desktop-enabled template (one whose image runs an X server and
+exposes boxd's DesktopService). Every action is a single authenticated
+data-plane RPC: a coordinate click is one round trip, a drag is one batched
+request, and typing has no artificial per-character pacing.
+
+A paused sandbox is transparently resumed on first use, like ``commands``
+and ``files``.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
+from typing import Any, Literal
+from urllib.parse import urlencode
+
+import httpx
+
+from ._config import data_plane_target
+from ._http import api_request, async_api_request
+from ._token_retry import async_with_token_retry, with_token_retry
+
+_RPC_BASE = "/superserve.boxd.v1.DesktopService"
+
+#: Port the desktop template serves noVNC (websockify) on.
+DESKTOP_STREAM_PORT = 6080
+
+MouseButton = Literal["left", "right", "middle"]
+
+_BUTTONS: dict[str, str] = {
+    "left": "POINTER_BUTTON_LEFT",
+    "right": "POINTER_BUTTON_RIGHT",
+    "middle": "POINTER_BUTTON_MIDDLE",
+}
+
+# Friendly key names -> X keysyms, so agent-facing code can say "enter" or
+# "ctrl". Unlisted names pass through verbatim (all X keysyms stay usable).
+_KEYSYMS: dict[str, str] = {
+    "enter": "Return",
+    "return": "Return",
+    "esc": "Escape",
+    "escape": "Escape",
+    "tab": "Tab",
+    "space": "space",
+    "backspace": "BackSpace",
+    "delete": "Delete",
+    "insert": "Insert",
+    "up": "Up",
+    "down": "Down",
+    "left": "Left",
+    "right": "Right",
+    "home": "Home",
+    "end": "End",
+    "pageup": "Page_Up",
+    "pagedown": "Page_Down",
+    "ctrl": "ctrl",
+    "control": "ctrl",
+    "alt": "alt",
+    "shift": "shift",
+    "cmd": "super",
+    "win": "super",
+    "super": "super",
+}
+
+
+@dataclass(frozen=True)
+class Screenshot:
+    """A captured frame: PNG bytes plus the display dimensions."""
+
+    data: bytes
+    width: int
+    height: int
+
+
+@dataclass(frozen=True)
+class DesktopDeps:
+    """Internal deps from Sandbox. ``refresh_activate`` is invoked on 401."""
+
+    sandbox_id: str
+    sandbox_host: str
+    get_access_token: Callable[[], str]
+    refresh_activate: Callable[[], str]
+    publish_stream_port: Callable[[], None]
+    stream_base_url: Callable[[], str]
+
+
+@dataclass(frozen=True)
+class AsyncDesktopDeps:
+    """Async variant of DesktopDeps."""
+
+    sandbox_id: str
+    sandbox_host: str
+    get_access_token: Callable[[], str]
+    refresh_activate: Callable[[], Awaitable[str]]
+    publish_stream_port: Callable[[], Awaitable[None]]
+    stream_base_url: Callable[[], str]
+
+
+def _keysym(key: str) -> str:
+    return _KEYSYMS.get(key.lower(), key)
+
+
+def _chord_parts(key: str | Sequence[str]) -> tuple[list[str], str]:
+    """Split a chord into (modifiers, final key) for the KeyEvent RPC.
+
+    ``press("ctrl+c")`` and ``press(["ctrl", "c"])`` are equivalent.
+    """
+    parts = [_keysym(p) for p in (key.split("+") if isinstance(key, str) else key)]
+    if not parts or any(p == "" for p in parts):
+        raise ValueError("press: empty key")
+    return parts[:-1], parts[-1]
+
+
+def _assert_coordinate(x: int, y: int) -> None:
+    # 0 is a valid coordinate — validate explicitly, never with truthiness.
+    if not isinstance(x, int) or not isinstance(y, int) or x < 0 or y < 0:
+        raise ValueError(f"Invalid coordinates ({x}, {y}): must be integers >= 0")
+
+
+def _pointer_body(x: int, y: int, action: str, button: MouseButton = "left") -> dict:
+    _assert_coordinate(x, y)
+    return {"x": x, "y": y, "button": _BUTTONS[button], "action": action}
+
+
+def _action_body(action: dict[str, Any]) -> dict[str, Any]:
+    """Lower one ``desktop.actions()`` step into its proto-JSON shape."""
+    kind = action.get("type")
+    if kind == "click":
+        return {
+            "pointer": _pointer_body(
+                action["x"],
+                action["y"],
+                "POINTER_ACTION_CLICK",
+                action.get("button", "left"),
+            )
+        }
+    if kind == "double_click":
+        return {
+            "pointer": _pointer_body(
+                action["x"], action["y"], "POINTER_ACTION_DOUBLE_CLICK"
+            )
+        }
+    if kind == "move":
+        return {
+            "pointer": _pointer_body(action["x"], action["y"], "POINTER_ACTION_MOVE")
+        }
+    if kind == "mouse_down":
+        return {
+            "pointer": _pointer_body(
+                action["x"],
+                action["y"],
+                "POINTER_ACTION_DOWN",
+                action.get("button", "left"),
+            )
+        }
+    if kind == "mouse_up":
+        return {
+            "pointer": _pointer_body(
+                action["x"],
+                action["y"],
+                "POINTER_ACTION_UP",
+                action.get("button", "left"),
+            )
+        }
+    if kind == "press":
+        modifiers, final_key = _chord_parts(action["key"])
+        return {"key": {"key": final_key, "modifiers": modifiers}}
+    if kind == "write":
+        return {"key": {"text": action["text"]}}
+    if kind == "scroll":
+        return {"scroll": {"dx": action.get("dx", 0), "dy": action.get("dy", 0)}}
+    raise ValueError(f"Unknown desktop action type: {kind!r}")
+
+
+def _decode_screenshot(raw: dict[str, Any]) -> Screenshot:
+    image = raw.get("image")
+    if image is None:
+        raise ValueError("Screenshot response missing image data")
+    return Screenshot(
+        data=base64.b64decode(image),
+        width=raw.get("width", 0),
+        height=raw.get("height", 0),
+    )
+
+
+def _stream_url(base: str, *, view_only: bool) -> str:
+    params: dict[str, str] = {"autoconnect": "1", "resize": "scale"}
+    if view_only:
+        params["view_only"] = "1"
+    return f"{base}/vnc.html?{urlencode(params)}"
+
+
+class Desktop:
+    """Sync desktop control. Access as ``sandbox.desktop``."""
+
+    def __init__(self, deps: DesktopDeps, client: httpx.Client | None = None) -> None:
+        self._deps = deps
+        self._client = client
+        target = data_plane_target(deps.sandbox_id, deps.sandbox_host)
+        self._data_plane_base_url = target.url
+        self._routing_headers = target.headers
+
+    def screenshot(self) -> Screenshot:
+        """Capture the current screen as a PNG.
+
+        One round trip; safe to call while a live stream viewer is open.
+        """
+        return _decode_screenshot(self._rpc("Screenshot", {}))
+
+    def click(self, x: int, y: int, *, button: MouseButton = "left") -> None:
+        """Click at (x, y). One RPC — move and click are a single action."""
+        self._rpc("SendPointer", _pointer_body(x, y, "POINTER_ACTION_CLICK", button))
+
+    def double_click(self, x: int, y: int) -> None:
+        """Double-click at (x, y)."""
+        self._rpc("SendPointer", _pointer_body(x, y, "POINTER_ACTION_DOUBLE_CLICK"))
+
+    def right_click(self, x: int, y: int) -> None:
+        """Right-click at (x, y)."""
+        self.click(x, y, button="right")
+
+    def middle_click(self, x: int, y: int) -> None:
+        """Middle-click at (x, y)."""
+        self.click(x, y, button="middle")
+
+    def move_mouse(self, x: int, y: int) -> None:
+        """Move the pointer to (x, y) without clicking."""
+        self._rpc("SendPointer", _pointer_body(x, y, "POINTER_ACTION_MOVE"))
+
+    def drag(
+        self,
+        start: tuple[int, int],
+        end: tuple[int, int],
+        *,
+        button: MouseButton = "left",
+    ) -> None:
+        """Drag from ``start`` to ``end`` as one atomic batch (down-move-up)
+        under the sandbox's input lock, so no other input can interleave."""
+        self.actions(
+            [
+                {"type": "mouse_down", "x": start[0], "y": start[1], "button": button},
+                {"type": "move", "x": end[0], "y": end[1]},
+                {"type": "mouse_up", "x": end[0], "y": end[1], "button": button},
+            ]
+        )
+
+    def scroll(self, *, dx: int = 0, dy: int = 0) -> None:
+        """Scroll under the pointer. Positive ``dy`` scrolls down, negative
+        up; ``dx`` scrolls horizontally. Both axes in one call."""
+        self._rpc("Scroll", {"dx": dx, "dy": dy})
+
+    def write(self, text: str) -> None:
+        """Type literal text. Fast by default — no per-character pacing."""
+        if not text:
+            return
+        self._rpc("SendKey", {"text": text})
+
+    def press(self, key: str | Sequence[str]) -> None:
+        """Press a key or chord: ``press("enter")``, ``press("ctrl+c")``,
+        ``press(["ctrl", "shift", "p"])``. Friendly names map to X keysyms;
+        unrecognized names pass through verbatim."""
+        modifiers, final_key = _chord_parts(key)
+        self._rpc("SendKey", {"key": final_key, "modifiers": modifiers})
+
+    def actions(self, actions: Sequence[dict[str, Any]]) -> None:
+        """Execute an ordered batch of actions in a single request.
+
+        The whole batch is validated before anything runs, then executed
+        under the sandbox's input lock. Execution stops at the first failing
+        action. This is the fast path for models that emit several actions
+        per turn.
+
+        Example::
+
+            sandbox.desktop.actions([
+                {"type": "click", "x": 640, "y": 32},
+                {"type": "write", "text": "https://example.com"},
+                {"type": "press", "key": "enter"},
+            ])
+        """
+        if not actions:
+            return
+        self._rpc("SendActions", {"actions": [_action_body(a) for a in actions]})
+
+    def resize(self, width: int, height: int) -> None:
+        """Resize the virtual display. Width must be a multiple of 8 between
+        320 and 8192; height between 200 and 8192. Takes effect live."""
+        self._rpc("Resize", {"width": width, "height": height})
+
+    def get_stream_url(self, *, view_only: bool = False) -> str:
+        """Publish the live desktop viewer (noVNC) and return its browser URL.
+
+        The URL goes through the sandbox's preview-port access policy — under
+        a private policy, viewers also need a preview token.
+        """
+        self._deps.publish_stream_port()
+        return _stream_url(self._deps.stream_base_url(), view_only=view_only)
+
+    def _rpc(self, method: str, body: dict[str, Any]) -> dict[str, Any]:
+        def send(token: str) -> Any:
+            return api_request(
+                "POST",
+                f"{self._data_plane_base_url}{_RPC_BASE}/{method}",
+                headers={**self._routing_headers, "X-Access-Token": token},
+                json_body=body,
+                client=self._client,
+            )
+
+        return with_token_retry(
+            self._deps.get_access_token, self._deps.refresh_activate, send
+        )
+
+
+class AsyncDesktop:
+    """Async desktop control. Access as ``sandbox.desktop``."""
+
+    def __init__(
+        self, deps: AsyncDesktopDeps, client: httpx.AsyncClient | None = None
+    ) -> None:
+        self._deps = deps
+        self._client = client
+        target = data_plane_target(deps.sandbox_id, deps.sandbox_host)
+        self._data_plane_base_url = target.url
+        self._routing_headers = target.headers
+
+    async def screenshot(self) -> Screenshot:
+        """Async variant of :meth:`Desktop.screenshot`."""
+        return _decode_screenshot(await self._rpc("Screenshot", {}))
+
+    async def click(self, x: int, y: int, *, button: MouseButton = "left") -> None:
+        """Async variant of :meth:`Desktop.click`."""
+        await self._rpc(
+            "SendPointer", _pointer_body(x, y, "POINTER_ACTION_CLICK", button)
+        )
+
+    async def double_click(self, x: int, y: int) -> None:
+        """Async variant of :meth:`Desktop.double_click`."""
+        await self._rpc(
+            "SendPointer", _pointer_body(x, y, "POINTER_ACTION_DOUBLE_CLICK")
+        )
+
+    async def right_click(self, x: int, y: int) -> None:
+        """Async variant of :meth:`Desktop.right_click`."""
+        await self.click(x, y, button="right")
+
+    async def middle_click(self, x: int, y: int) -> None:
+        """Async variant of :meth:`Desktop.middle_click`."""
+        await self.click(x, y, button="middle")
+
+    async def move_mouse(self, x: int, y: int) -> None:
+        """Async variant of :meth:`Desktop.move_mouse`."""
+        await self._rpc("SendPointer", _pointer_body(x, y, "POINTER_ACTION_MOVE"))
+
+    async def drag(
+        self,
+        start: tuple[int, int],
+        end: tuple[int, int],
+        *,
+        button: MouseButton = "left",
+    ) -> None:
+        """Async variant of :meth:`Desktop.drag`."""
+        await self.actions(
+            [
+                {"type": "mouse_down", "x": start[0], "y": start[1], "button": button},
+                {"type": "move", "x": end[0], "y": end[1]},
+                {"type": "mouse_up", "x": end[0], "y": end[1], "button": button},
+            ]
+        )
+
+    async def scroll(self, *, dx: int = 0, dy: int = 0) -> None:
+        """Async variant of :meth:`Desktop.scroll`."""
+        await self._rpc("Scroll", {"dx": dx, "dy": dy})
+
+    async def write(self, text: str) -> None:
+        """Async variant of :meth:`Desktop.write`."""
+        if not text:
+            return
+        await self._rpc("SendKey", {"text": text})
+
+    async def press(self, key: str | Sequence[str]) -> None:
+        """Async variant of :meth:`Desktop.press`."""
+        modifiers, final_key = _chord_parts(key)
+        await self._rpc("SendKey", {"key": final_key, "modifiers": modifiers})
+
+    async def actions(self, actions: Sequence[dict[str, Any]]) -> None:
+        """Async variant of :meth:`Desktop.actions`."""
+        if not actions:
+            return
+        await self._rpc("SendActions", {"actions": [_action_body(a) for a in actions]})
+
+    async def resize(self, width: int, height: int) -> None:
+        """Async variant of :meth:`Desktop.resize`."""
+        await self._rpc("Resize", {"width": width, "height": height})
+
+    async def get_stream_url(self, *, view_only: bool = False) -> str:
+        """Async variant of :meth:`Desktop.get_stream_url`."""
+        await self._deps.publish_stream_port()
+        return _stream_url(self._deps.stream_base_url(), view_only=view_only)
+
+    async def _rpc(self, method: str, body: dict[str, Any]) -> dict[str, Any]:
+        async def send(token: str) -> Any:
+            return await async_api_request(
+                "POST",
+                f"{self._data_plane_base_url}{_RPC_BASE}/{method}",
+                headers={**self._routing_headers, "X-Access-Token": token},
+                json_body=body,
+                client=self._client,
+            )
+
+        return await async_with_token_retry(
+            self._deps.get_access_token, self._deps.refresh_activate, send
+        )

--- a/packages/python-sdk/src/superserve/sandbox.py
+++ b/packages/python-sdk/src/superserve/sandbox.py
@@ -12,6 +12,7 @@ import httpx
 from ._config import ResolvedConfig, preview_url, resolve_config
 from ._http import api_request
 from .commands import Commands, CommandsDeps
+from .desktop import DESKTOP_STREAM_PORT, Desktop, DesktopDeps
 from .errors import NotFoundError, SandboxError
 from .files import Files, FilesDeps
 from .types import (
@@ -74,6 +75,21 @@ class Sandbox:
                 sandbox_host=config.sandbox_host,
                 get_access_token=lambda: self._access_token,
                 refresh_activate=self._refresh_activate,
+            ),
+            client=self._http_client,
+        )
+
+        def _publish_stream_port() -> None:
+            self.publish_preview_port(DESKTOP_STREAM_PORT)
+
+        self.desktop = Desktop(
+            DesktopDeps(
+                sandbox_id=self.id,
+                sandbox_host=config.sandbox_host,
+                get_access_token=lambda: self._access_token,
+                refresh_activate=self._refresh_activate,
+                publish_stream_port=_publish_stream_port,
+                stream_base_url=lambda: self.get_preview_url(DESKTOP_STREAM_PORT),
             ),
             client=self._http_client,
         )

--- a/packages/python-sdk/tests/test_desktop.py
+++ b/packages/python-sdk/tests/test_desktop.py
@@ -1,0 +1,311 @@
+"""Tests for sandbox.desktop — RPC shapes, key mapping, batching."""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import httpx
+import pytest
+import respx
+from superserve.desktop import (
+    AsyncDesktop,
+    AsyncDesktopDeps,
+    Desktop,
+    DesktopDeps,
+    _chord_parts,
+)
+
+SANDBOX_HOST = "sandbox.example.com"
+SBX = "sbx-1"
+RPC_BASE = f"https://boxd-{SBX}.{SANDBOX_HOST}/superserve.boxd.v1.DesktopService"
+
+
+def _make_desktop() -> Desktop:
+    deps = DesktopDeps(
+        sandbox_id=SBX,
+        sandbox_host=SANDBOX_HOST,
+        get_access_token=lambda: "tok-initial",
+        refresh_activate=lambda: "tok-refreshed",
+        publish_stream_port=lambda: None,
+        stream_base_url=lambda: f"https://6080-{SBX}.{SANDBOX_HOST}",
+    )
+    return Desktop(deps)
+
+
+def _request_body(route: respx.Route) -> dict:
+    return json.loads(route.calls.last.request.content)
+
+
+class TestScreenshot:
+    @respx.mock
+    def test_decodes_png_and_dimensions(self) -> None:
+        png = b"\x89PNG-fake"
+        route = respx.post(f"{RPC_BASE}/Screenshot").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "image": base64.b64encode(png).decode(),
+                    "width": 1280,
+                    "height": 800,
+                },
+            )
+        )
+        shot = _make_desktop().screenshot()
+        assert route.called
+        assert shot.data == png
+        assert (shot.width, shot.height) == (1280, 800)
+        assert route.calls.last.request.headers["X-Access-Token"] == "tok-initial"
+
+    @respx.mock
+    def test_missing_image_raises(self) -> None:
+        respx.post(f"{RPC_BASE}/Screenshot").mock(
+            return_value=httpx.Response(200, json={"width": 1, "height": 1})
+        )
+        with pytest.raises(ValueError, match="missing image"):
+            _make_desktop().screenshot()
+
+
+class TestPointer:
+    @respx.mock
+    def test_click_is_single_rpc(self) -> None:
+        route = respx.post(f"{RPC_BASE}/SendPointer").mock(
+            return_value=httpx.Response(200, json={})
+        )
+        _make_desktop().click(10, 20)
+        assert route.call_count == 1
+        assert _request_body(route) == {
+            "x": 10,
+            "y": 20,
+            "button": "POINTER_BUTTON_LEFT",
+            "action": "POINTER_ACTION_CLICK",
+        }
+
+    @respx.mock
+    def test_zero_is_a_valid_coordinate(self) -> None:
+        route = respx.post(f"{RPC_BASE}/SendPointer").mock(
+            return_value=httpx.Response(200, json={})
+        )
+        _make_desktop().click(0, 300)
+        assert _request_body(route)["x"] == 0
+
+    def test_invalid_coordinates_rejected_locally(self) -> None:
+        desktop = _make_desktop()
+        with pytest.raises(ValueError, match="Invalid coordinates"):
+            desktop.click(-1, 5)
+        with pytest.raises(ValueError, match="Invalid coordinates"):
+            desktop.move_mouse(1.5, 5)  # type: ignore[arg-type]
+
+    @respx.mock
+    def test_drag_is_one_atomic_batch(self) -> None:
+        route = respx.post(f"{RPC_BASE}/SendActions").mock(
+            return_value=httpx.Response(200, json={"executed": 3})
+        )
+        _make_desktop().drag((1, 2), (30, 40))
+        assert route.call_count == 1
+        actions = _request_body(route)["actions"]
+        assert [next(iter(a)) for a in actions] == ["pointer", "pointer", "pointer"]
+        assert actions[0]["pointer"]["action"] == "POINTER_ACTION_DOWN"
+        assert actions[1]["pointer"] == {
+            "x": 30,
+            "y": 40,
+            "button": "POINTER_BUTTON_LEFT",
+            "action": "POINTER_ACTION_MOVE",
+        }
+        assert actions[2]["pointer"]["action"] == "POINTER_ACTION_UP"
+
+
+class TestKeyboard:
+    @respx.mock
+    def test_write_sends_literal_text(self) -> None:
+        route = respx.post(f"{RPC_BASE}/SendKey").mock(
+            return_value=httpx.Response(200, json={})
+        )
+        _make_desktop().write("hello world")
+        assert _request_body(route) == {"text": "hello world"}
+
+    @respx.mock
+    def test_write_empty_is_noop(self) -> None:
+        route = respx.post(f"{RPC_BASE}/SendKey").mock(
+            return_value=httpx.Response(200, json={})
+        )
+        _make_desktop().write("")
+        assert not route.called
+
+    @respx.mock
+    def test_press_maps_names_and_chords(self) -> None:
+        route = respx.post(f"{RPC_BASE}/SendKey").mock(
+            return_value=httpx.Response(200, json={})
+        )
+        desktop = _make_desktop()
+        desktop.press("enter")
+        assert _request_body(route) == {"key": "Return", "modifiers": []}
+        desktop.press("ctrl+c")
+        assert _request_body(route) == {"key": "c", "modifiers": ["ctrl"]}
+        desktop.press(["cmd", "shift", "p"])
+        assert _request_body(route) == {"key": "p", "modifiers": ["super", "shift"]}
+
+    def test_chord_parts_passthrough_and_empty(self) -> None:
+        assert _chord_parts("F5") == ([], "F5")
+        with pytest.raises(ValueError, match="empty key"):
+            _chord_parts("")
+
+
+class TestBatchAndMisc:
+    @respx.mock
+    def test_actions_maps_every_type(self) -> None:
+        route = respx.post(f"{RPC_BASE}/SendActions").mock(
+            return_value=httpx.Response(200, json={"executed": 3})
+        )
+        _make_desktop().actions(
+            [
+                {"type": "click", "x": 5, "y": 6, "button": "right"},
+                {"type": "write", "text": "hi"},
+                {"type": "scroll", "dy": 3},
+            ]
+        )
+        actions = _request_body(route)["actions"]
+        assert actions == [
+            {
+                "pointer": {
+                    "x": 5,
+                    "y": 6,
+                    "button": "POINTER_BUTTON_RIGHT",
+                    "action": "POINTER_ACTION_CLICK",
+                }
+            },
+            {"key": {"text": "hi"}},
+            {"scroll": {"dx": 0, "dy": 3}},
+        ]
+
+    @respx.mock
+    def test_invalid_action_rejects_batch_before_any_request(self) -> None:
+        route = respx.post(f"{RPC_BASE}/SendActions").mock(
+            return_value=httpx.Response(200, json={})
+        )
+        with pytest.raises(ValueError, match="Invalid coordinates"):
+            _make_desktop().actions(
+                [
+                    {"type": "click", "x": 1, "y": 1},
+                    {"type": "move", "x": -4, "y": 2},
+                ]
+            )
+        assert not route.called
+
+    def test_unknown_action_type_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Unknown desktop action"):
+            _make_desktop().actions([{"type": "teleport", "x": 1, "y": 1}])
+
+    @respx.mock
+    def test_scroll_and_resize(self) -> None:
+        scroll = respx.post(f"{RPC_BASE}/Scroll").mock(
+            return_value=httpx.Response(200, json={})
+        )
+        resize = respx.post(f"{RPC_BASE}/Resize").mock(
+            return_value=httpx.Response(200, json={})
+        )
+        desktop = _make_desktop()
+        desktop.scroll(dx=-2, dy=5)
+        desktop.resize(1024, 768)
+        assert _request_body(scroll) == {"dx": -2, "dy": 5}
+        assert _request_body(resize) == {"width": 1024, "height": 768}
+
+
+class TestStreamUrl:
+    def test_publishes_and_builds_novnc_url(self) -> None:
+        published: list[bool] = []
+        deps = DesktopDeps(
+            sandbox_id=SBX,
+            sandbox_host=SANDBOX_HOST,
+            get_access_token=lambda: "tok",
+            refresh_activate=lambda: "tok",
+            publish_stream_port=lambda: published.append(True),
+            stream_base_url=lambda: f"https://6080-{SBX}.{SANDBOX_HOST}",
+        )
+        url = Desktop(deps).get_stream_url()
+        assert published == [True]
+        assert url == (
+            f"https://6080-{SBX}.{SANDBOX_HOST}/vnc.html?autoconnect=1&resize=scale"
+        )
+
+    def test_view_only_flag(self) -> None:
+        url = _make_desktop().get_stream_url(view_only=True)
+        assert "view_only=1" in url
+
+
+class TestTokenRetry:
+    @respx.mock
+    def test_stale_token_activates_and_retries_once(self) -> None:
+        tokens: list[str] = []
+
+        def responder(request: httpx.Request) -> httpx.Response:
+            tokens.append(request.headers["X-Access-Token"])
+            if len(tokens) == 1:
+                return httpx.Response(401, json={"error": "unauthenticated"})
+            return httpx.Response(200, json={})
+
+        respx.post(f"{RPC_BASE}/SendPointer").mock(side_effect=responder)
+        refreshes: list[bool] = []
+
+        def refresh() -> str:
+            refreshes.append(True)
+            return "tok-refreshed"
+
+        state = {"token": "tok-initial"}
+
+        def refresh_and_store() -> str:
+            state["token"] = refresh()
+            return state["token"]
+
+        deps = DesktopDeps(
+            sandbox_id=SBX,
+            sandbox_host=SANDBOX_HOST,
+            get_access_token=lambda: state["token"],
+            refresh_activate=refresh_and_store,
+            publish_stream_port=lambda: None,
+            stream_base_url=lambda: "unused",
+        )
+        Desktop(deps).click(1, 1)
+        assert tokens == ["tok-initial", "tok-refreshed"]
+        assert refreshes == [True]
+
+
+class TestAsyncDesktop:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_click_and_screenshot(self) -> None:
+        pointer = respx.post(f"{RPC_BASE}/SendPointer").mock(
+            return_value=httpx.Response(200, json={})
+        )
+        png = b"png-bytes"
+        respx.post(f"{RPC_BASE}/Screenshot").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "image": base64.b64encode(png).decode(),
+                    "width": 10,
+                    "height": 5,
+                },
+            )
+        )
+
+        async def publish() -> None:
+            return None
+
+        async def refresh() -> str:
+            return "tok"
+
+        deps = AsyncDesktopDeps(
+            sandbox_id=SBX,
+            sandbox_host=SANDBOX_HOST,
+            get_access_token=lambda: "tok",
+            refresh_activate=refresh,
+            publish_stream_port=publish,
+            stream_base_url=lambda: f"https://6080-{SBX}.{SANDBOX_HOST}",
+        )
+        desktop = AsyncDesktop(deps)
+        await desktop.click(3, 4)
+        shot = await desktop.screenshot()
+        assert pointer.call_count == 1
+        assert shot.data == png
+        assert (shot.width, shot.height) == (10, 5)

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -56,6 +56,31 @@ sandbox to strict `public`. `legacy_public` is returned only for pre-migration
 sandboxes.
 See the [preview URL guide](https://docs.superserve.ai/sandbox/preview-urls).
 
+## Desktop (computer use)
+
+Control a GUI desktop inside a sandbox — screenshot, mouse, keyboard, and a
+live browser viewer. Requires a desktop-enabled template.
+
+```typescript
+const sandbox = await Sandbox.create({ template: "superserve/desktop" })
+
+const shot = await sandbox.desktop.screenshot() // PNG bytes + dimensions
+await sandbox.desktop.click(640, 400)
+await sandbox.desktop.write("hello") // no per-character pacing
+await sandbox.desktop.press("ctrl+l")
+await sandbox.desktop.drag([10, 10], [200, 200]) // one atomic request
+
+// Several model-emitted actions in a single round trip:
+await sandbox.desktop.actions([
+  { type: "click", x: 640, y: 32 },
+  { type: "write", text: "https://example.com" },
+  { type: "press", key: "enter" },
+])
+
+await sandbox.desktop.resize(1920, 1080) // live, no restart
+const viewer = await sandbox.desktop.getStreamUrl() // noVNC URL
+```
+
 ## Authentication
 
 Set the `SUPERSERVE_API_KEY` environment variable:

--- a/packages/sdk/src/Sandbox.ts
+++ b/packages/sdk/src/Sandbox.ts
@@ -16,6 +16,7 @@
 
 import { Commands } from "./commands.js"
 import { previewUrl, type ResolvedConfig, resolveConfig } from "./config.js"
+import { Desktop, DESKTOP_STREAM_PORT } from "./desktop.js"
 import { NotFoundError, SandboxError } from "./errors.js"
 import { Files } from "./files.js"
 import { request, requestVoid } from "./http.js"
@@ -73,6 +74,12 @@ export class Sandbox {
    */
   readonly files: Files
 
+  /**
+   * Control a GUI desktop inside this sandbox (screenshot, mouse, keyboard,
+   * live viewer). Requires a desktop-enabled template.
+   */
+  readonly desktop: Desktop
+
   private _accessToken: string
   private _refreshInFlight: Promise<string> | null = null
   private readonly _config: ResolvedConfig
@@ -103,6 +110,16 @@ export class Sandbox {
       sandboxHost: config.sandboxHost,
       getAccessToken: () => this._accessToken,
       refreshActivate: () => this._refreshActivate(),
+    })
+    this.desktop = new Desktop({
+      sandboxId: this.id,
+      sandboxHost: config.sandboxHost,
+      getAccessToken: () => this._accessToken,
+      refreshActivate: () => this._refreshActivate(),
+      publishStreamPort: async () => {
+        await this.publishPreviewPort(DESKTOP_STREAM_PORT)
+      },
+      streamBaseUrl: () => this.getPreviewUrl(DESKTOP_STREAM_PORT),
     })
   }
 

--- a/packages/sdk/src/desktop.ts
+++ b/packages/sdk/src/desktop.ts
@@ -1,0 +1,390 @@
+/**
+ * `sandbox.desktop` - control a GUI desktop inside a sandbox.
+ *
+ * Requires a desktop-enabled template (one whose image runs an X server and
+ * exposes boxd's DesktopService). Every action is a single authenticated
+ * data-plane RPC: a coordinate click is one round trip, a drag is one batched
+ * request, and typing has no artificial per-character pacing.
+ *
+ * A paused sandbox is transparently resumed on first use, like `commands`
+ * and `files`.
+ *
+ * Accessed as `sandbox.desktop.screenshot()`, `sandbox.desktop.click(x, y)`, …
+ */
+
+import { dataPlaneTarget } from "./config.js"
+import { request } from "./http.js"
+import { withTokenRetry } from "./tokenRetry.js"
+
+/** @internal */
+export interface DesktopDeps {
+  sandboxId: string
+  sandboxHost: string
+  getAccessToken: () => string
+  refreshActivate: () => Promise<string>
+  /** Publish the noVNC port and build its public URL (from the Sandbox). */
+  publishStreamPort: () => Promise<void>
+  streamBaseUrl: () => string
+}
+
+const RPC_BASE = "/superserve.boxd.v1.DesktopService"
+
+/** Port the desktop template serves noVNC (websockify) on. */
+export const DESKTOP_STREAM_PORT = 6080
+
+/**
+ * Cap on a buffered screenshot RPC response. boxd caps a frame at 32 MiB of
+ * PNG; base64 in the JSON envelope inflates that by 4/3.
+ */
+export const MAX_SCREENSHOT_RESPONSE_BYTES = 48 * 1024 * 1024
+
+export type MouseButton = "left" | "right" | "middle"
+
+/** One step of a `desktop.actions()` batch. */
+export type DesktopAction =
+  | { type: "click"; x: number; y: number; button?: MouseButton }
+  | { type: "doubleClick"; x: number; y: number }
+  | { type: "move"; x: number; y: number }
+  | { type: "mouseDown"; x: number; y: number; button?: MouseButton }
+  | { type: "mouseUp"; x: number; y: number; button?: MouseButton }
+  | { type: "press"; key: string | string[] }
+  | { type: "write"; text: string }
+  | { type: "scroll"; dx?: number; dy?: number }
+
+export interface Screenshot {
+  /** PNG bytes. */
+  data: Uint8Array
+  width: number
+  height: number
+}
+
+export interface StreamUrlOptions {
+  /**
+   * Open the viewer read-only (viewer-side flag on the noVNC client;
+   * interactive control stays available to anyone else with the URL).
+   */
+  viewOnly?: boolean
+}
+
+/**
+ * Friendly key names → X keysyms, so agent-facing code can say "enter" or
+ * "ctrl". Unlisted names pass through verbatim (all X keysyms stay usable).
+ */
+const KEYSYMS: Record<string, string> = {
+  enter: "Return",
+  return: "Return",
+  esc: "Escape",
+  escape: "Escape",
+  tab: "Tab",
+  space: "space",
+  backspace: "BackSpace",
+  delete: "Delete",
+  insert: "Insert",
+  up: "Up",
+  down: "Down",
+  left: "Left",
+  right: "Right",
+  home: "Home",
+  end: "End",
+  pageup: "Page_Up",
+  pagedown: "Page_Down",
+  ctrl: "ctrl",
+  control: "ctrl",
+  alt: "alt",
+  shift: "shift",
+  cmd: "super",
+  win: "super",
+  super: "super",
+}
+
+function toKeysym(key: string): string {
+  return KEYSYMS[key.toLowerCase()] ?? key
+}
+
+/**
+ * Split a chord into (modifiers, final key) for the KeyEvent RPC.
+ * `press("ctrl+c")` and `press(["ctrl", "c"])` are equivalent.
+ */
+function chordParts(key: string | string[]): {
+  modifiers: string[]
+  key: string
+} {
+  const parts = (Array.isArray(key) ? key : key.split("+")).map(toKeysym)
+  if (parts.length === 0 || parts.some((p) => p === "")) {
+    throw new Error("press: empty key")
+  }
+  return { modifiers: parts.slice(0, -1), key: parts[parts.length - 1] }
+}
+
+function buttonEnum(button: MouseButton = "left"): string {
+  switch (button) {
+    case "left":
+      return "POINTER_BUTTON_LEFT"
+    case "right":
+      return "POINTER_BUTTON_RIGHT"
+    case "middle":
+      return "POINTER_BUTTON_MIDDLE"
+  }
+}
+
+function assertCoordinate(x: number, y: number): void {
+  // 0 is a valid coordinate — validate with integer checks, never truthiness.
+  if (!Number.isInteger(x) || !Number.isInteger(y) || x < 0 || y < 0) {
+    throw new Error(`Invalid coordinates (${x}, ${y}): must be integers >= 0`)
+  }
+}
+
+/** Proto-JSON shapes for the DesktopService RPCs. @internal */
+type PointerEventBody = {
+  x: number
+  y: number
+  button?: string
+  action: string
+}
+type KeyEventBody = { key?: string; text?: string; modifiers?: string[] }
+type ScrollEventBody = { dx?: number; dy?: number }
+type ActionBody =
+  | { pointer: PointerEventBody }
+  | { key: KeyEventBody }
+  | { scroll: ScrollEventBody }
+
+function pointerBody(
+  x: number,
+  y: number,
+  action: string,
+  button?: MouseButton,
+): PointerEventBody {
+  assertCoordinate(x, y)
+  return { x, y, button: buttonEnum(button), action }
+}
+
+function actionBody(action: DesktopAction): ActionBody {
+  switch (action.type) {
+    case "click":
+      return {
+        pointer: pointerBody(
+          action.x,
+          action.y,
+          "POINTER_ACTION_CLICK",
+          action.button,
+        ),
+      }
+    case "doubleClick":
+      return {
+        pointer: pointerBody(action.x, action.y, "POINTER_ACTION_DOUBLE_CLICK"),
+      }
+    case "move":
+      return {
+        pointer: pointerBody(action.x, action.y, "POINTER_ACTION_MOVE"),
+      }
+    case "mouseDown":
+      return {
+        pointer: pointerBody(
+          action.x,
+          action.y,
+          "POINTER_ACTION_DOWN",
+          action.button,
+        ),
+      }
+    case "mouseUp":
+      return {
+        pointer: pointerBody(
+          action.x,
+          action.y,
+          "POINTER_ACTION_UP",
+          action.button,
+        ),
+      }
+    case "press": {
+      const { modifiers, key } = chordParts(action.key)
+      return { key: { key, modifiers } }
+    }
+    case "write":
+      return { key: { text: action.text } }
+    case "scroll":
+      return { scroll: { dx: action.dx ?? 0, dy: action.dy ?? 0 } }
+  }
+}
+
+export class Desktop {
+  private readonly _dataPlaneBaseUrl: string
+  private readonly _routingHeaders: Record<string, string>
+
+  /** @internal */
+  constructor(private readonly _deps: DesktopDeps) {
+    const target = dataPlaneTarget(_deps.sandboxId, _deps.sandboxHost)
+    this._dataPlaneBaseUrl = target.url
+    this._routingHeaders = target.headers
+  }
+
+  /**
+   * Capture the current screen as a PNG.
+   *
+   * One round trip; safe to call while a live stream viewer is open.
+   *
+   * @example
+   * ```typescript
+   * const shot = await sandbox.desktop.screenshot()
+   * await fs.writeFile("screen.png", shot.data)
+   * ```
+   */
+  async screenshot(): Promise<Screenshot> {
+    const raw = await this._rpc<{
+      image?: string
+      width?: number
+      height?: number
+    }>("Screenshot", {}, { maxBytes: MAX_SCREENSHOT_RESPONSE_BYTES })
+    if (raw.image === undefined) {
+      throw new Error("Screenshot response missing image data")
+    }
+    return {
+      data: Uint8Array.from(atob(raw.image), (c) => c.charCodeAt(0)),
+      width: raw.width ?? 0,
+      height: raw.height ?? 0,
+    }
+  }
+
+  /** Click at (x, y). One RPC — move and click are a single action. */
+  async click(
+    x: number,
+    y: number,
+    options: { button?: MouseButton } = {},
+  ): Promise<void> {
+    await this._pointer(
+      pointerBody(x, y, "POINTER_ACTION_CLICK", options.button),
+    )
+  }
+
+  /** Double-click at (x, y). */
+  async doubleClick(x: number, y: number): Promise<void> {
+    await this._pointer(pointerBody(x, y, "POINTER_ACTION_DOUBLE_CLICK"))
+  }
+
+  /** Right-click at (x, y). */
+  rightClick(x: number, y: number): Promise<void> {
+    return this.click(x, y, { button: "right" })
+  }
+
+  /** Middle-click at (x, y). */
+  middleClick(x: number, y: number): Promise<void> {
+    return this.click(x, y, { button: "middle" })
+  }
+
+  /** Move the pointer to (x, y) without clicking. */
+  async moveMouse(x: number, y: number): Promise<void> {
+    await this._pointer(pointerBody(x, y, "POINTER_ACTION_MOVE"))
+  }
+
+  /**
+   * Drag from one point to another. Executes as one atomic batch
+   * (down → move → up) under the sandbox's input lock, so no other input
+   * can interleave mid-drag.
+   */
+  async drag(
+    from: [number, number],
+    to: [number, number],
+    options: { button?: MouseButton } = {},
+  ): Promise<void> {
+    await this.actions([
+      { type: "mouseDown", x: from[0], y: from[1], button: options.button },
+      { type: "move", x: to[0], y: to[1] },
+      { type: "mouseUp", x: to[0], y: to[1], button: options.button },
+    ])
+  }
+
+  /**
+   * Scroll the viewport under the pointer. Positive `dy` scrolls down,
+   * negative up; `dx` scrolls horizontally. Both axes in one call.
+   */
+  async scroll(options: { dx?: number; dy?: number }): Promise<void> {
+    await this._rpc("Scroll", { dx: options.dx ?? 0, dy: options.dy ?? 0 })
+  }
+
+  /**
+   * Type literal text. Fast by default — no per-character pacing, so long
+   * strings land in well under a second.
+   */
+  async write(text: string): Promise<void> {
+    if (text.length === 0) return
+    await this._rpc("SendKey", { text })
+  }
+
+  /**
+   * Press a key or chord: `press("enter")`, `press("ctrl+c")`,
+   * `press(["ctrl", "shift", "p"])`. Friendly names (enter, esc, cmd, …)
+   * map to X keysyms; unrecognized names pass through verbatim.
+   */
+  async press(key: string | string[]): Promise<void> {
+    const { modifiers, key: finalKey } = chordParts(key)
+    await this._rpc("SendKey", { key: finalKey, modifiers })
+  }
+
+  /**
+   * Execute an ordered batch of actions in a single request.
+   *
+   * The whole batch is validated before anything runs, then executed under
+   * the sandbox's input lock — no other input can interleave. Execution
+   * stops at the first failing action. This is the fast path for models
+   * that emit several actions per turn.
+   *
+   * @example
+   * ```typescript
+   * await sandbox.desktop.actions([
+   *   { type: "click", x: 640, y: 32 },
+   *   { type: "write", text: "https://example.com" },
+   *   { type: "press", key: "enter" },
+   * ])
+   * ```
+   */
+  async actions(actions: DesktopAction[]): Promise<void> {
+    if (actions.length === 0) return
+    await this._rpc("SendActions", { actions: actions.map(actionBody) })
+  }
+
+  /**
+   * Resize the virtual display. Width must be a multiple of 8 between 320
+   * and 8192; height between 200 and 8192. Takes effect live — no restart.
+   */
+  async resize(width: number, height: number): Promise<void> {
+    await this._rpc("Resize", { width, height })
+  }
+
+  /**
+   * Publish the live desktop viewer (noVNC) and return its browser URL.
+   *
+   * The URL goes through the sandbox's preview-port access policy — under a
+   * private policy, viewers also need a preview token.
+   */
+  async getStreamUrl(options: StreamUrlOptions = {}): Promise<string> {
+    await this._deps.publishStreamPort()
+    const base = this._deps.streamBaseUrl()
+    const params = new URLSearchParams({ autoconnect: "1", resize: "scale" })
+    if (options.viewOnly) params.set("view_only", "1")
+    return `${base}/vnc.html?${params.toString()}`
+  }
+
+  private async _pointer(body: PointerEventBody): Promise<void> {
+    await this._rpc("SendPointer", body)
+  }
+
+  /**
+   * One unary DesktopService call, Connect JSON protocol: a plain POST of
+   * proto-JSON to the procedure path. Paused sandboxes resume via the shared
+   * token-retry path.
+   */
+  private async _rpc<T = Record<string, never>>(
+    method: string,
+    body: unknown,
+    opts: { maxBytes?: number } = {},
+  ): Promise<T> {
+    const send = (token: string) =>
+      request<T>({
+        method: "POST",
+        url: `${this._dataPlaneBaseUrl}${RPC_BASE}/${method}`,
+        headers: { ...this._routingHeaders, "X-Access-Token": token },
+        body,
+        maxBytes: opts.maxBytes,
+      })
+    return withTokenRetry(this._deps, send)
+  }
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -10,6 +10,13 @@ export {
   resolveConfig,
 } from "./config.js"
 export type { ResolvedConfig } from "./config.js"
+export { DESKTOP_STREAM_PORT } from "./desktop.js"
+export type {
+  DesktopAction,
+  MouseButton,
+  Screenshot,
+  StreamUrlOptions,
+} from "./desktop.js"
 export {
   AuthenticationError,
   BuildError,

--- a/packages/sdk/tests/desktop.test.ts
+++ b/packages/sdk/tests/desktop.test.ts
@@ -1,0 +1,285 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { Desktop, type DesktopDeps } from "../src/desktop.js"
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+const sandboxId = "sbx-1"
+const sandboxHost = "sandbox.example.com"
+const rpcBase = `https://boxd-${sandboxId}.${sandboxHost}/superserve.boxd.v1.DesktopService`
+
+function makeDeps(overrides: Partial<DesktopDeps> = {}): DesktopDeps {
+  let token = "tok-initial"
+  return {
+    sandboxId,
+    sandboxHost,
+    getAccessToken: () => token,
+    refreshActivate: async () => {
+      token = "tok-refreshed"
+      return token
+    },
+    publishStreamPort: async () => {},
+    streamBaseUrl: () => `https://6080-${sandboxId}.${sandboxHost}`,
+    ...overrides,
+  }
+}
+
+/** Stub fetch, run `fn`, and return the recorded [url, parsed body] calls. */
+async function recordCalls(
+  responses: Response[],
+  fn: (desktop: Desktop) => Promise<unknown>,
+): Promise<Array<{ url: string; body: unknown; headers: Headers }>> {
+  const calls: Array<{ url: string; body: unknown; headers: Headers }> = []
+  let i = 0
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string, init: RequestInit) => {
+      calls.push({
+        url: String(url),
+        body: init.body ? JSON.parse(String(init.body)) : undefined,
+        headers: new Headers(init.headers),
+      })
+      return responses[Math.min(i++, responses.length - 1)]
+    }),
+  )
+  await fn(new Desktop(makeDeps()))
+  return calls
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("Desktop.screenshot", () => {
+  it("decodes base64 PNG and dimensions", async () => {
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47])
+    const image = btoa(String.fromCharCode(...png))
+    let shot: Awaited<ReturnType<Desktop["screenshot"]>> | undefined
+    const calls = await recordCalls(
+      [jsonResponse({ image, width: 1280, height: 800 })],
+      async (d) => {
+        shot = await d.screenshot()
+      },
+    )
+    expect(calls[0].url).toBe(`${rpcBase}/Screenshot`)
+    expect(calls[0].headers.get("X-Access-Token")).toBe("tok-initial")
+    expect(shot!.data).toEqual(png)
+    expect(shot!.width).toBe(1280)
+    expect(shot!.height).toBe(800)
+  })
+
+  it("throws when the response has no image", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ width: 1, height: 1 })),
+    )
+    await expect(new Desktop(makeDeps()).screenshot()).rejects.toThrow(
+      /missing image/,
+    )
+  })
+})
+
+describe("Desktop pointer actions", () => {
+  it("click is a single RPC carrying move+click", async () => {
+    const calls = await recordCalls([jsonResponse({})], (d) => d.click(10, 20))
+    expect(calls).toHaveLength(1)
+    expect(calls[0].url).toBe(`${rpcBase}/SendPointer`)
+    expect(calls[0].body).toEqual({
+      x: 10,
+      y: 20,
+      button: "POINTER_BUTTON_LEFT",
+      action: "POINTER_ACTION_CLICK",
+    })
+  })
+
+  it("treats 0 as a valid coordinate", async () => {
+    const calls = await recordCalls([jsonResponse({})], (d) => d.click(0, 300))
+    expect(calls[0].body).toMatchObject({ x: 0, y: 300 })
+  })
+
+  it("rejects negative and non-integer coordinates without a request", async () => {
+    const fetchSpy = vi.fn()
+    vi.stubGlobal("fetch", fetchSpy)
+    const desktop = new Desktop(makeDeps())
+    await expect(desktop.click(-1, 5)).rejects.toThrow(/Invalid coordinates/)
+    await expect(desktop.moveMouse(1.5, 5)).rejects.toThrow(
+      /Invalid coordinates/,
+    )
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it("drag is one atomic batch: down, move, up", async () => {
+    const calls = await recordCalls([jsonResponse({ executed: 3 })], (d) =>
+      d.drag([1, 2], [30, 40]),
+    )
+    expect(calls).toHaveLength(1)
+    expect(calls[0].url).toBe(`${rpcBase}/SendActions`)
+    const actions = (calls[0].body as { actions: unknown[] }).actions
+    expect(actions).toEqual([
+      {
+        pointer: {
+          x: 1,
+          y: 2,
+          button: "POINTER_BUTTON_LEFT",
+          action: "POINTER_ACTION_DOWN",
+        },
+      },
+      {
+        pointer: {
+          x: 30,
+          y: 40,
+          button: "POINTER_BUTTON_LEFT",
+          action: "POINTER_ACTION_MOVE",
+        },
+      },
+      {
+        pointer: {
+          x: 30,
+          y: 40,
+          button: "POINTER_BUTTON_LEFT",
+          action: "POINTER_ACTION_UP",
+        },
+      },
+    ])
+  })
+})
+
+describe("Desktop keyboard", () => {
+  it("write sends literal text", async () => {
+    const calls = await recordCalls([jsonResponse({})], (d) =>
+      d.write("hello world"),
+    )
+    expect(calls[0].url).toBe(`${rpcBase}/SendKey`)
+    expect(calls[0].body).toEqual({ text: "hello world" })
+  })
+
+  it("write with empty text is a no-op", async () => {
+    const fetchSpy = vi.fn()
+    vi.stubGlobal("fetch", fetchSpy)
+    await new Desktop(makeDeps()).write("")
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it("press maps friendly names and splits chords", async () => {
+    const calls = await recordCalls(
+      [jsonResponse({}), jsonResponse({}), jsonResponse({})],
+      async (d) => {
+        await d.press("enter")
+        await d.press("ctrl+c")
+        await d.press(["cmd", "shift", "p"])
+      },
+    )
+    expect(calls[0].body).toEqual({ key: "Return", modifiers: [] })
+    expect(calls[1].body).toEqual({ key: "c", modifiers: ["ctrl"] })
+    expect(calls[2].body).toEqual({ key: "p", modifiers: ["super", "shift"] })
+  })
+
+  it("press passes unknown keysyms through verbatim", async () => {
+    const calls = await recordCalls([jsonResponse({})], (d) => d.press("F5"))
+    expect(calls[0].body).toEqual({ key: "F5", modifiers: [] })
+  })
+})
+
+describe("Desktop.scroll / resize / actions", () => {
+  it("scroll sends both axes", async () => {
+    const calls = await recordCalls([jsonResponse({})], (d) =>
+      d.scroll({ dx: -2, dy: 5 }),
+    )
+    expect(calls[0].url).toBe(`${rpcBase}/Scroll`)
+    expect(calls[0].body).toEqual({ dx: -2, dy: 5 })
+  })
+
+  it("resize posts dimensions", async () => {
+    const calls = await recordCalls([jsonResponse({})], (d) =>
+      d.resize(1024, 768),
+    )
+    expect(calls[0].url).toBe(`${rpcBase}/Resize`)
+    expect(calls[0].body).toEqual({ width: 1024, height: 768 })
+  })
+
+  it("actions maps every action type into one batch", async () => {
+    const calls = await recordCalls([jsonResponse({ executed: 3 })], (d) =>
+      d.actions([
+        { type: "click", x: 5, y: 6, button: "right" },
+        { type: "write", text: "hi" },
+        { type: "scroll", dy: 3 },
+      ]),
+    )
+    expect(calls).toHaveLength(1)
+    const actions = (calls[0].body as { actions: unknown[] }).actions
+    expect(actions).toEqual([
+      {
+        pointer: {
+          x: 5,
+          y: 6,
+          button: "POINTER_BUTTON_RIGHT",
+          action: "POINTER_ACTION_CLICK",
+        },
+      },
+      { key: { text: "hi" } },
+      { scroll: { dx: 0, dy: 3 } },
+    ])
+  })
+
+  it("empty actions batch is a no-op", async () => {
+    const fetchSpy = vi.fn()
+    vi.stubGlobal("fetch", fetchSpy)
+    await new Desktop(makeDeps()).actions([])
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it("an invalid action anywhere rejects the batch before any request", async () => {
+    const fetchSpy = vi.fn()
+    vi.stubGlobal("fetch", fetchSpy)
+    await expect(
+      new Desktop(makeDeps()).actions([
+        { type: "click", x: 1, y: 1 },
+        { type: "move", x: -4, y: 2 },
+      ]),
+    ).rejects.toThrow(/Invalid coordinates/)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe("Desktop.getStreamUrl", () => {
+  it("publishes the port and returns the noVNC URL", async () => {
+    const publish = vi.fn(async () => {})
+    const desktop = new Desktop(makeDeps({ publishStreamPort: publish }))
+    const url = await desktop.getStreamUrl()
+    expect(publish).toHaveBeenCalledOnce()
+    expect(url).toBe(
+      `https://6080-${sandboxId}.${sandboxHost}/vnc.html?autoconnect=1&resize=scale`,
+    )
+  })
+
+  it("appends view_only when requested", async () => {
+    const desktop = new Desktop(makeDeps())
+    const url = await desktop.getStreamUrl({ viewOnly: true })
+    expect(url).toContain("view_only=1")
+  })
+})
+
+describe("Desktop token retry", () => {
+  it("activates and retries once on a stale token", async () => {
+    const tokens: Array<string | null> = []
+    let call = 0
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init: RequestInit) => {
+        tokens.push(new Headers(init.headers).get("X-Access-Token"))
+        call++
+        if (call === 1) {
+          return jsonResponse({ code: "unauthenticated" }, 401)
+        }
+        return jsonResponse({})
+      }),
+    )
+    await new Desktop(makeDeps()).click(1, 1)
+    expect(tokens).toEqual(["tok-initial", "tok-refreshed"])
+  })
+})


### PR DESCRIPTION
## Summary

- `sandbox.desktop` namespace in the TS SDK: `screenshot()` (PNG bytes + dimensions, one RPC), single-RPC coordinate clicks, `drag()` as one atomic batch, `scroll({dx, dy})`, unpaced `write()`, `press()` with friendly key-name mapping, `actions([...])` ordered batches, live `resize()`, `getStreamUrl()` (publishes the noVNC port through the preview-access policy)
- Python SDK mirror: `Desktop` (sync) and `AsyncDesktop`, same surface in snake_case
- MCP `sandbox_computer` tool: one action per call in the standard computer-use vocabulary; screenshots return as MCP image blocks, and input actions return a fresh screenshot by default so an agent's act-then-look turn is a single tool call; `wait` sleeps locally and is capped
- Desktop RPCs speak the Connect JSON protocol as plain POSTs through the existing data-plane request/token-retry machinery — no protobuf toolchain added; paused sandboxes auto-resume on any desktop call
- 49 new tests across the three packages; README sections for all three

Requires a desktop-enabled template (`superserve/desktop`) serving boxd's DesktopService.

## Validation

- `packages/sdk`: typecheck, oxlint, 250 tests pass
- `packages/python-sdk`: ruff check/format, 324 tests pass
- `packages/mcp`: typecheck, oxlint, 107 tests pass (tool-surface pin updated)
- End-to-end against a live desktop sandbox pending staging availability of the backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)