### PR TITLE
sdk: add status, limit, and offset options to Sandbox.list

### DIFF
--- a/docs/sandbox/connect.mdx
+++ b/docs/sandbox/connect.mdx
@@ -27,7 +27,9 @@ sandbox.commands.run("ls /app")
 
 ## Find sandboxes with `list`
 
-List all sandboxes on the team, or filter by metadata. Filters combine with AND.
+List all sandboxes on the team, or narrow the result with filters. `metadata`
+filters combine with AND; `status` selects one lifecycle state; `limit` and
+`offset` page through large lists.
 
 <CodeGroup>
 ```typescript TypeScript
@@ -36,6 +38,13 @@ const all = await Sandbox.list()
 const prod = await Sandbox.list({
   metadata: { env: "prod", owner: "agent-7" },
 })
+
+// Only currently running sandboxes — a much smaller set than the
+// full history once paused sandboxes accumulate.
+const running = await Sandbox.list({ status: "active" })
+
+// Page through everything, 100 rows at a time.
+const page = await Sandbox.list({ limit: 100, offset: 100 })
 
 for (const info of prod) {
   console.log(info.id, info.name, info.status)
@@ -46,6 +55,13 @@ for (const info of prod) {
 all_boxes = Sandbox.list()
 
 prod = Sandbox.list(metadata={"env": "prod", "owner": "agent-7"})
+
+# Only currently running sandboxes — a much smaller set than the
+# full history once paused sandboxes accumulate.
+running = Sandbox.list(status="active")
+
+# Page through everything, 100 rows at a time.
+page = Sandbox.list(limit=100, offset=100)
 
 for info in prod:
     print(info.id, info.name, info.status.value)

--- a/docs/sandbox/connect.mdx
+++ b/docs/sandbox/connect.mdx
@@ -39,11 +39,8 @@ const prod = await Sandbox.list({
   metadata: { env: "prod", owner: "agent-7" },
 })
 
-// Only currently running sandboxes — a much smaller set than the
-// full history once paused sandboxes accumulate.
 const running = await Sandbox.list({ status: "active" })
 
-// Page through everything, 100 rows at a time.
 const page = await Sandbox.list({ limit: 100, offset: 100 })
 
 for (const info of prod) {
@@ -56,11 +53,8 @@ all_boxes = Sandbox.list()
 
 prod = Sandbox.list(metadata={"env": "prod", "owner": "agent-7"})
 
-# Only currently running sandboxes — a much smaller set than the
-# full history once paused sandboxes accumulate.
 running = Sandbox.list(status="active")
 
-# Page through everything, 100 rows at a time.
 page = Sandbox.list(limit=100, offset=100)
 
 for info in prod:

--- a/docs/sdk-reference/sandbox.mdx
+++ b/docs/sdk-reference/sandbox.mdx
@@ -102,21 +102,32 @@ sandbox = Sandbox.connect("7a3f2b8c-1234-...")
 ### `Sandbox.list`
 
 List sandboxes on the authenticated team. `metadata` filters combine with AND.
+`status` filters to one lifecycle state, and `limit`/`offset` page through the
+list.
 
 <CodeGroup>
 ```typescript TypeScript
 const all = await Sandbox.list()
 const prod = await Sandbox.list({ metadata: { env: "prod" } })
+const running = await Sandbox.list({ status: "active" })
+const page = await Sandbox.list({ limit: 100, offset: 100 })
 ```
 
 ```python Python
 all_boxes = Sandbox.list()
 prod = Sandbox.list(metadata={"env": "prod"})
+running = Sandbox.list(status="active")
+page = Sandbox.list(limit=100, offset=100)
 ```
 
 </CodeGroup>
 
 Returns an array of [`SandboxInfo`](#sandboxinfo).
+
+Without `limit`, the entire team history is returned in one response. Paused
+sandboxes are kept until you delete them, so long-running teams accumulate
+large lists — prefer `status: "active"` when you only need running sandboxes,
+or `limit`/`offset` paging when you need the full history.
 
 ### `Sandbox.killById` / `Sandbox.kill_by_id`
 

--- a/docs/sdk-reference/sandbox.mdx
+++ b/docs/sdk-reference/sandbox.mdx
@@ -124,11 +124,6 @@ page = Sandbox.list(limit=100, offset=100)
 
 Returns an array of [`SandboxInfo`](#sandboxinfo).
 
-Without `limit`, the entire team history is returned in one response. Paused
-sandboxes are kept until you delete them, so long-running teams accumulate
-large lists — prefer `status: "active"` when you only need running sandboxes,
-or `limit`/`offset` paging when you need the full history.
-
 ### `Sandbox.killById` / `Sandbox.kill_by_id`
 
 Delete a sandbox by ID without instantiating it. Idempotent.

--- a/docs/sdk-reference/sandbox.mdx
+++ b/docs/sdk-reference/sandbox.mdx
@@ -167,12 +167,12 @@ Fetch the current server-side state. Returns a fresh [`SandboxInfo`](#sandboxinf
 <CodeGroup>
 ```typescript TypeScript
 const info = await sandbox.getInfo()
-console.log(info.status)  // "active" | "paused" | "resuming" | "failed"
+console.log(info.status)  // e.g. "active" — see SandboxStatus
 ```
 
 ```python Python
 info = sandbox.get_info()
-print(info.status.value)  # "active" | "paused" | "resuming" | "failed"
+print(info.status.value)  # e.g. "active" — see SandboxStatus
 ```
 
 </CodeGroup>
@@ -368,25 +368,38 @@ for e in page.events:
 
 <CodeGroup>
 ```typescript TypeScript
-type SandboxStatus = "active" | "paused" | "resuming" | "failed"
+type SandboxStatus =
+  | "starting"
+  | "active"
+  | "pausing"
+  | "paused"
+  | "resuming"
+  | "failed"
+  | "deleted"
 ```
 
 ```python Python
 from enum import Enum
 
 class SandboxStatus(str, Enum):
+    STARTING = "starting"
     ACTIVE = "active"
+    PAUSING = "pausing"
     PAUSED = "paused"
     RESUMING = "resuming"
     FAILED = "failed"
+    DELETED = "deleted"
 ```
 
 </CodeGroup>
 
+- `starting` - transient, briefly visible while a new sandbox boots
 - `active` - running and ready to accept commands
+- `pausing` - transient, briefly visible while a pause is in progress
 - `paused` - stopped with state saved to disk
 - `resuming` - transient, briefly visible while a paused sandbox is being restored to `active` (retry shortly)
 - `failed` - the sandbox couldn't boot or resume; the entry remains until you delete it
+- `deleted` - removed; deleted sandboxes do not appear in list results
 
 Deletion removes the sandbox entirely - subsequent API calls return `404`.
 

--- a/docs/sdk-reference/sandbox.mdx
+++ b/docs/sdk-reference/sandbox.mdx
@@ -397,7 +397,7 @@ class SandboxStatus(str, Enum):
 - `active` - running and ready to accept commands
 - `pausing` - transient, briefly visible while a pause is in progress
 - `paused` - stopped with state saved to disk
-- `resuming` - transient, briefly visible while a paused sandbox is being restored to `active` (retry shortly)
+- `resuming` - transient, briefly visible while a paused sandbox is being restored to `active`
 - `failed` - the sandbox couldn't boot or resume; the entry remains until you delete it
 - `deleted` - removed; deleted sandboxes do not appear in list results
 

--- a/packages/python-sdk/src/superserve/async_sandbox.py
+++ b/packages/python-sdk/src/superserve/async_sandbox.py
@@ -17,6 +17,7 @@ from .files import AsyncFiles, AsyncFilesDeps
 from .types import (
     UNSET,
     build_update_body,
+    list_query,
     NetworkConfig,
     NetworkLogPage,
     NetworkVerdict,
@@ -200,17 +201,24 @@ class AsyncSandbox:
         cls,
         *,
         metadata: dict[str, str] | None = None,
+        status: str | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
         api_key: str | None = None,
         base_url: str | None = None,
     ) -> builtins.list[SandboxInfo]:
-        """List all sandboxes belonging to the authenticated team."""
+        """List sandboxes belonging to the authenticated team.
+
+        Without ``limit``, the entire list is returned — for teams with a long
+        sandbox history, prefer a ``status`` filter (e.g. ``"active"``) or
+        ``limit``+``offset`` paging. The API clamps ``limit`` at its page-size
+        cap.
+        """
         config = resolve_config(api_key=api_key, base_url=base_url)
         url = f"{config.base_url}/sandboxes"
-        if metadata:
-            from urllib.parse import urlencode
-
-            params = {f"metadata.{k}": v for k, v in metadata.items()}
-            url += f"?{urlencode(params)}"
+        query = list_query(metadata, status, limit, offset)
+        if query:
+            url += f"?{query}"
 
         raw = await async_api_request("GET", url, headers={"X-API-Key": config.api_key})
         return [to_sandbox_info(item) for item in raw]

--- a/packages/python-sdk/src/superserve/async_sandbox.py
+++ b/packages/python-sdk/src/superserve/async_sandbox.py
@@ -209,10 +209,9 @@ class AsyncSandbox:
     ) -> builtins.list[SandboxInfo]:
         """List sandboxes belonging to the authenticated team.
 
-        Without ``limit``, the entire list is returned — for teams with a long
-        sandbox history, prefer a ``status`` filter (e.g. ``"active"``) or
-        ``limit``+``offset`` paging. The API clamps ``limit`` at its page-size
-        cap.
+        Optional filters: ``metadata`` (AND semantics), ``status``, and
+        ``limit``/``offset`` paging. Without ``limit`` the full list is
+        returned.
         """
         config = resolve_config(api_key=api_key, base_url=base_url)
         url = f"{config.base_url}/sandboxes"

--- a/packages/python-sdk/src/superserve/sandbox.py
+++ b/packages/python-sdk/src/superserve/sandbox.py
@@ -215,10 +215,9 @@ class Sandbox:
     ) -> builtins.list[SandboxInfo]:
         """List sandboxes belonging to the authenticated team.
 
-        Without ``limit``, the entire list is returned — for teams with a long
-        sandbox history, prefer a ``status`` filter (e.g. ``"active"``) or
-        ``limit``+``offset`` paging. The API clamps ``limit`` at its page-size
-        cap.
+        Optional filters: ``metadata`` (AND semantics), ``status``, and
+        ``limit``/``offset`` paging. Without ``limit`` the full list is
+        returned.
         """
         config = resolve_config(api_key=api_key, base_url=base_url)
         url = f"{config.base_url}/sandboxes"

--- a/packages/python-sdk/src/superserve/sandbox.py
+++ b/packages/python-sdk/src/superserve/sandbox.py
@@ -17,6 +17,7 @@ from .files import Files, FilesDeps
 from .types import (
     UNSET,
     build_update_body,
+    list_query,
     NetworkConfig,
     NetworkLogPage,
     NetworkVerdict,
@@ -206,17 +207,24 @@ class Sandbox:
         cls,
         *,
         metadata: dict[str, str] | None = None,
+        status: str | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
         api_key: str | None = None,
         base_url: str | None = None,
     ) -> builtins.list[SandboxInfo]:
-        """List all sandboxes belonging to the authenticated team."""
+        """List sandboxes belonging to the authenticated team.
+
+        Without ``limit``, the entire list is returned — for teams with a long
+        sandbox history, prefer a ``status`` filter (e.g. ``"active"``) or
+        ``limit``+``offset`` paging. The API clamps ``limit`` at its page-size
+        cap.
+        """
         config = resolve_config(api_key=api_key, base_url=base_url)
         url = f"{config.base_url}/sandboxes"
-        if metadata:
-            from urllib.parse import urlencode
-
-            params = {f"metadata.{k}": v for k, v in metadata.items()}
-            url += f"?{urlencode(params)}"
+        query = list_query(metadata, status, limit, offset)
+        if query:
+            url += f"?{query}"
 
         raw = api_request("GET", url, headers={"X-API-Key": config.api_key})
         return [to_sandbox_info(item) for item in raw]

--- a/packages/python-sdk/src/superserve/types.py
+++ b/packages/python-sdk/src/superserve/types.py
@@ -139,7 +139,8 @@ def list_query(
     """Build the query string for the list-sandboxes endpoint ("" when empty)."""
     params: dict[str, str] = {f"metadata.{k}": v for k, v in (metadata or {}).items()}
     if status is not None:
-        params["status"] = status
+        # A (str, Enum) member urlencodes as "SandboxStatus.ACTIVE"; send its value.
+        params["status"] = status.value if isinstance(status, Enum) else status
     if limit is not None:
         params["limit"] = str(limit)
     if offset is not None:

--- a/packages/python-sdk/src/superserve/types.py
+++ b/packages/python-sdk/src/superserve/types.py
@@ -13,10 +13,13 @@ from .errors import SandboxError
 
 
 class SandboxStatus(str, Enum):
+    STARTING = "starting"
     ACTIVE = "active"
+    PAUSING = "pausing"
     PAUSED = "paused"
     RESUMING = "resuming"
     FAILED = "failed"
+    DELETED = "deleted"
 
 
 class PreviewAccess(str, Enum):

--- a/packages/python-sdk/src/superserve/types.py
+++ b/packages/python-sdk/src/superserve/types.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from enum import Enum
 from typing import Any, Literal, Optional, Union
+from urllib.parse import urlencode
 
 from pydantic import BaseModel, Field
 
@@ -124,6 +125,23 @@ def build_update_body(
     if preview_access is not None:
         body["preview_access"] = preview_access
     return body
+
+
+def list_query(
+    metadata: Optional[dict[str, str]],
+    status: Optional[str],
+    limit: Optional[int],
+    offset: Optional[int],
+) -> str:
+    """Build the query string for the list-sandboxes endpoint ("" when empty)."""
+    params: dict[str, str] = {f"metadata.{k}": v for k, v in (metadata or {}).items()}
+    if status is not None:
+        params["status"] = status
+    if limit is not None:
+        params["limit"] = str(limit)
+    if offset is not None:
+        params["offset"] = str(offset)
+    return urlencode(params)
 
 
 def _parse_iso8601(value: str) -> datetime:

--- a/packages/python-sdk/tests/test_async.py
+++ b/packages/python-sdk/tests/test_async.py
@@ -52,6 +52,17 @@ class TestAsyncStaticMethodsAreAsync:
 
 
 class TestAsyncSandboxSmoke:
+    async def test_list_passes_status_and_pagination(self) -> None:
+        with respx.mock() as router:
+            route = router.get(url__regex=rf"{API}/sandboxes.*").mock(
+                return_value=httpx.Response(200, json=[])
+            )
+            await AsyncSandbox.list(status="active", limit=100, offset=200)
+            url = str(route.calls.last.request.url)
+            assert "status=active" in url
+            assert "limit=100" in url
+            assert "offset=200" in url
+
     async def test_create_returns_instance(self) -> None:
         with respx.mock() as router:
             router.post(f"{API}/sandboxes").mock(

--- a/packages/python-sdk/tests/test_sandbox.py
+++ b/packages/python-sdk/tests/test_sandbox.py
@@ -321,6 +321,14 @@ class TestList:
             Sandbox.list(metadata={"env": "prod"})
             assert "metadata.env=prod" in str(route.calls.last.request.url)
 
+    def test_status_enum_serializes_as_value(self) -> None:
+        with respx.mock() as router:
+            route = router.get(url__regex=rf"{API}/sandboxes.*").mock(
+                return_value=httpx.Response(200, json=[])
+            )
+            Sandbox.list(status=SandboxStatus.ACTIVE)
+            assert "status=active" in str(route.calls.last.request.url)
+
     def test_passes_status_and_pagination(self) -> None:
         with respx.mock() as router:
             route = router.get(url__regex=rf"{API}/sandboxes.*").mock(

--- a/packages/python-sdk/tests/test_sandbox.py
+++ b/packages/python-sdk/tests/test_sandbox.py
@@ -321,6 +321,28 @@ class TestList:
             Sandbox.list(metadata={"env": "prod"})
             assert "metadata.env=prod" in str(route.calls.last.request.url)
 
+    def test_passes_status_and_pagination(self) -> None:
+        with respx.mock() as router:
+            route = router.get(url__regex=rf"{API}/sandboxes.*").mock(
+                return_value=httpx.Response(200, json=[])
+            )
+            Sandbox.list(
+                metadata={"env": "prod"}, status="active", limit=100, offset=200
+            )
+            url = str(route.calls.last.request.url)
+            assert "metadata.env=prod" in url
+            assert "status=active" in url
+            assert "limit=100" in url
+            assert "offset=200" in url
+
+    def test_no_query_string_without_filters(self) -> None:
+        with respx.mock() as router:
+            route = router.get(f"{API}/sandboxes").mock(
+                return_value=httpx.Response(200, json=[])
+            )
+            Sandbox.list()
+            assert route.calls.last.request.url.query == b""
+
 
 class TestKillById:
     def test_success(self) -> None:

--- a/packages/python-sdk/tests/test_types.py
+++ b/packages/python-sdk/tests/test_types.py
@@ -126,17 +126,23 @@ class TestToSandboxInfo:
 
 class TestSandboxStatus:
     def test_all_statuses_exist(self) -> None:
+        assert SandboxStatus.STARTING.value == "starting"
         assert SandboxStatus.ACTIVE.value == "active"
+        assert SandboxStatus.PAUSING.value == "pausing"
         assert SandboxStatus.PAUSED.value == "paused"
         assert SandboxStatus.RESUMING.value == "resuming"
         assert SandboxStatus.FAILED.value == "failed"
+        assert SandboxStatus.DELETED.value == "deleted"
 
     def test_status_enum_values(self) -> None:
         assert {s.value for s in SandboxStatus} == {
+            "starting",
             "active",
+            "pausing",
             "paused",
             "resuming",
             "failed",
+            "deleted",
         }
 
 

--- a/packages/sdk/src/Sandbox.ts
+++ b/packages/sdk/src/Sandbox.ts
@@ -235,13 +235,20 @@ export class Sandbox {
   }
 
   /**
-   * List all sandboxes belonging to the authenticated team.
+   * List sandboxes belonging to the authenticated team.
+   *
+   * Without `limit`, the entire list is returned — for teams with a long
+   * sandbox history, prefer a `status` filter or `limit`+`offset` paging.
    *
    * @param options.metadata — Filter by metadata key-value pairs.
+   * @param options.status — Only return sandboxes in this status.
+   * @param options.limit — Maximum rows to return.
+   * @param options.offset — Rows to skip; combine with `limit` to page.
    *
    * @example
    * ```typescript
-   * const sandboxes = await Sandbox.list()
+   * const running = await Sandbox.list({ status: "active" })
+   * const page = await Sandbox.list({ limit: 100, offset: 200 })
    * const prodBoxes = await Sandbox.list({ metadata: { env: "prod" } })
    * ```
    */
@@ -249,13 +256,15 @@ export class Sandbox {
     const config = resolveConfig(options)
 
     let url = `${config.baseUrl}/sandboxes`
-    if (options.metadata && Object.keys(options.metadata).length > 0) {
-      const params = new URLSearchParams()
-      for (const [key, value] of Object.entries(options.metadata)) {
-        params.set(`metadata.${key}`, value)
-      }
-      url += `?${params.toString()}`
+    const params = new URLSearchParams()
+    for (const [key, value] of Object.entries(options.metadata ?? {})) {
+      params.set(`metadata.${key}`, value)
     }
+    if (options.status !== undefined) params.set("status", options.status)
+    if (options.limit !== undefined) params.set("limit", String(options.limit))
+    if (options.offset !== undefined)
+      params.set("offset", String(options.offset))
+    if (params.toString()) url += `?${params.toString()}`
 
     const raw = await request<ApiSandboxResponse[]>({
       method: "GET",

--- a/packages/sdk/src/Sandbox.ts
+++ b/packages/sdk/src/Sandbox.ts
@@ -237,9 +237,6 @@ export class Sandbox {
   /**
    * List sandboxes belonging to the authenticated team.
    *
-   * Without `limit`, the entire list is returned — for teams with a long
-   * sandbox history, prefer a `status` filter or `limit`+`offset` paging.
-   *
    * @param options.metadata — Filter by metadata key-value pairs.
    * @param options.status — Only return sandboxes in this status.
    * @param options.limit — Maximum rows to return.

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -11,7 +11,14 @@ import { SandboxError } from "./errors.js"
 // Sandbox
 // ---------------------------------------------------------------------------
 
-export type SandboxStatus = "active" | "paused" | "resuming" | "failed"
+export type SandboxStatus =
+  | "starting"
+  | "active"
+  | "pausing"
+  | "paused"
+  | "resuming"
+  | "failed"
+  | "deleted"
 
 /** Current preview-routing policy returned by the API. */
 export type PreviewAccess = "legacy_public" | "public" | "private"
@@ -85,22 +92,11 @@ export interface SandboxCreateOptions extends ConnectionOptions {
   previewAccess?: PreviewAccessPolicy
 }
 
-/** Status values the list endpoint accepts as a filter — a superset of
- * `SandboxStatus` that includes the transitional and terminal states. */
-export type SandboxStatusFilter =
-  | "starting"
-  | "active"
-  | "pausing"
-  | "paused"
-  | "resuming"
-  | "failed"
-  | "deleted"
-
 export interface SandboxListOptions extends ConnectionOptions {
   metadata?: Record<string, string>
   /** Only return sandboxes in this status (e.g. `"active"` for currently
    * running ones — usually a far smaller set than the full history). */
-  status?: SandboxStatusFilter
+  status?: SandboxStatus
   /** Maximum rows to return. The API clamps values above its page-size cap.
    * Omitting it returns the team's entire sandbox list. */
   limit?: number

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -94,14 +94,11 @@ export interface SandboxCreateOptions extends ConnectionOptions {
 
 export interface SandboxListOptions extends ConnectionOptions {
   metadata?: Record<string, string>
-  /** Only return sandboxes in this status (e.g. `"active"` for currently
-   * running ones — usually a far smaller set than the full history). */
+  /** Only return sandboxes in this status. */
   status?: SandboxStatus
-  /** Maximum rows to return. The API clamps values above its page-size cap.
-   * Omitting it returns the team's entire sandbox list. */
+  /** Maximum rows to return. Omit to return the full list. */
   limit?: number
-  /** Rows to skip before the first returned one; combine with `limit` to
-   * page through large lists. */
+  /** Rows to skip; combine with `limit` to page. */
   offset?: number
 }
 

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -85,8 +85,28 @@ export interface SandboxCreateOptions extends ConnectionOptions {
   previewAccess?: PreviewAccessPolicy
 }
 
+/** Status values the list endpoint accepts as a filter — a superset of
+ * `SandboxStatus` that includes the transitional and terminal states. */
+export type SandboxStatusFilter =
+  | "starting"
+  | "active"
+  | "pausing"
+  | "paused"
+  | "resuming"
+  | "failed"
+  | "deleted"
+
 export interface SandboxListOptions extends ConnectionOptions {
   metadata?: Record<string, string>
+  /** Only return sandboxes in this status (e.g. `"active"` for currently
+   * running ones — usually a far smaller set than the full history). */
+  status?: SandboxStatusFilter
+  /** Maximum rows to return. The API clamps values above its page-size cap.
+   * Omitting it returns the team's entire sandbox list. */
+  limit?: number
+  /** Rows to skip before the first returned one; combine with `limit` to
+   * page through large lists. */
+  offset?: number
 }
 
 export interface SandboxUpdateOptions {

--- a/packages/sdk/tests/sandbox.test.ts
+++ b/packages/sdk/tests/sandbox.test.ts
@@ -282,6 +282,31 @@ describe("Sandbox statics", () => {
     expect(url).toContain("metadata.tier=gold")
   })
 
+  it("Sandbox.list appends status, limit, and offset to URL", async () => {
+    const mock = vi.fn(async () => jsonResponse([]))
+    vi.stubGlobal("fetch", mock)
+
+    await Sandbox.list({
+      ...commonOpts,
+      status: "active",
+      limit: 100,
+      offset: 200,
+    })
+    const [url] = mock.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain("status=active")
+    expect(url).toContain("limit=100")
+    expect(url).toContain("offset=200")
+  })
+
+  it("Sandbox.list sends no query string without filters", async () => {
+    const mock = vi.fn(async () => jsonResponse([]))
+    vi.stubGlobal("fetch", mock)
+
+    await Sandbox.list(commonOpts)
+    const [url] = mock.mock.calls[0] as [string, RequestInit]
+    expect(url).not.toContain("?")
+  })
+
   it("Sandbox.killById swallows 404", async () => {
     vi.stubGlobal(
       "fetch",


### PR DESCRIPTION
## Summary

- `Sandbox.list()` in the TypeScript SDK and the Python sync/async SDKs now accepts `status`, `limit`, and `offset` alongside the existing `metadata` filter, passing them straight through to `GET /sandboxes`.
- All three options are additive and optional — omitting them keeps today's behavior exactly, so this is non-breaking.

## Why

The list endpoint has always supported status filtering and limit/offset pagination, but the SDKs only exposed the metadata filter, so every SDK call returned the team's entire sandbox list. Teams with a long sandbox history can now fetch just their running sandboxes (`status: "active"`) or page through the full list instead of downloading all of it on every call.

## Test plan

- TS: `npm run typecheck` clean, `vitest run` 234 passed (new cases: status/limit/offset in URL, no query string without filters)
- Python: `pytest` 309 passed, `mypy` clean (new cases in sync and async suites)