### PR TITLE
docs: exempt console billing and stripe endpoints from the docs-nav check

### DIFF
--- a/scripts/check-docs-nav.ts
+++ b/scripts/check-docs-nav.ts
@@ -26,6 +26,12 @@ const EXEMPT_PATHS = new Set([
   "/health",
   "/billing/pricing",
   "/billing/pricing/public",
+  "/teams/{team_id}/billing/usage",
+  "/teams/{team_id}/billing/periods",
+  "/teams/{team_id}/billing/periods/{period_id}/export-preview",
+  "/stripe/checkout-session",
+  "/stripe/customer-portal-session",
+  "/stripe/webhook",
 ])
 
 const OP_RE = new RegExp(`^(${HTTP_METHODS.join("|")})\\s+/`)


### PR DESCRIPTION
## Summary

The docs-nav check fetches the live OpenAPI spec, so when the new team billing and Stripe endpoints landed in the public spec, CI started failing on every branch in this repo. These are console-UI/webhook endpoints, not part of the developer sandbox API reference — the same category as the existing `/billing/pricing` exemptions — so this adds them to `EXEMPT_PATHS` rather than the public docs nav.

## Test plan

- `bun run docs:check-nav` now passes: "docs nav in sync with OpenAPI spec (57 operations)"