### PR TITLE
sdk: bump TypeScript and Python SDKs to 0.8.3

### DIFF
--- a/docs/sandbox/connect.mdx
+++ b/docs/sandbox/connect.mdx
@@ -28,8 +28,8 @@ sandbox.commands.run("ls /app")
 ## Find sandboxes with `list`
 
 List all sandboxes on the team, or narrow the result with filters. `metadata`
-filters combine with AND; `status` selects one lifecycle state; `limit` and
-`offset` page through large lists.
+returns only sandboxes matching every key-value pair you pass; `status`
+selects one lifecycle state; `limit` and `offset` page through large lists.
 
 <CodeGroup>
 ```typescript TypeScript

--- a/docs/sandbox/metadata.mdx
+++ b/docs/sandbox/metadata.mdx
@@ -50,7 +50,7 @@ sandbox.update(metadata={"env": "staging", "owner": "agent-7"})
 
 ## Filter sandboxes by metadata
 
-`Sandbox.list()` accepts a `metadata` filter. Multiple keys combine with AND - a sandbox must match every key-value pair to be returned.
+`Sandbox.list()` accepts a `metadata` filter that returns only sandboxes matching every key-value pair you pass.
 
 <CodeGroup>
 ```typescript TypeScript

--- a/docs/sdk-reference/sandbox.mdx
+++ b/docs/sdk-reference/sandbox.mdx
@@ -393,11 +393,11 @@ class SandboxStatus(str, Enum):
 
 </CodeGroup>
 
-- `starting` - transient, briefly visible while a new sandbox boots
+- `starting` - a new sandbox is booting
 - `active` - running and ready to accept commands
-- `pausing` - transient, briefly visible while a pause is in progress
+- `pausing` - a pause is in progress
 - `paused` - stopped with state saved to disk
-- `resuming` - transient, briefly visible while a paused sandbox is being restored to `active`
+- `resuming` - a paused sandbox is being restored
 - `failed` - the sandbox couldn't boot or resume; the entry remains until you delete it
 - `deleted` - removed; deleted sandboxes do not appear in list results
 

--- a/docs/sdk-reference/sandbox.mdx
+++ b/docs/sdk-reference/sandbox.mdx
@@ -101,9 +101,9 @@ sandbox = Sandbox.connect("7a3f2b8c-1234-...")
 
 ### `Sandbox.list`
 
-List sandboxes on the authenticated team. `metadata` filters combine with AND.
-`status` filters to one lifecycle state, and `limit`/`offset` page through the
-list.
+List sandboxes on the authenticated team. `metadata` returns only sandboxes
+matching every key-value pair you pass; `status` filters to one lifecycle
+state; `limit`/`offset` page through the list.
 
 <CodeGroup>
 ```typescript TypeScript

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "superserve"
-version = "0.8.2"
+version = "0.8.3"
 description = "Python SDK for the Superserve sandbox API"
 license = "Apache-2.0"
 readme = "README.md"

--- a/packages/python-sdk/src/superserve/__init__.py
+++ b/packages/python-sdk/src/superserve/__init__.py
@@ -59,7 +59,7 @@ from .types import (
     WorkdirStep,
 )
 
-__version__ = "0.8.2"
+__version__ = "0.8.3"
 
 __all__ = [
     "AsyncCommandSession",

--- a/packages/python-sdk/src/superserve/_http.py
+++ b/packages/python-sdk/src/superserve/_http.py
@@ -25,7 +25,7 @@ DEFAULT_MAX_DOWNLOAD_BYTES = (
     2 * 1024 * 1024 * 1024
 )  # 2 GiB; matches boxd's server-side zip cap
 
-SDK_VERSION = "0.8.2"
+SDK_VERSION = "0.8.3"
 USER_AGENT = (
     f"superserve-python/{SDK_VERSION} "
     f"(python/{sys.version_info.major}.{sys.version_info.minor})"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superserve/sdk",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "TypeScript SDK for the Superserve sandbox API",
   "keywords": [
     "firecracker",

--- a/packages/sdk/src/http.ts
+++ b/packages/sdk/src/http.ts
@@ -20,7 +20,7 @@ import type { ApiExecStreamEvent } from "./types.js"
 
 const DEFAULT_TIMEOUT_MS = 30_000
 
-const SDK_VERSION = "0.8.2"
+const SDK_VERSION = "0.8.3"
 const USER_AGENT = `@superserve/sdk/${SDK_VERSION} (node/${
   typeof process !== "undefined" && process.versions?.node
     ? `v${process.versions.node}`

--- a/uv.lock
+++ b/uv.lock
@@ -492,7 +492,7 @@ wheels = [
 
 [[package]]
 name = "superserve"
-version = "0.8.2"
+version = "0.8.3"
 source = { editable = "packages/python-sdk" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Version bump ahead of releasing the new `Sandbox.list` options (`status`, `limit`, `offset`) from #310. Bumps all version carriers: TS `package.json` + `SDK_VERSION` in `http.ts`, Python `pyproject.toml` + `__version__` + `SDK_VERSION` in `_http.py`, and the regenerated `uv.lock`.

## Test plan

- Unit suites green on the underlying changes (234 TS / 310 Python)
- End-to-end against staging with both SDKs at this version: plain `list()` unchanged, `status` filter (string and Python enum) returns matching rows only, `limit`/`offset` pages are disjoint, combined filters round-trip