### PR TITLE
Add Turnstile protection to email signup

### DIFF
--- a/apps/console/.env.example
+++ b/apps/console/.env.example
@@ -10,6 +10,10 @@ NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=
 
+# Cloudflare Turnstile signup protection. Leave both empty to disable.
+NEXT_PUBLIC_TURNSTILE_SITE_KEY=
+TURNSTILE_SECRET_KEY=
+
 # Base host for per-sandbox websockets (terminal, etc). URLs become wss://boxd-<id>.<host>/…
 NEXT_PUBLIC_SANDBOX_HOST=sandbox.superserve.ai
 # Secret used to derive per-user proxy API keys, generate with: openssl rand -base64 48

--- a/apps/console/src/app/(auth)/auth/signup/action.ts
+++ b/apps/console/src/app/(auth)/auth/signup/action.ts
@@ -9,23 +9,107 @@ import { ConfirmationEmail } from "@/lib/email/templates/confirmation"
 import { WelcomeEmail } from "@/lib/email/templates/welcome"
 import { createAdminClient } from "@/lib/supabase/admin"
 
+const TURNSTILE_ACTION = "signup"
+
 const signUpSchema = z.object({
   email: z.string().email("Invalid email address."),
   password: z.string().min(8, "Password must be at least 8 characters."),
   fullName: z.string().min(1, "Name is required.").max(200),
+  turnstileToken: z.string().optional(),
 })
+
+type TurnstileVerification = {
+  success: boolean
+  hostname?: string
+  action?: string
+  "error-codes"?: string[]
+}
+
+async function verifyTurnstile(token: string | undefined) {
+  const secret = process.env.TURNSTILE_SECRET_KEY
+  const siteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY
+
+  if (!secret && !siteKey) return { success: true as const }
+
+  if (!secret || !siteKey) {
+    console.error("Turnstile signup protection is only partially configured")
+    return { success: false as const }
+  }
+
+  if (!token) return { success: false as const }
+
+  const response = await fetch(
+    "https://challenges.cloudflare.com/turnstile/v0/siteverify",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({ secret, response: token }),
+      cache: "no-store",
+    },
+  )
+
+  if (!response.ok) {
+    console.error("Turnstile verification request failed", {
+      status: response.status,
+    })
+    return { success: false as const }
+  }
+
+  const verification = (await response.json()) as TurnstileVerification
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL
+  let expectedHostname: string | undefined
+
+  if (appUrl) {
+    try {
+      expectedHostname = new URL(appUrl).hostname
+    } catch {
+      console.error("NEXT_PUBLIC_APP_URL is invalid; cannot validate Turnstile hostname")
+      return { success: false as const }
+    }
+  }
+
+  const valid =
+    verification.success &&
+    verification.action === TURNSTILE_ACTION &&
+    (!expectedHostname || verification.hostname === expectedHostname)
+
+  if (!valid) {
+    console.warn("Turnstile signup verification rejected", {
+      action: verification.action,
+      hostname: verification.hostname,
+      errorCodes: verification["error-codes"],
+    })
+  }
+
+  return { success: valid }
+}
 
 export const signUpWithEmail = async (
   email: string,
   password: string,
   fullName: string,
+  turnstileToken?: string,
 ) => {
-  const parsed = signUpSchema.safeParse({ email, password, fullName })
+  const parsed = signUpSchema.safeParse({
+    email,
+    password,
+    fullName,
+    turnstileToken,
+  })
   if (!parsed.success) {
     return { success: false, error: parsed.error.issues[0].message }
   }
 
   try {
+    const turnstile = await verifyTurnstile(parsed.data.turnstileToken)
+    if (!turnstile.success) {
+      return {
+        success: false,
+        error: "Please complete the verification challenge and try again.",
+        errorCode: "turnstile_failed" as const,
+      }
+    }
+
     const supabase = createAdminClient()
 
     const appUrl =

--- a/apps/console/src/app/(auth)/auth/signup/page.tsx
+++ b/apps/console/src/app/(auth)/auth/signup/page.tsx
@@ -6,15 +6,18 @@ import Image from "next/image"
 import Link from "next/link"
 import { useRouter, useSearchParams } from "next/navigation"
 import { usePostHog } from "posthog-js/react"
-import { Suspense, useEffect, useState } from "react"
+import { Suspense, useCallback, useEffect, useState } from "react"
 
 import { CornerBrackets } from "@/components/corner-brackets"
 import { DitherBackground } from "@/components/dither-background"
 import { GoogleIcon, Spinner } from "@/components/icons"
+import { Turnstile } from "@/components/turnstile"
 import { AUTH_EVENTS } from "@/lib/posthog/events"
 import { createBrowserClient } from "@/lib/supabase/client"
 
 import { signUpWithEmail } from "./action"
+
+const TURNSTILE_ACTION = "signup"
 
 function SignUpContent() {
   const [isLoading, setIsLoading] = useState(false)
@@ -26,12 +29,20 @@ function SignUpContent() {
   const [showPassword, setShowPassword] = useState(false)
   const [showConfirmPassword, setShowConfirmPassword] = useState(false)
   const [emailSent, setEmailSent] = useState(false)
+  const [turnstileToken, setTurnstileToken] = useState<string | null>(null)
+  const [turnstileResetKey, setTurnstileResetKey] = useState(0)
   const [errors, setErrors] = useState<Record<string, string>>({})
   const posthog = usePostHog()
   const router = useRouter()
   const searchParams = useSearchParams()
   const rawNext = searchParams.get("next") || "/"
   const nextUrl = rawNext.startsWith("/") ? rawNext : "/"
+  const turnstileSiteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY
+  const turnstileEnabled = Boolean(turnstileSiteKey)
+  const handleTurnstileToken = useCallback(
+    (token: string | null) => setTurnstileToken(token),
+    [],
+  )
 
   useEffect(() => {
     if (searchParams.get("error") === "link_expired") {
@@ -50,13 +61,20 @@ function SignUpContent() {
       newErrors.password = "Must be at least 8 characters."
     if (password && password !== confirmPassword)
       newErrors.confirmPassword = "Passwords do not match."
+    if (turnstileEnabled && !turnstileToken)
+      newErrors.form = "Please complete the verification challenge."
     if (Object.keys(newErrors).length > 0) {
       setErrors(newErrors)
       return
     }
     setIsLoading(true)
     try {
-      const result = await signUpWithEmail(email, password, fullName)
+      const result = await signUpWithEmail(
+        email,
+        password,
+        fullName,
+        turnstileToken ?? undefined,
+      )
       if (!result.success) {
         posthog.capture(AUTH_EVENTS.SIGN_UP_FAILED, {
           method: "email",
@@ -65,6 +83,10 @@ function SignUpContent() {
         if ("errorCode" in result && result.errorCode === "blocked_email") {
           router.push("/auth/auth-code-error?reason=signup_blocked")
           return
+        }
+        if ("errorCode" in result && result.errorCode === "turnstile_failed") {
+          setTurnstileToken(null)
+          setTurnstileResetKey((key) => key + 1)
         }
         setErrors({ form: result.error || "Error creating account." })
         return
@@ -223,12 +245,24 @@ function SignUpContent() {
                   </button>
                 }
               />
+              {turnstileSiteKey && (
+                <Turnstile
+                  siteKey={turnstileSiteKey}
+                  action={TURNSTILE_ACTION}
+                  resetKey={turnstileResetKey}
+                  onToken={handleTurnstileToken}
+                />
+              )}
               {errors.form && (
                 <p className="text-xs text-destructive">{errors.form}</p>
               )}
               <Button
                 type="submit"
-                disabled={isLoading || isGoogleLoading}
+                disabled={
+                  isLoading ||
+                  isGoogleLoading ||
+                  (turnstileEnabled && !turnstileToken)
+                }
                 className="w-full"
               >
                 {isLoading ? <Spinner /> : null}

--- a/apps/console/src/components/turnstile.tsx
+++ b/apps/console/src/components/turnstile.tsx
@@ -1,0 +1,80 @@
+"use client"
+
+import Script from "next/script"
+import { useEffect, useRef, useState } from "react"
+
+type TurnstileApi = {
+  render: (
+    container: HTMLElement,
+    options: {
+      sitekey: string
+      action?: string
+      callback: (token: string) => void
+      "error-callback"?: () => void
+      "expired-callback"?: () => void
+      theme?: "light" | "dark" | "auto"
+    },
+  ) => string
+  remove: (widgetId: string) => void
+}
+
+declare global {
+  interface Window {
+    turnstile?: TurnstileApi
+  }
+}
+
+type TurnstileProps = {
+  siteKey: string
+  action: string
+  resetKey: number
+  onToken: (token: string | null) => void
+}
+
+export function Turnstile({
+  siteKey,
+  action,
+  resetKey,
+  onToken,
+}: TurnstileProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const widgetIdRef = useRef<string | null>(null)
+  const [scriptReady, setScriptReady] = useState(false)
+
+  useEffect(() => {
+    if (!scriptReady || !containerRef.current || !window.turnstile) return
+
+    if (widgetIdRef.current) {
+      window.turnstile.remove(widgetIdRef.current)
+      widgetIdRef.current = null
+    }
+
+    onToken(null)
+    widgetIdRef.current = window.turnstile.render(containerRef.current, {
+      sitekey: siteKey,
+      action,
+      theme: "auto",
+      callback: (token) => onToken(token),
+      "expired-callback": () => onToken(null),
+      "error-callback": () => onToken(null),
+    })
+
+    return () => {
+      if (widgetIdRef.current && window.turnstile) {
+        window.turnstile.remove(widgetIdRef.current)
+        widgetIdRef.current = null
+      }
+    }
+  }, [action, onToken, resetKey, scriptReady, siteKey])
+
+  return (
+    <>
+      <Script
+        src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit"
+        strategy="afterInteractive"
+        onReady={() => setScriptReady(true)}
+      />
+      <div ref={containerRef} className="flex min-h-[65px] justify-center" />
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- render Cloudflare Turnstile on email signup when configured
- validate the single-use token server-side before Supabase `admin.generateLink`
- validate Turnstile action and expected app hostname
- fail closed for partial Turnstile configuration and remain disabled when both vars are absent
- leave Google OAuth unchanged
- document the two environment variables

## Staging configuration
Configured in Vercel Staging:
- `NEXT_PUBLIC_TURNSTILE_SITE_KEY`
- `TURNSTILE_SECRET_KEY`

The widget hostname should be `console-staging.superserve.ai`.

## Notes
This deliberately verifies Turnstile in the application server action rather than relying on Supabase Auth CAPTCHA, because this signup flow uses `auth.admin.generateLink` rather than client `auth.signUp`.